### PR TITLE
Optimize database sync and smooth demo setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,12 @@ jobs:
         run: python -m pip install --upgrade pip && python -m pip install -e '.[web]'
 
       - name: Run search index maintenance smoke tests
-        run: python -m unittest \
-          tests.test_importer.ImporterTest.test_check_search_index_reports_healthy_catalog \
-          tests.test_importer.ImporterTest.test_check_search_index_detects_missing_orphan_duplicate_and_mismatched_rows \
-          tests.test_importer.ImporterTest.test_rebuild_search_index_repairs_detected_drift \
-          -q
+        run: |
+          python -m unittest \
+            tests.test_importer.ImporterTest.test_check_search_index_reports_healthy_catalog \
+            tests.test_importer.ImporterTest.test_check_search_index_detects_missing_orphan_duplicate_and_mismatched_rows \
+            tests.test_importer.ImporterTest.test_rebuild_search_index_repairs_detected_drift \
+            -q
 
       - name: Run backend tests
         run: ./scripts/test_backend.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,13 @@ jobs:
       - name: Install backend dependencies
         run: python -m pip install --upgrade pip && python -m pip install -e '.[web]'
 
+      - name: Run search index maintenance smoke tests
+        run: python -m unittest \
+          tests.test_importer.ImporterTest.test_check_search_index_reports_healthy_catalog \
+          tests.test_importer.ImporterTest.test_check_search_index_detects_missing_orphan_duplicate_and_mismatched_rows \
+          tests.test_importer.ImporterTest.test_rebuild_search_index_repairs_detected_drift \
+          -q
+
       - name: Run backend tests
         run: ./scripts/test_backend.sh
 

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -234,6 +234,16 @@ Localhost API test layer:
 python3 -m unittest tests.test_web_api tests.test_api_app -q
 ```
 
+Importer benchmark:
+
+```bash
+python3 scripts/benchmark_import_pipeline.py \
+  --db /tmp/mtg_benchmark.db \
+  --scryfall-json /path/to/default-cards.json \
+  --identifiers-json /path/to/AllIdentifiers.json.gz \
+  --prices-json /path/to/AllPricesToday.json.gz
+```
+
 ## Contract Surfaces
 
 If backend behavior changes, inspect these together:

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -251,6 +251,21 @@ python3 -m mtg_source_stack.mvp_importer check-search-index --db var/db/mtg_mvp.
 python3 -m mtg_source_stack.mvp_importer rebuild-search-index --db var/db/mtg_mvp.db
 ```
 
+Sync run history:
+
+```bash
+python3 -m mtg_source_stack.mvp_importer list-sync-runs --db var/db/mtg_mvp.db
+python3 -m mtg_source_stack.mvp_importer show-sync-run --db var/db/mtg_mvp.db --run-id 1
+```
+
+Suggested local/shared-service cadence:
+
+- `sync-prices`: daily
+- `sync-scryfall`: weekly
+- `sync-identifiers`: weekly or less often
+- `check-search-index`: after unusual repairs/import interruptions, or on a periodic ops check
+- `rebuild-search-index`: repair-only command when `check-search-index` reports drift
+
 ## Contract Surfaces
 
 If backend behavior changes, inspect these together:

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -129,17 +129,18 @@ Migration `0008` note:
 Default demo bootstrap:
 
 ```bash
-python3 scripts/bootstrap_frontend_demo.py --db var/db/frontend_demo.db --force
+cd frontend
+npm run demo:bootstrap -- --force
 ```
 
 Full-catalog demo bootstrap:
 
 ```bash
-python3 scripts/bootstrap_frontend_demo.py \
-  --db var/db/frontend_demo_full.db \
+npm run demo:bootstrap -- \
   --force \
   --full-catalog \
-  --scryfall-json /path/to/default-cards.json
+  --scryfall-json /path/to/default-cards.json \
+  --db ../var/db/frontend_demo_full.db
 ```
 
 Rules of thumb:

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -244,6 +244,13 @@ python3 scripts/benchmark_import_pipeline.py \
   --prices-json /path/to/AllPricesToday.json.gz
 ```
 
+Search index maintenance:
+
+```bash
+python3 -m mtg_source_stack.mvp_importer check-search-index --db var/db/mtg_mvp.db
+python3 -m mtg_source_stack.mvp_importer rebuild-search-index --db var/db/mtg_mvp.db
+```
+
 ## Contract Surfaces
 
 If backend behavior changes, inspect these together:

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -143,6 +143,18 @@ npm run demo:bootstrap -- \
   --db ../var/db/frontend_demo_full.db
 ```
 
+Optional full-catalog pricing import:
+
+```bash
+npm run demo:bootstrap -- \
+  --force \
+  --full-catalog \
+  --scryfall-json /path/to/default-cards.json \
+  --identifiers-json /path/to/AllIdentifiers.json \
+  --prices-json /path/to/AllPricesToday.json \
+  --db ../var/db/frontend_demo_full.db
+```
+
 Rules of thumb:
 
 - keep the default small demo mode fast and self-contained

--- a/README.md
+++ b/README.md
@@ -344,6 +344,21 @@ clear bootstrap error instead of a later finish-mismatch surprise. It is the
 better fit when the frontend should search a realistic card catalog while still
 keeping the owned demo rows intentionally curated.
 
+If you also want real MTGJSON-backed price snapshots in that full-catalog demo
+database:
+
+```bash
+npm run demo:bootstrap -- \
+  --force \
+  --full-catalog \
+  --scryfall-json /path/to/default-cards.json \
+  --identifiers-json /path/to/AllIdentifiers.json \
+  --prices-json /path/to/AllPricesToday.json
+```
+
+Without those MTGJSON files, full-catalog mode keeps the curated demo price
+seed for the showcase owned rows only.
+
 Recommended local API start from the frontend sandbox:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -178,6 +178,30 @@ mtg-mvp-importer sync-bulk \
   --cache-dir "var/bulk_cache/latest"
 ```
 
+Recommended ongoing refresh cadence:
+
+```bash
+mtg-mvp-importer sync-scryfall --db "var/db/mtg_mvp.db" --cache-dir "var/bulk_cache/latest"
+mtg-mvp-importer sync-identifiers --db "var/db/mtg_mvp.db" --cache-dir "var/bulk_cache/latest"
+mtg-mvp-importer sync-prices --db "var/db/mtg_mvp.db" --cache-dir "var/bulk_cache/latest"
+```
+
+For most local or modest shared-service use, treat those commands as:
+
+- `sync-prices`: daily
+- `sync-scryfall`: weekly
+- `sync-identifiers`: weekly or less often
+- `sync-bulk`: catch-up/bootstrap command when you want one operator action to refresh everything
+
+Search index maintenance and sync history:
+
+```bash
+mtg-mvp-importer check-search-index --db "var/db/mtg_mvp.db"
+mtg-mvp-importer rebuild-search-index --db "var/db/mtg_mvp.db"
+mtg-mvp-importer list-sync-runs --db "var/db/mtg_mvp.db"
+mtg-mvp-importer show-sync-run --db "var/db/mtg_mvp.db" --run-id 42
+```
+
 Important upgrade note:
 
 - migration `0008` adds the durable catalog-classification fields used by the

--- a/README.md
+++ b/README.md
@@ -320,7 +320,9 @@ modes.
 Small default demo:
 
 ```bash
-python3 scripts/bootstrap_frontend_demo.py --db var/db/frontend_demo.db --force
+cd frontend
+npm install
+npm run demo:bootstrap -- --force
 ```
 
 This keeps the tiny built-in catalog and the curated richer demo inventory.
@@ -328,8 +330,7 @@ This keeps the tiny built-in catalog and the curated richer demo inventory.
 Full searchable catalog demo:
 
 ```bash
-python3 scripts/bootstrap_frontend_demo.py \
-  --db var/db/frontend_demo.db \
+npm run demo:bootstrap -- \
   --force \
   --full-catalog \
   --scryfall-json /path/to/default-cards.json
@@ -342,6 +343,17 @@ printing policy used by the app, so upstream catalog drift fails early with a
 clear bootstrap error instead of a later finish-mismatch surprise. It is the
 better fit when the frontend should search a realistic card catalog while still
 keeping the owned demo rows intentionally curated.
+
+Recommended local API start from the frontend sandbox:
+
+```bash
+npm run backend:demo
+```
+
+The frontend demo launchers prefer the repo-local `.venv/bin/python` when it
+exists, force `PYTHONPATH` to this checkout, and avoid the false
+cross-checkout/schema-mismatch problems that can happen with a globally
+installed `mtg-web-api` wrapper.
 
 For the fuller maintenance surface, check `--help` on:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ requests. GitHub issues and PRs are the only live tracking surface; files under
 `docs/frontend_backend_requests/` are optional supporting specs and historical
 context, not the authoritative ticket state.
 
+If you want the easiest-to-find snapshot of recent milestones, the current
+review branch context, and the likely next work sequence, read `ROADMAP.md`.
+
 ## Current Runtime Shape
 
 - The active runtime package lives in `src/mtg_source_stack/`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,84 +3,242 @@
 Historical roadmap context for this repo.
 
 GitHub issues and pull requests are the only active work-tracking surface.
-This file is background context for recent milestones and likely workstreams,
-and it may drift between commits without being kept in sync with live ticket
-status.
+This file is meant to be easy-to-find background context for recent branch
+milestones, current review context, and the next likely work sequence. It may
+drift between commits, so treat GitHub as the source of truth for live ticket
+status and ownership.
 
-## Recent Baseline Milestones
+## Current Checkpoint
 
-- `a4452d2` Add inventory membership foundations
-- `ab1b1db` Fix health previews and blank location responses
-- `cd433ad` Enforce inventory-scoped read access
-- `8b760ae` Enforce inventory write access by membership
-- `ecc5756` Add bulk inventory tag mutations
-- `5bfc988` Add default inventory bootstrap flow
-- `b58f089` Add catalog classification import fields
-- `c1a5976` Apply default add-search catalog scope
-- `49f333e` Add broad catalog search scope opt-in
-- `3a1cfca` Define oracle-id default printing ranking
-- `3c7aff1` Document oracle-id default printing policy
-- `c88f80a` Make full-catalog demo bootstrap resolver-driven
-- `4d8e97f` Fix grouped card-name search parameter ordering
-- `65fea2d` Add bulk finish mutation support
-- `2d002c6` Add bulk location mutation support
-- `ec20433` Add bulk condition mutation support
-- `c8c042f` Add whole-inventory transfer support
-- `537de8e` Add inventory duplication API
-- `f1220fa` Canonicalize inventory slug usage
-- `485f937` Merge import/export backend tools into this branch
-- `869717c` Fix CSV import multipart dependency handling
+Last refreshed: `2026-04-14`
 
-## Working Assumption
+Current review branch:
 
-After the Phase 2 merge point, expect new work to happen on focused feature
-branches rather than one long-lived integration branch.
+- `database-sync-optimization`
 
-Current frontend handoff status on `frontend_phase_2`:
+Open review PR:
 
-- the shared frontend API client now supports JSON requests, multipart CSV
-  upload, and CSV/text downloads
-- the frontend type surface and client wrappers now cover shared-service
-  bootstrap, import/export, transfer, duplicate, and the broader bulk-mutation
-  contract
-- the current demo UI still passes frontend tests/build on top of that refactor
-- the next frontend product branch should start with shared-service bootstrap
-  UX and permission-aware empty states, then move into import/export flows
-  before transfer/duplicate polish
+- `#42` `Optimize database sync and smooth demo setup`
+- <https://github.com/monsonbo2/mtg_inventory_tool/pull/42>
 
-For live branch priority, prefer:
+Mainline assumption:
+
+- `origin/HEAD` still points to `origin/master`
+
+## What Recently Landed On The Review Branch
+
+Sync and importer work:
+
+- sync run, step, artifact, and issue bookkeeping
+- split sync commands:
+  - `sync-scryfall`
+  - `sync-identifiers`
+  - `sync-prices`
+- unchanged-artifact skip behavior for sync/import runs
+- streamed MTGJSON identifier and price payload reads
+- importer timing and sync-history visibility
+- Scryfall metadata caching and safer validator reuse
+- search-index maintenance commands:
+  - `check-search-index`
+  - `rebuild-search-index`
+  - `list-sync-runs`
+  - `show-sync-run --run-id ...`
+
+Important performance result:
+
+- narrowing the `mtg_cards` FTS update trigger removed the main bulk identifier
+  import bottleneck
+- on the benchmark harness, `import-identifiers` dropped from effectively
+  `13m+` to about `12.8s`
+
+Frontend/demo work:
+
+- frontend demo launchers now prefer the repo-local `.venv/bin/python`
+- `frontend/` now has first-class:
+  - `npm run demo:bootstrap`
+  - `npm run backend:demo`
+- the demo bootstrap output and docs now point people to repo-local launchers
+  instead of a global `mtg-web-api` wrapper
+- full-catalog demo bootstrap now optionally supports real MTGJSON pricing when
+  both `--identifiers-json` and `--prices-json` are supplied alongside
+  `--scryfall-json`
+
+Recent commits worth knowing:
+
+- `213b7d6` `Smooth frontend demo setup flow`
+- `3cccf81` `Add priced full-catalog demo bootstrap`
+
+## Current Validation Snapshot
+
+Last known green checks on the review branch:
+
+- `PYTHONPATH=src ./.venv/bin/python -m unittest discover -s tests -q`
+  - `391` passed, `75` skipped
+- `cd frontend && npm run test`
+  - `67` passed
+- `cd frontend && npm run build`
+  - passed
+- full-catalog priced demo bootstrap via npm
+  - passed with local fixture files
+
+## Recommended Next Issue Sequence
+
+If work resumes after PR `#42`, the best next sequence is:
+
+1. `#43` Shared-service onboarding-state contract clarity
+2. `#45` Shared-service validation fixtures for permission-aware frontend states
+3. `#44` Proxy-backed shared-service validation harness for `/api` rollout
+4. `#38` Optimize grouped name search latency on full-catalog demo DB
+5. Re-scope `#39` Local-first bootstrap and lightweight printing lookup support
+6. `#41` Support bulk inventory mutations across all filtered rows
+
+Why this order:
+
+- `#43` is likely the cheapest high-value shared-service issue
+- `#45` turns shared-service permission states into something repeatable
+- `#44` becomes much easier and more useful once those fixtures exist
+- `#38` is the sharpest remaining product-feel / demo-latency issue
+- `#39` is partly stale relative to the current code and should be narrowed
+  before more backend work is added
+- `#41` is the largest remaining feature contract and should follow the smaller
+  shared-service and demo-readiness wins
+
+## Open Issue Notes
+
+### `#43` Shared-service onboarding-state contract clarity
+
+Best first approach:
+
+- add a small machine-readable status route such as `/me/access-summary`
+- keep it focused on:
+  - `can_bootstrap`
+  - `has_readable_inventory`
+  - `visible_inventory_count`
+  - `default_inventory_slug`
+- document the frontend decision tree against that route
+
+Reasonable alternative:
+
+- docs-only decision tree using current `GET /inventories` plus
+  `POST /me/bootstrap`
+
+Why the route is preferred:
+
+- the frontend currently has to infer too much from multiple endpoints and
+  permission failures
+
+### `#45` Shared-service validation fixtures
+
+Best first approach:
+
+- add a scripted fixture bootstrap that seeds:
+  - one bootstrap-eligible editor
+  - one authenticated user with no memberships
+  - one read-only inventory member
+  - one write-capable member
+  - one global admin
+- publish the expected verified headers and visible inventory outcomes
+
+Reasonable alternative:
+
+- commit a prebuilt SQLite fixture DB
+
+Why the scripted fixture is preferred:
+
+- it survives migrations better and is easier to reason about than a binary DB
+  snapshot
+
+### `#44` Proxy-backed shared-service validation harness
+
+Best first approach:
+
+- add a lightweight committed reverse-proxy config for the exact `/api`
+  deployment shape
+- add a smoke-test path that validates:
+  - `/api` prefix stripping
+  - verified header injection
+  - denied client-supplied auth headers
+  - same-origin request behavior
+
+Reasonable alternative:
+
+- simulate the proxy in an in-process ASGI test harness
+
+Why the real proxy shape is preferred:
+
+- the issue is about rollout validation, not only backend unit correctness
+
+### `#38` Grouped name search latency
+
+Best first approach:
+
+- remove or sharply constrain the broad grouped-search substring fallback
+- rely on FTS plus exact/prefix ordering for the normal path
+- add benchmark coverage so future regressions are obvious
+
+Reasonable alternative:
+
+- build a dedicated grouped-name index keyed by `oracle_id`
+
+Why the tactical query fix is preferred first:
+
+- it is the likely first speed win with the lowest schema complexity
+
+### `#39` Local-first bootstrap and lightweight printing lookup support
+
+Current caution:
+
+- parts of the original issue are already partially satisfied by current code:
+  - `/me/bootstrap` is already idempotent
+  - printing lookup already defaults to an English-first subset and only loads
+    all languages on demand
+
+Best first approach:
+
+- re-scope or split the issue before implementation
+- keep only the work that is still actually missing
+
+Reasonable alternative:
+
+- add a lighter-weight printing summary route immediately
+
+Why re-scoping is preferred:
+
+- this issue is at risk of duplicating behavior the repo now already has
+
+### `#41` Filter-based bulk mutations
+
+Best first approach:
+
+- extend the existing bulk route to support a selection envelope
+  - explicit `item_ids`
+  - or backend-owned filters matching the inventory list route semantics
+- resolve the filtered selection inside the same transaction
+- return transfer-style summaries for large operations rather than giant ID
+  payloads
+
+Reasonable alternative:
+
+- add a sibling route such as `/items/bulk-filtered`
+
+Why the additive selection envelope is preferred:
+
+- it keeps one long-term bulk contract instead of splitting closely related
+  behavior across multiple endpoints
+
+## Current Working Assumptions
+
+- stay local-first and SQLite-first for now
+- treat `shared_service` as a modest single-host rollout shape, not a
+  horizontally scaled SaaS target
+- keep demo/bootstrap tooling as part of the supported developer experience, not
+  as throwaway scripts
+- prefer GitHub issues / PRs for live tracking, and use this file only as
+  quickly discoverable planning context
+
+## First Places To Look When This File Drifts
 
 1. `git status --short --branch`
-2. recent commits on the current branch
-3. GitHub issues / PRs
-
-Do not treat this file as a source of truth once it drifts from active git
-state.
-
-## Likely Workstreams
-
-1. Shared-service rollout validation behind the real reverse proxy and verified
-   auth headers.
-2. Frontend integration and handoff follow-through for:
-   - generalized bulk mutations
-   - transfer / duplicate inventory flows
-   - import / export preview and commit paths
-3. Issue and runbook hygiene around recently landed work such as:
-   - full-catalog demo bootstrap
-   - playable-card default search scope
-   - documented `oracle_id` default printing policy
-   - import / export operational notes
-4. Membership/bootstrap follow-through, especially the `POST /me/bootstrap`
-   first-run flow and operator runbooks.
-5. Later reporting/performance work once rollout behavior is stable.
-
-## Active Questions To Watch
-
-- Does the current shared-service rollout behave cleanly behind the real proxy
-  and verified auth headers?
-- Are GitHub issues / PRs aligned with the actual branch state?
-- What is the next product feature branch after Phase 2 merge:
-  frontend integration of the current bulk / transfer features, pasted list
-  import, or something else?
-- Are there any remaining operator runbook gaps around memberships, bootstrap,
-  catalog refresh expectations, or import/export dependencies?
+2. recent commits on the active branch
+3. open GitHub issues and pull requests
+4. the current PR description if a review branch is already open

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -80,9 +80,15 @@
             "title": "Language Code"
           },
           "location": {
-            "default": "",
-            "title": "Location",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location"
           },
           "name": {
             "anyOf": [

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -183,11 +183,24 @@ Use this as the first-pass UI-to-endpoint map:
      --scryfall-json /path/to/default-cards.json
    ```
 
+   If you also want imported MTGJSON pricing in that full-catalog demo:
+
+   ```bash
+   npm run demo:bootstrap -- \
+     --force \
+     --full-catalog \
+     --scryfall-json /path/to/default-cards.json \
+     --identifiers-json /path/to/AllIdentifiers.json \
+     --prices-json /path/to/AllPricesToday.json
+   ```
+
    In full-catalog mode the bootstrap still creates the same curated demo
    inventories and owned-row states, but it resolves those rows against real
    imported printings using the same default `oracle_id` printing policy as the
    app. If the imported catalog cannot satisfy one of the intended demo states,
-   the bootstrap now fails early with a clear seed-resolution error.
+   the bootstrap now fails early with a clear seed-resolution error. Without the
+   optional MTGJSON files, full-catalog mode keeps the curated demo price seed
+   for the showcase owned rows only.
 
    Refresh guidance:
 

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -168,15 +168,16 @@ Use this as the first-pass UI-to-endpoint map:
 1. Bootstrap a local demo database:
 
    ```bash
-   python3 scripts/bootstrap_frontend_demo.py --db var/db/frontend_demo.db --force
+   cd frontend
+   npm install
+   npm run demo:bootstrap -- --force
    ```
 
    Or, if you want the frontend to search a real imported catalog instead of
    the tiny built-in demo catalog:
 
    ```bash
-   python3 scripts/bootstrap_frontend_demo.py \
-     --db var/db/frontend_demo.db \
+   npm run demo:bootstrap -- \
      --force \
      --full-catalog \
      --scryfall-json /path/to/default-cards.json
@@ -200,24 +201,37 @@ Use this as the first-pass UI-to-endpoint map:
    - only reused older pre-`0008` databases need an extra Scryfall refresh
      before relying on the narrowed default search scope
 
-2. Start the backend locally:
+2. Install the backend web dependencies if you have not already:
 
    ```bash
+   cd ..
+   python3 -m venv .venv
+   . .venv/bin/activate
    pip install -e '.[web]'
-   mtg-web-api --db var/db/frontend_demo.db
+   cd frontend
+   ```
+
+   The frontend demo launchers prefer `../.venv/bin/python` automatically when
+   it exists. If you use a different environment, set
+   `MTG_FRONTEND_PYTHON=/path/to/python`.
+
+3. Start the backend locally:
+
+   ```bash
+   npm run backend:demo
    ```
 
    If you are working against an upgraded existing pre-`0008` database instead
    of a fresh bootstrap, run a fresh Scryfall import before relying on the
    narrowed default catalog search scope.
 
-3. Point the frontend at the local API base URL.
-4. Build against the published HTTP contract rather than backend internals.
+4. Point the frontend at the local API base URL.
+5. Build against the published HTTP contract rather than backend internals.
 
 ## Frontend Quick Start
 
 - Backend command:
-  `mtg-web-api --db var/db/frontend_demo.db`
+  `npm run backend:demo`
 - Expected API base URL:
   `http://127.0.0.1:8000`
 - Preferred browser-dev setup:

--- a/docs/ingestion_flow.md
+++ b/docs/ingestion_flow.md
@@ -15,7 +15,12 @@ screen request.
 The current importer writes into:
 
 - `mtg_cards`
+- `mtgjson_card_links`
 - `price_snapshots`
+- `sync_runs`
+- `sync_run_steps`
+- `sync_run_artifacts`
+- `sync_run_issues`
 
 The inventory domain separately writes:
 
@@ -26,7 +31,7 @@ The inventory domain separately writes:
 The normalized tables described in `docs/schema_full.sql` are future-target
 design notes, not the live ingestion model.
 
-## Daily Bulk Sync
+## Bulk Refresh Flow
 
 Current recommended order:
 
@@ -37,11 +42,12 @@ Current recommended order:
 5. Update `mtg_cards` vendor-id fields and `mtgjson_uuid` when a row matches by
    `scryfallId`, or by existing `mtgjson_uuid` for older linked rows.
 6. Download or locate MTGJSON `AllPricesToday`.
-7. Resolve MTGJSON UUIDs through the local `mtg_cards.mtgjson_uuid` mapping.
+7. Resolve MTGJSON UUIDs through the local `mtgjson_card_links` mapping, with
+   `mtg_cards.mtgjson_uuid` retained as a compatibility pointer.
 8. Insert or update `price_snapshots` rows by provider, finish, price kind,
    currency, and snapshot date.
-
-There is currently no `source_sync_runs` bookkeeping table in the live schema.
+9. Record the run, step, artifact, and issue metadata in the sync bookkeeping
+   tables.
 
 ## Current Lookup Behavior
 
@@ -108,10 +114,20 @@ If identifier matching fails:
 
 ## Suggested Job Cadence
 
-- Scryfall bulk catalog sync: daily
-- MTGJSON identifiers sync: daily or weekly
-- MTGJSON prices today sync: daily
+Current practical operator cadence:
+
+- `sync-prices`: daily
+- `sync-scryfall`: weekly
+- `sync-identifiers`: weekly or less often
+- `sync-bulk`: bootstrap/catch-up command when you want one operation to refresh everything
 - targeted live fetches: not part of the ordinary current runtime flow
+
+Operational safety commands:
+
+- `check-search-index`: verify that `mtg_cards_fts` still matches `mtg_cards`
+- `rebuild-search-index`: repair `mtg_cards_fts` from the current catalog rows
+- `list-sync-runs`: review recent tracked imports/syncs
+- `show-sync-run --run-id ...`: inspect one tracked run in detail
 
 ## Mapping Summary
 
@@ -137,13 +153,16 @@ Inventory app actions to local tables:
 1. Operator runs Scryfall bulk import.
 2. The importer upserts printings into `mtg_cards`.
 3. Operator runs MTGJSON identifier import.
-4. Matching rows in `mtg_cards` gain `mtgjson_uuid` and vendor identifiers.
+4. Matching rows in `mtg_cards` gain `mtgjson_uuid` and vendor identifiers, and
+   additional UUID links are stored in `mtgjson_card_links`.
 5. Operator runs MTGJSON price import.
-6. The importer resolves local `mtg_cards` rows by `mtgjson_uuid`.
+6. The importer resolves local `mtg_cards` rows through the tracked MTGJSON UUID
+   links.
 7. Imported prices are written into `price_snapshots`.
-8. User searches cards from the local catalog.
-9. User creates or increments an `inventory_items` row for the owned printing.
-10. Valuation and health queries join `inventory_items` to the latest matching
+8. The importer records run/step/artifact bookkeeping for operator review.
+9. User searches cards from the local catalog.
+10. User creates or increments an `inventory_items` row for the owned printing.
+11. Valuation and health queries join `inventory_items` to the latest matching
     `price_snapshots` rows.
 
 For upgraded existing catalogs, insert one more operator step after the schema

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -67,6 +67,21 @@ root-mounted routes such as `/inventories` and `/cards/search`.
    npm run demo:bootstrap -- --full-catalog --scryfall-json /path/to/default-cards.json --force
    ```
 
+   If you also want real MTGJSON-backed price snapshots in that full-catalog
+   demo database, provide both local MTGJSON files too:
+
+   ```bash
+   npm run demo:bootstrap -- \
+     --full-catalog \
+     --scryfall-json /path/to/default-cards.json \
+     --identifiers-json /path/to/AllIdentifiers.json \
+     --prices-json /path/to/AllPricesToday.json \
+     --force
+   ```
+
+   Without those MTGJSON inputs, full-catalog mode still uses the curated demo
+   price seed for the owned showcase rows only.
+
 3. Install the backend web dependencies if you have not already:
 
    ```bash

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -49,35 +49,49 @@ root-mounted routes such as `/inventories` and `/cards/search`.
 
 ## Quick Start
 
-1. Bootstrap a demo database:
+1. Install the frontend dependencies:
 
    ```bash
-   python3 ../scripts/bootstrap_frontend_demo.py --db ../var/db/frontend_demo.db --force
+   npm install
    ```
 
-2. Install the backend web dependencies if you have not already:
+2. Bootstrap a demo database:
 
    ```bash
-   pip install -e '..[web]'
+   npm run demo:bootstrap -- --force
    ```
 
-3. Start the API from this checkout:
+   Pass extra bootstrap args through npm when needed:
+
+   ```bash
+   npm run demo:bootstrap -- --full-catalog --scryfall-json /path/to/default-cards.json --force
+   ```
+
+3. Install the backend web dependencies if you have not already:
+
+   ```bash
+   cd ..
+   python3 -m venv .venv
+   . .venv/bin/activate
+   pip install -e '.[web]'
+   cd frontend
+   ```
+
+   The frontend demo launchers prefer `../.venv/bin/python` automatically when
+   it exists. If you use a different environment, set
+   `MTG_FRONTEND_PYTHON=/path/to/python`.
+
+4. Start the API from this checkout:
 
    ```bash
    npm run backend:demo
    ```
 
-   This launcher forces `PYTHONPATH` to the current repo's `src/` tree before
-   starting the backend. Use it instead of a globally installed `mtg-web-api`
-   wrapper when you have more than one local checkout of `mtg_source_stack`, or
-   the demo can fail with a false `schema_not_ready` mismatch against another
-   repo's migration set.
-
-4. Install the frontend dependencies:
-
-   ```bash
-   npm install
-   ```
+   This launcher forces `PYTHONPATH` to the current repo's `src/` tree and
+   prefers the repo-local virtualenv before falling back to `python3`. Use it
+   instead of a globally installed `mtg-web-api` wrapper when you have more
+   than one local checkout of `mtg_source_stack`, or the demo can fail with a
+   false `schema_not_ready` mismatch against another repo's migration set.
 
 5. Start the frontend:
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "demo:bootstrap": "bash ./scripts/bootstrap_demo_db.sh",
     "backend:demo": "bash ./scripts/run_demo_backend.sh",
     "dev": "vite",
     "build": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json && vite build",

--- a/frontend/scripts/bootstrap_demo_db.sh
+++ b/frontend/scripts/bootstrap_demo_db.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${FRONTEND_DIR}/.." && pwd)"
+BACKEND_PYTHON="$(bash "${SCRIPT_DIR}/resolve_repo_python.sh")"
+
+export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+has_db_arg=0
+for arg in "$@"; do
+  if [ "$arg" = "--db" ]; then
+    has_db_arg=1
+    break
+  fi
+done
+
+if [ "$has_db_arg" -eq 0 ]; then
+  set -- --db "${REPO_ROOT}/var/db/frontend_demo.db" "$@"
+fi
+
+exec "${BACKEND_PYTHON}" "${REPO_ROOT}/scripts/bootstrap_frontend_demo.py" "$@"

--- a/frontend/scripts/resolve_repo_python.sh
+++ b/frontend/scripts/resolve_repo_python.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${FRONTEND_DIR}/.." && pwd)"
+
+if [ -n "${MTG_FRONTEND_PYTHON:-}" ]; then
+  printf '%s\n' "${MTG_FRONTEND_PYTHON}"
+  exit 0
+fi
+
+if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+  printf '%s\n' "${REPO_ROOT}/.venv/bin/python"
+  exit 0
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  printf '%s\n' "python3"
+  exit 0
+fi
+
+echo "Could not find a Python interpreter for the frontend demo tools." >&2
+echo "Set MTG_FRONTEND_PYTHON or create ${REPO_ROOT}/.venv/bin/python." >&2
+exit 1

--- a/frontend/scripts/run_demo_backend.sh
+++ b/frontend/scripts/run_demo_backend.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 FRONTEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd -- "${FRONTEND_DIR}/.." && pwd)"
+BACKEND_PYTHON="$(bash "${SCRIPT_DIR}/resolve_repo_python.sh")"
 
 export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
 
@@ -19,4 +20,15 @@ if [ "$has_db_arg" -eq 0 ]; then
   set -- --db "${REPO_ROOT}/var/db/frontend_demo.db" "$@"
 fi
 
-exec python3 -c 'from mtg_source_stack.api.app import main; import sys; main(sys.argv[1:])' "$@"
+if ! "${BACKEND_PYTHON}" -c 'import fastapi, uvicorn, pydantic' >/dev/null 2>&1; then
+  echo "Selected Python interpreter '${BACKEND_PYTHON}' is missing the FastAPI web dependencies." >&2
+  echo "The frontend demo launcher prefers '${REPO_ROOT}/.venv/bin/python' when it exists." >&2
+  echo "Install the repo web stack, for example:" >&2
+  echo "  python3 -m venv .venv" >&2
+  echo "  . .venv/bin/activate" >&2
+  echo "  pip install -e '.[web]'" >&2
+  echo "Or set MTG_FRONTEND_PYTHON=/path/to/python if you use another environment." >&2
+  exit 1
+fi
+
+exec "${BACKEND_PYTHON}" -c 'from mtg_source_stack.api.app import main; import sys; main(sys.argv[1:])' "$@"

--- a/scripts/benchmark_import_pipeline.py
+++ b/scripts/benchmark_import_pipeline.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Run a repeatable local benchmark for the importer pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+IMPORTER_MODULE = "mtg_source_stack.mvp_importer"
+
+
+def _module_env() -> dict[str, str]:
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{SRC_DIR}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else str(SRC_DIR)
+    return env
+
+
+def _run_importer(*args: str) -> dict[str, Any]:
+    command = [sys.executable, "-m", IMPORTER_MODULE, *args]
+    started = time.perf_counter()
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        env=_module_env(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed_seconds = time.perf_counter() - started
+    return {
+        "command": command,
+        "returncode": result.returncode,
+        "wall_seconds": round(elapsed_seconds, 6),
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def _latest_run_step(db_path: Path, *, run_kind: str, step_name: str) -> dict[str, Any] | None:
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    try:
+        row = connection.execute(
+            """
+            SELECT
+                runs.id AS run_id,
+                runs.status AS run_status,
+                runs.summary_json,
+                steps.status AS step_status,
+                steps.rows_seen,
+                steps.rows_written,
+                steps.rows_skipped,
+                steps.details_json
+            FROM sync_runs AS runs
+            LEFT JOIN sync_run_steps AS steps
+                ON steps.sync_run_id = runs.id
+               AND steps.step_name = ?
+            WHERE runs.run_kind = ?
+            ORDER BY runs.id DESC
+            LIMIT 1
+            """,
+            (step_name, run_kind),
+        ).fetchone()
+    finally:
+        connection.close()
+    if row is None:
+        return None
+    return {
+        "run_id": row["run_id"],
+        "run_status": row["run_status"],
+        "summary": json.loads(row["summary_json"]) if row["summary_json"] else None,
+        "step_status": row["step_status"],
+        "rows_seen": row["rows_seen"],
+        "rows_written": row["rows_written"],
+        "rows_skipped": row["rows_skipped"],
+        "details": json.loads(row["details_json"]) if row["details_json"] else None,
+    }
+
+
+def _db_counts(db_path: Path) -> dict[str, int]:
+    connection = sqlite3.connect(db_path)
+    try:
+        return {
+            "mtg_cards": int(connection.execute("SELECT COUNT(*) FROM mtg_cards").fetchone()[0]),
+            "mtgjson_card_links": int(
+                connection.execute("SELECT COUNT(*) FROM mtgjson_card_links").fetchone()[0]
+            ),
+            "price_snapshots": int(connection.execute("SELECT COUNT(*) FROM price_snapshots").fetchone()[0]),
+        }
+    finally:
+        connection.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Benchmark the local importer pipeline on local bulk files.")
+    parser.add_argument("--db", required=True, help="SQLite database path for the benchmark run.")
+    parser.add_argument("--scryfall-json", required=True, help="Path to Scryfall default-cards JSON.")
+    parser.add_argument("--identifiers-json", required=True, help="Path to MTGJSON AllIdentifiers JSON or JSON.GZ.")
+    parser.add_argument("--prices-json", required=True, help="Path to MTGJSON AllPricesToday JSON or JSON.GZ.")
+    parser.add_argument(
+        "--source-name",
+        default="mtgjson_all_prices_today",
+        help="Source name to use for the price import step.",
+    )
+    parser.add_argument(
+        "--keep-db",
+        action="store_true",
+        help="Reuse an existing database instead of deleting it before the benchmark.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    db_path = Path(args.db)
+    if db_path.exists() and not args.keep_db:
+        db_path.unlink()
+
+    init_result = _run_importer("init-db", "--db", str(db_path))
+    if init_result["returncode"] != 0:
+        print(json.dumps({"init": init_result}, indent=2))
+        return int(init_result["returncode"])
+
+    steps = [
+        {
+            "label": "import_scryfall",
+            "run_kind": "import_scryfall",
+            "step_name": "import_scryfall",
+            "args": ("import-scryfall", "--db", str(db_path), "--json", args.scryfall_json),
+        },
+        {
+            "label": "import_identifiers",
+            "run_kind": "import_identifiers",
+            "step_name": "import_identifiers",
+            "args": ("import-identifiers", "--db", str(db_path), "--json", args.identifiers_json),
+        },
+        {
+            "label": "import_prices",
+            "run_kind": "import_prices",
+            "step_name": "import_prices",
+            "args": (
+                "import-prices",
+                "--db",
+                str(db_path),
+                "--json",
+                args.prices_json,
+                "--source-name",
+                args.source_name,
+            ),
+        },
+    ]
+
+    results: dict[str, Any] = {
+        "db_path": str(db_path),
+        "inputs": {
+            "scryfall_json": str(Path(args.scryfall_json).resolve()),
+            "identifiers_json": str(Path(args.identifiers_json).resolve()),
+            "prices_json": str(Path(args.prices_json).resolve()),
+        },
+        "steps": {},
+    }
+
+    for step in steps:
+        command_result = _run_importer(*step["args"])
+        results["steps"][step["label"]] = {
+            "command": command_result,
+            "run": _latest_run_step(
+                db_path,
+                run_kind=step["run_kind"],
+                step_name=step["step_name"],
+            ),
+        }
+        if command_result["returncode"] != 0:
+            results["db_counts"] = _db_counts(db_path)
+            print(json.dumps(results, indent=2, sort_keys=True))
+            return int(command_result["returncode"])
+
+    results["db_counts"] = _db_counts(db_path)
+    print(json.dumps(results, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_frontend_demo.py
+++ b/scripts/bootstrap_frontend_demo.py
@@ -17,6 +17,7 @@ if str(SRC_ROOT) not in sys.path:
 from mtg_source_stack.db.connection import connect
 from mtg_source_stack.db.schema import initialize_database
 from mtg_source_stack.errors import NotFoundError, ValidationError
+from mtg_source_stack.importer.mtgjson import import_mtgjson_identifiers, import_mtgjson_prices
 from mtg_source_stack.importer.scryfall import import_scryfall_cards
 from mtg_source_stack.inventory.normalize import normalize_finish, validate_supported_finish
 from mtg_source_stack.inventory.service import (
@@ -72,6 +73,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--scryfall-json",
         help="Path to local Scryfall bulk JSON for --full-catalog mode.",
+    )
+    parser.add_argument(
+        "--identifiers-json",
+        help="Path to local MTGJSON AllIdentifiers JSON for importing real vendor links in --full-catalog mode.",
+    )
+    parser.add_argument(
+        "--prices-json",
+        help="Path to local MTGJSON AllPricesToday JSON for importing real price snapshots in --full-catalog mode.",
     )
     parser.add_argument(
         "--force",
@@ -527,7 +536,7 @@ def seed_small_demo_inventory_items(db_path: Path) -> None:
     )
 
 
-def seed_full_catalog_demo_inventory_items(db_path: Path) -> None:
+def seed_full_catalog_demo_inventory_items(db_path: Path, *, seed_demo_prices: bool) -> None:
     bolt = _add_full_catalog_demo_card(
         db_path,
         inventory_slug="personal",
@@ -704,63 +713,64 @@ def seed_full_catalog_demo_inventory_items(db_path: Path) -> None:
         request_id="seed-remove-forest",
     )
 
-    seed_price_snapshots(
-        db_path,
-        [
-            (bolt.scryfall_id, "tcgplayer", "retail", "normal", "USD", "2026-04-01", 2.50, "demo-seed"),
-            (bolt.scryfall_id, "tcgplayer", "retail", "foil", "USD", "2026-04-01", 6.75, "demo-seed"),
-            (
-                counterspell.scryfall_id,
-                "tcgplayer",
-                "retail",
-                "normal",
-                "USD",
-                "2026-04-01",
-                1.25,
-                "demo-seed",
-            ),
-            (
-                swords.scryfall_id,
-                "tcgplayer",
-                "retail",
-                "normal",
-                "USD",
-                "2026-04-01",
-                3.50,
-                "demo-seed",
-            ),
-            (
-                sol_ring.scryfall_id,
-                "tcgplayer",
-                "retail",
-                "normal",
-                "USD",
-                "2026-04-01",
-                1.75,
-                "demo-seed",
-            ),
-            (
-                sol_ring.scryfall_id,
-                "tcgplayer",
-                "retail",
-                "etched",
-                "USD",
-                "2026-04-01",
-                4.75,
-                "demo-seed",
-            ),
-            (
-                forest.scryfall_id,
-                "tcgplayer",
-                "retail",
-                "normal",
-                "USD",
-                "2026-04-01",
-                0.15,
-                "demo-seed",
-            ),
-        ],
-    )
+    if seed_demo_prices:
+        seed_price_snapshots(
+            db_path,
+            [
+                (bolt.scryfall_id, "tcgplayer", "retail", "normal", "USD", "2026-04-01", 2.50, "demo-seed"),
+                (bolt.scryfall_id, "tcgplayer", "retail", "foil", "USD", "2026-04-01", 6.75, "demo-seed"),
+                (
+                    counterspell.scryfall_id,
+                    "tcgplayer",
+                    "retail",
+                    "normal",
+                    "USD",
+                    "2026-04-01",
+                    1.25,
+                    "demo-seed",
+                ),
+                (
+                    swords.scryfall_id,
+                    "tcgplayer",
+                    "retail",
+                    "normal",
+                    "USD",
+                    "2026-04-01",
+                    3.50,
+                    "demo-seed",
+                ),
+                (
+                    sol_ring.scryfall_id,
+                    "tcgplayer",
+                    "retail",
+                    "normal",
+                    "USD",
+                    "2026-04-01",
+                    1.75,
+                    "demo-seed",
+                ),
+                (
+                    sol_ring.scryfall_id,
+                    "tcgplayer",
+                    "retail",
+                    "etched",
+                    "USD",
+                    "2026-04-01",
+                    4.75,
+                    "demo-seed",
+                ),
+                (
+                    forest.scryfall_id,
+                    "tcgplayer",
+                    "retail",
+                    "normal",
+                    "USD",
+                    "2026-04-01",
+                    0.15,
+                    "demo-seed",
+                ),
+            ],
+        )
 
 
 def import_full_demo_catalog(db_path: Path, *, scryfall_json: Path) -> int:
@@ -773,6 +783,8 @@ def bootstrap_demo_data(
     *,
     full_catalog: bool = False,
     scryfall_json: Path | None = None,
+    identifiers_json: Path | None = None,
+    prices_json: Path | None = None,
 ) -> dict[str, int | str]:
     initialize_database(db_path)
 
@@ -780,11 +792,24 @@ def bootstrap_demo_data(
         if scryfall_json is None:
             raise ValueError("scryfall_json is required when full_catalog is enabled.")
         catalog_rows = import_full_demo_catalog(db_path, scryfall_json=scryfall_json)
+        identifiers_rows = 0
+        imported_price_rows = 0
+        price_mode = "demo_seed"
+        if identifiers_json is not None and prices_json is not None:
+            identifiers_rows = int(import_mtgjson_identifiers(db_path, identifiers_json).rows_written)
+            imported_price_rows = int(import_mtgjson_prices(db_path, prices_json).rows_written)
+            price_mode = "imported"
         seed_demo_inventories(db_path)
-        seed_full_catalog_demo_inventory_items(db_path)
+        seed_full_catalog_demo_inventory_items(
+            db_path,
+            seed_demo_prices=(price_mode != "imported"),
+        )
         return {
             "catalog_mode": "full",
             "catalog_rows": catalog_rows,
+            "identifiers_rows": identifiers_rows,
+            "price_rows": imported_price_rows if price_mode == "imported" else 7,
+            "price_mode": price_mode,
         }
 
     seed_small_demo_catalog_and_prices(db_path)
@@ -801,11 +826,19 @@ def main(argv: list[str] | None = None) -> None:
     args = parser.parse_args(argv)
     db_path = Path(args.db)
     scryfall_json = Path(args.scryfall_json) if args.scryfall_json is not None else None
+    identifiers_json = Path(args.identifiers_json) if args.identifiers_json is not None else None
+    prices_json = Path(args.prices_json) if args.prices_json is not None else None
 
     if args.full_catalog and scryfall_json is None:
         parser.error("--scryfall-json is required with --full-catalog.")
     if not args.full_catalog and scryfall_json is not None:
         parser.error("--scryfall-json is only used with --full-catalog.")
+    if args.full_catalog and (identifiers_json is None) != (prices_json is None):
+        parser.error("--identifiers-json and --prices-json must be provided together with --full-catalog.")
+    if not args.full_catalog and identifiers_json is not None:
+        parser.error("--identifiers-json is only used with --full-catalog.")
+    if not args.full_catalog and prices_json is not None:
+        parser.error("--prices-json is only used with --full-catalog.")
 
     if db_path.exists():
         if not args.force:
@@ -819,14 +852,22 @@ def main(argv: list[str] | None = None) -> None:
             db_path,
             full_catalog=args.full_catalog,
             scryfall_json=scryfall_json,
+            identifiers_json=identifiers_json,
+            prices_json=prices_json,
         )
-    except (NotFoundError, ValidationError) as exc:
+    except (NotFoundError, ValidationError, ValueError) as exc:
         raise SystemExit(str(exc)) from exc
     print(f"Bootstrapped frontend demo data at {db_path}")
     print(f"Catalog mode: {summary['catalog_mode']}")
     print("Inventories seeded: personal, trade-binder")
     if args.full_catalog:
         print(f"Scryfall cards imported: {summary['catalog_rows']}")
+        if summary["price_mode"] == "imported":
+            print(f"MTGJSON identifier links imported: {summary['identifiers_rows']}")
+            print(f"MTGJSON price snapshots imported: {summary['price_rows']}")
+            print("Price mode: imported MTGJSON pricing.")
+        else:
+            print("Price mode: curated demo seed pricing.")
         print("Curated owned-item demo rows resolved from imported catalog printings.")
     else:
         print("Cards seeded for search: Lightning Bolt, Counterspell, Swords to Plowshares, Sol Ring, Forest")

--- a/scripts/bootstrap_frontend_demo.py
+++ b/scripts/bootstrap_frontend_demo.py
@@ -831,7 +831,7 @@ def main(argv: list[str] | None = None) -> None:
     else:
         print("Cards seeded for search: Lightning Bolt, Counterspell, Swords to Plowshares, Sol Ring, Forest")
     print("Suggested API start command:")
-    print(f"  mtg-web-api --db {db_path}")
+    print(f"  (cd frontend && npm run backend:demo -- --db {db_path})")
 
 
 if __name__ == "__main__":

--- a/src/mtg_source_stack/api/request_models.py
+++ b/src/mtg_source_stack/api/request_models.py
@@ -265,7 +265,7 @@ class AddInventoryItemRequest(ApiBaseModel):
     condition_code: str = Field(default=DEFAULT_CONDITION_CODE, description=CONDITION_CODE_DESCRIPTION)
     finish: FinishInput = Field(default=DEFAULT_FINISH, description=FINISH_INPUT_DESCRIPTION)
     language_code: str | None = Field(default=None, description=ADD_LANGUAGE_CODE_DESCRIPTION)
-    location: str = ""
+    location: str | None = None
     acquisition_price: str | None = None
     acquisition_currency: str | None = None
     notes: str | None = None

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import time
 from pathlib import Path
 from typing import Any, Callable
@@ -16,6 +17,7 @@ from ..importer.service import (
     DEFAULT_BULK_CACHE_DIR,
     DEFAULT_SCRYFALL_BULK_TYPE,
     find_scryfall_bulk_download_url_in_file,
+    format_bytes,
     MTGJSON_IDENTIFIERS_CACHE_FILENAME,
     MTGJSON_IDENTIFIERS_URL,
     MTGJSON_PRICES_CACHE_FILENAME,
@@ -38,7 +40,9 @@ from ..importer.sync_tracking import (
     file_artifact_info,
     finish_sync_run,
     finish_sync_step,
+    get_sync_run_report,
     import_stats_dict,
+    list_sync_runs,
     latest_sync_artifact,
     record_sync_artifact,
     record_sync_issue,
@@ -398,6 +402,156 @@ def _print_search_index_check_result(result: Any) -> None:
     )
 
 
+def _truncate(value: str | None, width: int) -> str:
+    if value is None:
+        return ""
+    return value if len(value) <= width else f"{value[: max(width - 3, 0)]}..."
+
+
+def _step_status_summary(step_rows: list[dict[str, Any]], *, width: int = 48) -> str:
+    if not step_rows:
+        return ""
+    summary = ", ".join(f"{row['step_name']}:{row['status']}" for row in step_rows)
+    return _truncate(summary, width)
+
+
+def _print_sync_run_history(rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        print("No rows found.")
+        return
+    print_table(
+        [
+            {
+                "id": row["id"],
+                "kind": row["run_kind"],
+                "status": row["status"],
+                "started": row["started_at"],
+                "duration_s": row["duration_seconds"],
+                "source": row["source_name"] or "",
+                "steps": _step_status_summary(row["steps"]),
+                "issues": row["issue_count"],
+            }
+            for row in rows
+        ],
+        [
+            ("id", "id"),
+            ("kind", "kind"),
+            ("status", "status"),
+            ("started", "started"),
+            ("duration_s", "duration_s"),
+            ("source", "source"),
+            ("steps", "steps"),
+            ("issues", "issues"),
+        ],
+    )
+
+
+def _print_sync_run_summary(summary: dict[str, Any] | None) -> None:
+    if not summary:
+        return
+    print("summary:")
+    for key, value in summary.items():
+        if isinstance(value, dict) and {"rows_seen", "rows_written", "rows_skipped"}.issubset(value.keys()):
+            print(
+                f"  {key}: seen={value['rows_seen']} written={value['rows_written']} skipped={value['rows_skipped']}"
+            )
+        else:
+            print(f"  {key}: {json.dumps(value, ensure_ascii=True, sort_keys=True)}")
+
+
+def _print_sync_run_report(report: dict[str, Any]) -> None:
+    print(f"sync run {report['id']}")
+    print(f"kind: {report['run_kind']}")
+    print(f"status: {report['status']}")
+    print(f"trigger: {report['trigger_kind']}")
+    print(f"started_at: {report['started_at']}")
+    print(f"finished_at: {report['finished_at'] or ''}")
+    print(f"duration_s: {report['duration_seconds']}")
+    print(f"source_name: {report['source_name'] or ''}")
+    print(f"limit_value: {report['limit_value'] if report['limit_value'] is not None else ''}")
+    print(f"snapshot_path: {report['snapshot_path'] or ''}")
+    _print_sync_run_summary(report.get("summary"))
+
+    print("steps:")
+    if report["steps"]:
+        print_table(
+            [
+                {
+                    "step": row["step_name"],
+                    "status": row["status"],
+                    "seen": row["rows_seen"] if row["rows_seen"] is not None else "",
+                    "written": row["rows_written"] if row["rows_written"] is not None else "",
+                    "skipped": row["rows_skipped"] if row["rows_skipped"] is not None else "",
+                    "elapsed_s": row["duration_seconds"],
+                    "notes": _truncate(
+                        (
+                            (row["details"] or {}).get("skip_reason")
+                            or (row["details"] or {}).get("error")
+                            or ""
+                        ),
+                        48,
+                    ),
+                }
+                for row in report["steps"]
+            ],
+            [
+                ("step", "step"),
+                ("status", "status"),
+                ("seen", "seen"),
+                ("written", "written"),
+                ("skipped", "skipped"),
+                ("elapsed_s", "elapsed_s"),
+                ("notes", "notes"),
+            ],
+        )
+    else:
+        print("No rows found.")
+
+    print("artifacts:")
+    if report["artifacts"]:
+        print_table(
+            [
+                {
+                    "role": row["artifact_role"],
+                    "size": format_bytes(int(row["bytes_written"] or 0)) if row["bytes_written"] is not None else "",
+                    "source": _truncate(row["source_url"], 48),
+                    "local": _truncate(Path(row["local_path"]).name if row["local_path"] else "", 36),
+                }
+                for row in report["artifacts"]
+            ],
+            [
+                ("role", "role"),
+                ("size", "size"),
+                ("source", "source"),
+                ("local", "local"),
+            ],
+        )
+    else:
+        print("No rows found.")
+
+    print("issues:")
+    if report["issues"]:
+        print_table(
+            [
+                {
+                    "step": row["step_name"] or "",
+                    "level": row["level"],
+                    "code": row["code"],
+                    "message": _truncate(row["message"], 64),
+                }
+                for row in report["issues"]
+            ],
+            [
+                ("step", "step"),
+                ("level", "level"),
+                ("code", "code"),
+                ("message", "message"),
+            ],
+        )
+    else:
+        print("No rows found.")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Initialize and import the MTG MVP schema from local Scryfall and MTGJSON bulk files.",
@@ -592,6 +746,22 @@ def build_parser() -> argparse.ArgumentParser:
     )
     rebuild_search_index.add_argument("--snapshot-dir", help="Optional override directory for snapshots.")
 
+    list_sync_runs_parser = subparsers.add_parser(
+        "list-sync-runs",
+        help="Show recent importer and sync runs in a compact history table.",
+    )
+    list_sync_runs_parser.add_argument("--db", default=str(DEFAULT_DB_PATH), help="SQLite database path.")
+    list_sync_runs_parser.add_argument("--limit", type=int, default=20, help="Maximum runs to show.")
+    list_sync_runs_parser.add_argument("--run-kind", help="Optional exact run_kind filter.")
+    list_sync_runs_parser.add_argument("--status", help="Optional exact status filter.")
+
+    show_sync_run_parser = subparsers.add_parser(
+        "show-sync-run",
+        help="Show a detailed report for one importer or sync run.",
+    )
+    show_sync_run_parser.add_argument("--db", default=str(DEFAULT_DB_PATH), help="SQLite database path.")
+    show_sync_run_parser.add_argument("--run-id", required=True, type=int, help="Tracked sync run id.")
+
     return parser
 
 
@@ -644,6 +814,25 @@ def main() -> None:
             _print_search_index_check_result(check_result)
             if not check_result.is_healthy:
                 raise SystemExit(1)
+            return
+
+        if args.command == "list-sync-runs":
+            require_current_schema(args.db)
+            rows = list_sync_runs(
+                args.db,
+                limit=args.limit,
+                run_kind=args.run_kind,
+                status=args.status,
+            )
+            _print_sync_run_history(rows)
+            return
+
+        if args.command == "show-sync-run":
+            require_current_schema(args.db)
+            report = get_sync_run_report(args.db, run_id=args.run_id)
+            if report is None:
+                parser.exit(status=2, message=f"Error: No sync run found with id={args.run_id}.\n")
+            _print_sync_run_report(report)
             return
 
         if args.command == "snapshot-db":

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -14,6 +14,7 @@ from ..importer.scryfall import import_scryfall_cards
 from ..importer.service import (
     DEFAULT_BULK_CACHE_DIR,
     DEFAULT_SCRYFALL_BULK_TYPE,
+    find_scryfall_bulk_download_url_in_file,
     MTGJSON_IDENTIFIERS_CACHE_FILENAME,
     MTGJSON_IDENTIFIERS_URL,
     MTGJSON_PRICES_CACHE_FILENAME,
@@ -203,21 +204,42 @@ def _download_hints_for_url(
     }
 
 
-def _download_hints_for_latest_role(
+def _scryfall_bulk_hints(
     db_path: str | Path,
     *,
-    artifact_role: str,
-) -> dict[str, str | None]:
-    artifact = latest_sync_artifact(
+    metadata_url: str,
+    bulk_type: str,
+) -> tuple[dict[str, str | None], str | None, dict[str, str | None]]:
+    metadata_hints = _download_hints_for_url(
         db_path,
-        artifact_role=artifact_role,
+        artifact_role="scryfall_bulk_metadata",
+        source_url=metadata_url,
     )
-    if artifact is None:
-        return {}
-    return {
-        "etag": artifact.get("etag"),
-        "last_modified": artifact.get("last_modified"),
-    }
+    metadata_artifact = latest_sync_artifact(
+        db_path,
+        artifact_role="scryfall_bulk_metadata",
+        source_url=metadata_url,
+    )
+    bulk_hint_url: str | None = None
+    if metadata_artifact is not None:
+        local_path = metadata_artifact.get("local_path")
+        if local_path:
+            metadata_path = Path(local_path)
+            if metadata_path.exists():
+                try:
+                    bulk_hint_url = find_scryfall_bulk_download_url_in_file(metadata_path, bulk_type=bulk_type)
+                except ValueError:
+                    bulk_hint_url = None
+    bulk_hints = (
+        _download_hints_for_url(
+            db_path,
+            artifact_role="scryfall_bulk",
+            source_url=bulk_hint_url,
+        )
+        if bulk_hint_url is not None
+        else {}
+    )
+    return metadata_hints, bulk_hint_url, bulk_hints
 
 
 def _build_sync_tracking_callbacks(
@@ -748,16 +770,14 @@ def main() -> None:
                 limit_value=args.limit,
                 source_name=args.source_name,
             )
+            metadata_download_hints, scryfall_bulk_hint_url, scryfall_bulk_download_hints = _scryfall_bulk_hints(
+                args.db,
+                metadata_url=args.scryfall_metadata_url,
+                bulk_type=args.scryfall_bulk_type,
+            )
             download_hints = {
-                SCRYFALL_BULK_METADATA_CACHE_FILENAME: _download_hints_for_url(
-                    args.db,
-                    artifact_role="scryfall_bulk_metadata",
-                    source_url=args.scryfall_metadata_url,
-                ),
-                SCRYFALL_BULK_CACHE_FILENAME: _download_hints_for_latest_role(
-                    args.db,
-                    artifact_role="scryfall_bulk",
-                ),
+                SCRYFALL_BULK_METADATA_CACHE_FILENAME: metadata_download_hints,
+                SCRYFALL_BULK_CACHE_FILENAME: scryfall_bulk_download_hints,
                 MTGJSON_IDENTIFIERS_CACHE_FILENAME: _download_hints_for_url(
                     args.db,
                     artifact_role="mtgjson_identifiers",
@@ -784,6 +804,7 @@ def main() -> None:
                 on_step=on_step,
                 should_skip_step=should_skip_step,
                 download_hints=download_hints,
+                scryfall_bulk_hint_url=scryfall_bulk_hint_url,
             )
             result["snapshot"] = get_snapshot()
             finish_sync_run(
@@ -813,14 +834,10 @@ def main() -> None:
                 tracked_run_id,
                 limit_value=args.limit,
             )
-            metadata_download_hints = _download_hints_for_url(
+            metadata_download_hints, scryfall_bulk_hint_url, bulk_download_hints = _scryfall_bulk_hints(
                 args.db,
-                artifact_role="scryfall_bulk_metadata",
-                source_url=args.scryfall_metadata_url,
-            )
-            bulk_download_hints = _download_hints_for_latest_role(
-                args.db,
-                artifact_role="scryfall_bulk",
+                metadata_url=args.scryfall_metadata_url,
+                bulk_type=args.scryfall_bulk_type,
             )
             result = sync_scryfall(
                 args.db,
@@ -834,6 +851,7 @@ def main() -> None:
                 should_skip_step=should_skip_step,
                 metadata_if_none_match=metadata_download_hints.get("etag"),
                 metadata_if_modified_since=metadata_download_hints.get("last_modified"),
+                bulk_hint_url=scryfall_bulk_hint_url,
                 bulk_if_none_match=bulk_download_hints.get("etag"),
                 bulk_if_modified_since=bulk_download_hints.get("last_modified"),
             )

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -23,6 +23,16 @@ from ..importer.service import (
     print_sync_bulk_result,
     sync_bulk,
 )
+from ..importer.sync_tracking import (
+    file_artifact_info,
+    finish_sync_run,
+    finish_sync_step,
+    import_stats_dict,
+    record_sync_artifact,
+    record_sync_issue,
+    start_sync_run,
+    start_sync_step,
+)
 
 
 def build_snapshot_callback(
@@ -47,6 +57,71 @@ def build_snapshot_callback(
         return snapshot
 
     return ensure_snapshot, current_snapshot
+
+
+def _ensure_existing_json_file(path: str | Path) -> None:
+    if not Path(path).exists():
+        raise ValueError(f"Could not read JSON file '{path}'.")
+
+
+def _record_local_artifact(
+    db_path: str | Path,
+    run_id: int,
+    *,
+    artifact_role: str,
+    path: str | Path,
+) -> None:
+    info = file_artifact_info(path)
+    record_sync_artifact(
+        db_path,
+        run_id,
+        artifact_role=artifact_role,
+        local_path=info["local_path"],
+        bytes_written=info["bytes_written"],
+        sha256=info["sha256"],
+    )
+
+
+def _run_tracked_step(
+    db_path: str | Path,
+    run_id: int,
+    *,
+    step_name: str,
+    operation: Callable[[], Any],
+    details: dict[str, Any] | None = None,
+) -> Any:
+    step_id = start_sync_step(db_path, run_id, step_name=step_name, details=details)
+    try:
+        result = operation()
+    except Exception as exc:
+        finish_sync_step(
+            db_path,
+            step_id,
+            status="failed",
+            details={**(details or {}), "error": str(exc)},
+        )
+        raise
+
+    if hasattr(result, "rows_seen") and hasattr(result, "rows_written") and hasattr(result, "rows_skipped"):
+        finish_sync_step(
+            db_path,
+            step_id,
+            status="succeeded",
+            stats=result,
+            details=details,
+        )
+    else:
+        finish_sync_step(
+            db_path,
+            step_id,
+            status="succeeded",
+            details=details,
+        )
+    return result
+
+
+def _summary_for_stats(**stats: Any) -> dict[str, Any]:
+    return {label: import_stats_dict(value) for label, value in stats.items()}
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -163,6 +238,9 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
+    tracked_db_path: str | Path | None = None
+    tracked_run_id: int | None = None
+    tracked_snapshot_getter: Callable[[], dict[str, Any] | None] | None = None
     try:
         if args.command == "init-db":
             initialize_database(args.db)
@@ -209,60 +287,193 @@ def main() -> None:
             return
 
         if args.command == "import-scryfall":
+            _ensure_existing_json_file(args.json)
+            initialize_database(args.db)
             ensure_snapshot, get_snapshot = build_snapshot_callback(args.db, label="before_import_scryfall")
-            stats = import_scryfall_cards(args.db, args.json, args.limit, before_write=ensure_snapshot)
+            tracked_db_path = args.db
+            tracked_snapshot_getter = get_snapshot
+            tracked_run_id = start_sync_run(
+                args.db,
+                run_kind="import_scryfall",
+                limit_value=args.limit,
+            )
+            print(f"run_id: {tracked_run_id}")
+            _record_local_artifact(args.db, tracked_run_id, artifact_role="scryfall_json", path=args.json)
+            stats = _run_tracked_step(
+                args.db,
+                tracked_run_id,
+                step_name="import_scryfall",
+                operation=lambda: import_scryfall_cards(args.db, args.json, args.limit, before_write=ensure_snapshot),
+                details={"input_path": str(Path(args.json).resolve())},
+            )
             snapshot = get_snapshot()
+            finish_sync_run(
+                args.db,
+                tracked_run_id,
+                status="succeeded",
+                snapshot_path=snapshot["snapshot_path"] if snapshot is not None else None,
+                summary=_summary_for_stats(import_scryfall=stats),
+            )
+            tracked_run_id = None
             if snapshot is not None:
                 print(f"snapshot: {snapshot['snapshot_path']}")
             print_stats("import-scryfall", stats)
             return
 
         if args.command == "import-identifiers":
+            _ensure_existing_json_file(args.json)
+            initialize_database(args.db)
             ensure_snapshot, get_snapshot = build_snapshot_callback(args.db, label="before_import_identifiers")
-            stats = import_mtgjson_identifiers(args.db, args.json, args.limit, before_write=ensure_snapshot)
+            tracked_db_path = args.db
+            tracked_snapshot_getter = get_snapshot
+            tracked_run_id = start_sync_run(
+                args.db,
+                run_kind="import_identifiers",
+                limit_value=args.limit,
+            )
+            print(f"run_id: {tracked_run_id}")
+            _record_local_artifact(args.db, tracked_run_id, artifact_role="mtgjson_identifiers", path=args.json)
+            stats = _run_tracked_step(
+                args.db,
+                tracked_run_id,
+                step_name="import_identifiers",
+                operation=lambda: import_mtgjson_identifiers(args.db, args.json, args.limit, before_write=ensure_snapshot),
+                details={"input_path": str(Path(args.json).resolve())},
+            )
             snapshot = get_snapshot()
+            finish_sync_run(
+                args.db,
+                tracked_run_id,
+                status="succeeded",
+                snapshot_path=snapshot["snapshot_path"] if snapshot is not None else None,
+                summary=_summary_for_stats(import_identifiers=stats),
+            )
+            tracked_run_id = None
             if snapshot is not None:
                 print(f"snapshot: {snapshot['snapshot_path']}")
             print_stats("import-identifiers", stats)
             return
 
         if args.command == "import-prices":
+            _ensure_existing_json_file(args.json)
+            initialize_database(args.db)
             ensure_snapshot, get_snapshot = build_snapshot_callback(args.db, label="before_import_prices")
-            stats = import_mtgjson_prices(
+            tracked_db_path = args.db
+            tracked_snapshot_getter = get_snapshot
+            tracked_run_id = start_sync_run(
                 args.db,
-                args.json,
-                args.limit,
-                args.source_name,
-                before_write=ensure_snapshot,
+                run_kind="import_prices",
+                source_name=args.source_name,
+                limit_value=args.limit,
+            )
+            print(f"run_id: {tracked_run_id}")
+            _record_local_artifact(args.db, tracked_run_id, artifact_role="mtgjson_prices", path=args.json)
+            stats = _run_tracked_step(
+                args.db,
+                tracked_run_id,
+                step_name="import_prices",
+                operation=lambda: import_mtgjson_prices(
+                    args.db,
+                    args.json,
+                    args.limit,
+                    args.source_name,
+                    before_write=ensure_snapshot,
+                ),
+                details={
+                    "input_path": str(Path(args.json).resolve()),
+                    "source_name": args.source_name,
+                },
             )
             snapshot = get_snapshot()
+            finish_sync_run(
+                args.db,
+                tracked_run_id,
+                status="succeeded",
+                snapshot_path=snapshot["snapshot_path"] if snapshot is not None else None,
+                summary=_summary_for_stats(import_prices=stats),
+            )
+            tracked_run_id = None
             if snapshot is not None:
                 print(f"snapshot: {snapshot['snapshot_path']}")
             print_stats("import-prices", stats)
             return
 
         if args.command == "import-all":
+            _ensure_existing_json_file(args.scryfall_json)
+            _ensure_existing_json_file(args.identifiers_json)
+            _ensure_existing_json_file(args.prices_json)
+            initialize_database(args.db)
             ensure_snapshot, get_snapshot = build_snapshot_callback(args.db, label="before_import_all")
-            scryfall_stats = import_scryfall_cards(
+            tracked_db_path = args.db
+            tracked_snapshot_getter = get_snapshot
+            tracked_run_id = start_sync_run(
                 args.db,
-                args.scryfall_json,
-                args.limit,
-                before_write=ensure_snapshot,
+                run_kind="import_all",
+                source_name=args.source_name,
+                limit_value=args.limit,
             )
-            identifier_stats = import_mtgjson_identifiers(
+            print(f"run_id: {tracked_run_id}")
+            _record_local_artifact(args.db, tracked_run_id, artifact_role="scryfall_json", path=args.scryfall_json)
+            _record_local_artifact(
                 args.db,
-                args.identifiers_json,
-                args.limit,
-                before_write=ensure_snapshot,
+                tracked_run_id,
+                artifact_role="mtgjson_identifiers",
+                path=args.identifiers_json,
             )
-            price_stats = import_mtgjson_prices(
+            _record_local_artifact(args.db, tracked_run_id, artifact_role="mtgjson_prices", path=args.prices_json)
+            scryfall_stats = _run_tracked_step(
                 args.db,
-                args.prices_json,
-                args.limit,
-                args.source_name,
-                before_write=ensure_snapshot,
+                tracked_run_id,
+                step_name="import_scryfall",
+                operation=lambda: import_scryfall_cards(
+                    args.db,
+                    args.scryfall_json,
+                    args.limit,
+                    before_write=ensure_snapshot,
+                ),
+                details={"input_path": str(Path(args.scryfall_json).resolve())},
+            )
+            identifier_stats = _run_tracked_step(
+                args.db,
+                tracked_run_id,
+                step_name="import_identifiers",
+                operation=lambda: import_mtgjson_identifiers(
+                    args.db,
+                    args.identifiers_json,
+                    args.limit,
+                    before_write=ensure_snapshot,
+                ),
+                details={"input_path": str(Path(args.identifiers_json).resolve())},
+            )
+            price_stats = _run_tracked_step(
+                args.db,
+                tracked_run_id,
+                step_name="import_prices",
+                operation=lambda: import_mtgjson_prices(
+                    args.db,
+                    args.prices_json,
+                    args.limit,
+                    args.source_name,
+                    before_write=ensure_snapshot,
+                ),
+                details={
+                    "input_path": str(Path(args.prices_json).resolve()),
+                    "source_name": args.source_name,
+                },
             )
             snapshot = get_snapshot()
+            finish_sync_run(
+                args.db,
+                tracked_run_id,
+                status="succeeded",
+                snapshot_path=snapshot["snapshot_path"] if snapshot is not None else None,
+                summary=_summary_for_stats(
+                    import_scryfall=scryfall_stats,
+                    import_identifiers=identifier_stats,
+                    import_prices=price_stats,
+                ),
+            )
+            tracked_run_id = None
             if snapshot is not None:
                 print(f"snapshot: {snapshot['snapshot_path']}")
             print_stats("import-scryfall", scryfall_stats)
@@ -271,7 +482,17 @@ def main() -> None:
             return
 
         if args.command == "sync-bulk":
+            initialize_database(args.db)
             ensure_snapshot, get_snapshot = build_snapshot_callback(args.db, label="before_sync_bulk")
+            tracked_db_path = args.db
+            tracked_snapshot_getter = get_snapshot
+            tracked_run_id = start_sync_run(
+                args.db,
+                run_kind="sync_bulk",
+                source_name=args.source_name,
+                limit_value=args.limit,
+            )
+            print(f"run_id: {tracked_run_id}")
             result = sync_bulk(
                 args.db,
                 cache_dir=args.cache_dir,
@@ -283,10 +504,85 @@ def main() -> None:
                 source_name=args.source_name,
                 before_write=ensure_snapshot,
             )
+            for download in result["downloads"]:
+                artifact_role = {
+                    "scryfall_default_cards.json": "scryfall_bulk",
+                    "AllIdentifiers.json.gz": "mtgjson_identifiers",
+                    "AllPricesToday.json.gz": "mtgjson_prices",
+                }.get(download.label, download.label)
+                record_sync_artifact(
+                    args.db,
+                    tracked_run_id,
+                    artifact_role=artifact_role,
+                    source_url=download.url,
+                    local_path=str(download.path.resolve()),
+                    bytes_written=download.bytes_written,
+                    sha256=download.sha256,
+                    etag=download.etag,
+                    last_modified=download.last_modified,
+                )
+            for step_name, stats_key, elapsed_key in (
+                ("import_scryfall", "scryfall_stats", "scryfall_elapsed_seconds"),
+                ("import_identifiers", "identifier_stats", "identifier_elapsed_seconds"),
+                ("import_prices", "price_stats", "price_elapsed_seconds"),
+            ):
+                step_id = start_sync_step(
+                    args.db,
+                    tracked_run_id,
+                    step_name=step_name,
+                    details={"elapsed_seconds": round(result[elapsed_key], 6)},
+                )
+                finish_sync_step(
+                    args.db,
+                    step_id,
+                    status="succeeded",
+                    stats=result[stats_key],
+                    details={"elapsed_seconds": round(result[elapsed_key], 6)},
+                )
             result["snapshot"] = get_snapshot()
+            finish_sync_run(
+                args.db,
+                tracked_run_id,
+                status="succeeded",
+                snapshot_path=result["snapshot"]["snapshot_path"] if result["snapshot"] is not None else None,
+                summary={
+                    "downloads": [
+                        {
+                            "label": download.label,
+                            "bytes_written": download.bytes_written,
+                            "sha256": download.sha256,
+                        }
+                        for download in result["downloads"]
+                    ],
+                    **_summary_for_stats(
+                        import_scryfall=result["scryfall_stats"],
+                        import_identifiers=result["identifier_stats"],
+                        import_prices=result["price_stats"],
+                    ),
+                },
+            )
+            tracked_run_id = None
             print_sync_bulk_result(result)
             return
 
         parser.error(f"Unknown command {args.command}")
-    except (OSError, ValueError) as exc:
-        parser.exit(status=2, message=f"Error: {exc}\n")
+    except Exception as exc:
+        if tracked_run_id is not None and tracked_db_path is not None:
+            snapshot = tracked_snapshot_getter() if tracked_snapshot_getter is not None else None
+            finish_sync_run(
+                tracked_db_path,
+                tracked_run_id,
+                status="failed",
+                snapshot_path=snapshot["snapshot_path"] if snapshot is not None else None,
+                summary={"error": str(exc)},
+            )
+            record_sync_issue(
+                tracked_db_path,
+                tracked_run_id,
+                level="error",
+                code=type(exc).__name__,
+                message=str(exc),
+            )
+        if isinstance(exc, (OSError, ValueError)):
+            parser.exit(status=2, message=f"Error: {exc}\n")
+        raise

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import time
 from pathlib import Path
 from typing import Any, Callable
 
@@ -116,31 +117,37 @@ def _run_tracked_step(
     details: dict[str, Any] | None = None,
 ) -> Any:
     step_id = start_sync_step(db_path, run_id, step_name=step_name, details=details)
+    started = time.perf_counter()
     try:
         result = operation()
     except Exception as exc:
+        elapsed_seconds = time.perf_counter() - started
         finish_sync_step(
             db_path,
             step_id,
             status="failed",
-            details=_merge_step_details(details, error=exc),
+            details=_merge_step_details(details, error=exc, elapsed_seconds=elapsed_seconds),
         )
         raise
 
+    elapsed_seconds = time.perf_counter() - started
     if hasattr(result, "rows_seen") and hasattr(result, "rows_written") and hasattr(result, "rows_skipped"):
+        result_details = _merge_step_details(details, result, elapsed_seconds=elapsed_seconds)
+        if result_details is not None:
+            result.details = result_details
         finish_sync_step(
             db_path,
             step_id,
             status="succeeded",
             stats=result,
-            details=_merge_step_details(details, result),
+            details=result_details,
         )
     else:
         finish_sync_step(
             db_path,
             step_id,
             status="succeeded",
-            details=details,
+            details=_merge_step_details(details, elapsed_seconds=elapsed_seconds),
         )
     return result
 

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -16,6 +16,7 @@ from ..importer.service import (
     MTGJSON_IDENTIFIERS_URL,
     MTGJSON_PRICES_URL,
     SCRYFALL_BULK_METADATA_URL,
+    find_scryfall_bulk_download_url,
     print_restore_snapshot_result,
     print_snapshot_created,
     print_snapshot_list,
@@ -32,10 +33,12 @@ from ..importer.sync_tracking import (
     finish_sync_run,
     finish_sync_step,
     import_stats_dict,
+    latest_sync_artifact,
     record_sync_artifact,
     record_sync_issue,
     start_sync_run,
     start_sync_step,
+    unchanged_import_skip_reason,
 )
 
 
@@ -154,13 +157,54 @@ def _artifact_role_for_download(label: str) -> str:
     }.get(label, label)
 
 
+def _artifact_role_for_step(step_name: str) -> str:
+    return {
+        "import_scryfall": "scryfall_bulk",
+        "import_identifiers": "mtgjson_identifiers",
+        "import_prices": "mtgjson_prices",
+    }[step_name]
+
+
+def _dependency_steps_for_skip(step_name: str) -> tuple[str, ...]:
+    return {
+        "import_scryfall": (),
+        "import_identifiers": ("import_scryfall",),
+        "import_prices": ("import_identifiers",),
+    }[step_name]
+
+
+def _download_hints_for_url(
+    db_path: str | Path,
+    *,
+    artifact_role: str,
+    source_url: str,
+) -> dict[str, str | None]:
+    artifact = latest_sync_artifact(
+        db_path,
+        artifact_role=artifact_role,
+        source_url=source_url,
+    )
+    if artifact is None:
+        return {}
+    return {
+        "etag": artifact.get("etag"),
+        "last_modified": artifact.get("last_modified"),
+    }
+
+
 def _build_sync_tracking_callbacks(
     db_path: str | Path,
     run_id: int,
+    *,
+    limit_value: int | None,
+    source_name: str | None = None,
 ) -> tuple[
     Callable[[Any], None],
     Callable[[str, str, Any | None, float, Exception | None], None],
+    Callable[[str, Any], str | None],
 ]:
+    step_write_state: dict[str, bool] = {}
+
     def on_download(download: Any) -> None:
         record_sync_artifact(
             db_path,
@@ -195,8 +239,28 @@ def _build_sync_tracking_callbacks(
             stats=stats,
             details=details,
         )
+        if status == "succeeded" and getattr(stats, "rows_written", 0) > 0:
+            step_write_state[step_name] = True
 
-    return on_download, on_step
+    def should_skip_step(
+        step_name: str,
+        download: Any,
+    ) -> str | None:
+        dependency_steps = _dependency_steps_for_skip(step_name)
+        if any(step_write_state.get(dependency_step) for dependency_step in dependency_steps):
+            return None
+        return unchanged_import_skip_reason(
+            db_path,
+            step_name=step_name,
+            artifact_role=_artifact_role_for_step(step_name),
+            source_url=download.url,
+            sha256=download.sha256,
+            limit_value=limit_value,
+            source_name=source_name if step_name == "import_prices" else None,
+            invalidated_by_steps=dependency_steps,
+        )
+
+    return on_download, on_step, should_skip_step
 
 
 def _sync_summary_for_result(result: dict[str, Any]) -> dict[str, Any]:
@@ -650,7 +714,33 @@ def main() -> None:
                 limit_value=args.limit,
             )
             print(f"run_id: {tracked_run_id}")
-            on_download, on_step = _build_sync_tracking_callbacks(args.db, tracked_run_id)
+            on_download, on_step, should_skip_step = _build_sync_tracking_callbacks(
+                args.db,
+                tracked_run_id,
+                limit_value=args.limit,
+                source_name=args.source_name,
+            )
+            scryfall_download_url = find_scryfall_bulk_download_url(
+                args.scryfall_metadata_url,
+                bulk_type=args.scryfall_bulk_type,
+            )
+            download_hints = {
+                "scryfall_default_cards.json": _download_hints_for_url(
+                    args.db,
+                    artifact_role="scryfall_bulk",
+                    source_url=scryfall_download_url,
+                ),
+                "AllIdentifiers.json.gz": _download_hints_for_url(
+                    args.db,
+                    artifact_role="mtgjson_identifiers",
+                    source_url=args.mtgjson_identifiers_url,
+                ),
+                "AllPricesToday.json.gz": _download_hints_for_url(
+                    args.db,
+                    artifact_role="mtgjson_prices",
+                    source_url=args.mtgjson_prices_url,
+                ),
+            }
 
             result = sync_bulk(
                 args.db,
@@ -664,6 +754,8 @@ def main() -> None:
                 before_write=ensure_snapshot,
                 on_download=on_download,
                 on_step=on_step,
+                should_skip_step=should_skip_step,
+                download_hints=download_hints,
             )
             result["snapshot"] = get_snapshot()
             finish_sync_run(
@@ -688,7 +780,20 @@ def main() -> None:
                 limit_value=args.limit,
             )
             print(f"run_id: {tracked_run_id}")
-            on_download, on_step = _build_sync_tracking_callbacks(args.db, tracked_run_id)
+            on_download, on_step, should_skip_step = _build_sync_tracking_callbacks(
+                args.db,
+                tracked_run_id,
+                limit_value=args.limit,
+            )
+            scryfall_download_url = find_scryfall_bulk_download_url(
+                args.scryfall_metadata_url,
+                bulk_type=args.scryfall_bulk_type,
+            )
+            download_hints = _download_hints_for_url(
+                args.db,
+                artifact_role="scryfall_bulk",
+                source_url=scryfall_download_url,
+            )
             result = sync_scryfall(
                 args.db,
                 cache_dir=args.cache_dir,
@@ -698,6 +803,9 @@ def main() -> None:
                 before_write=ensure_snapshot,
                 on_download=on_download,
                 on_step=on_step,
+                should_skip_step=should_skip_step,
+                if_none_match=download_hints.get("etag"),
+                if_modified_since=download_hints.get("last_modified"),
             )
             result["snapshot"] = get_snapshot()
             finish_sync_run(
@@ -726,7 +834,16 @@ def main() -> None:
                 limit_value=args.limit,
             )
             print(f"run_id: {tracked_run_id}")
-            on_download, on_step = _build_sync_tracking_callbacks(args.db, tracked_run_id)
+            on_download, on_step, should_skip_step = _build_sync_tracking_callbacks(
+                args.db,
+                tracked_run_id,
+                limit_value=args.limit,
+            )
+            download_hints = _download_hints_for_url(
+                args.db,
+                artifact_role="mtgjson_identifiers",
+                source_url=args.mtgjson_identifiers_url,
+            )
             result = sync_identifiers(
                 args.db,
                 cache_dir=args.cache_dir,
@@ -735,6 +852,9 @@ def main() -> None:
                 before_write=ensure_snapshot,
                 on_download=on_download,
                 on_step=on_step,
+                should_skip_step=should_skip_step,
+                if_none_match=download_hints.get("etag"),
+                if_modified_since=download_hints.get("last_modified"),
             )
             result["snapshot"] = get_snapshot()
             finish_sync_run(
@@ -764,7 +884,17 @@ def main() -> None:
                 limit_value=args.limit,
             )
             print(f"run_id: {tracked_run_id}")
-            on_download, on_step = _build_sync_tracking_callbacks(args.db, tracked_run_id)
+            on_download, on_step, should_skip_step = _build_sync_tracking_callbacks(
+                args.db,
+                tracked_run_id,
+                limit_value=args.limit,
+                source_name=args.source_name,
+            )
+            download_hints = _download_hints_for_url(
+                args.db,
+                artifact_role="mtgjson_prices",
+                source_url=args.mtgjson_prices_url,
+            )
             result = sync_prices(
                 args.db,
                 cache_dir=args.cache_dir,
@@ -774,6 +904,9 @@ def main() -> None:
                 before_write=ensure_snapshot,
                 on_download=on_download,
                 on_step=on_step,
+                should_skip_step=should_skip_step,
+                if_none_match=download_hints.get("etag"),
+                if_modified_since=download_hints.get("last_modified"),
             )
             result["snapshot"] = get_snapshot()
             finish_sync_run(

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import Any, Callable
 
 from ..db.connection import DEFAULT_DB_PATH, require_database_file
+from ..db.search_index import check_card_search_index, rebuild_card_search_index
 from ..db.migrator import migrate_database
-from ..db.schema import initialize_database
+from ..db.schema import initialize_database, require_current_schema
 from ..db.snapshots import create_database_snapshot, list_database_snapshots, restore_database_snapshot
 from ..importer.mtgjson import import_mtgjson_identifiers, import_mtgjson_prices
 from ..importer.scryfall import import_scryfall_cards
@@ -45,6 +46,7 @@ from ..importer.sync_tracking import (
     start_sync_step,
     unchanged_import_skip_reason,
 )
+from ..inventory.report_helpers import print_table
 
 
 def build_snapshot_callback(
@@ -334,6 +336,68 @@ def _sync_summary_for_result(result: dict[str, Any]) -> dict[str, Any]:
     return summary
 
 
+def _print_search_index_section(
+    title: str,
+    rows: list[dict[str, Any]],
+    columns: list[tuple[str, str]],
+) -> None:
+    if not rows:
+        return
+    print(f"{title}:")
+    print_table(rows, columns)
+
+
+def _print_search_index_check_result(result: Any) -> None:
+    status = "healthy" if result.is_healthy else "drift_detected"
+    print("check-search-index completed")
+    print(f"status: {status}")
+    print(
+        "summary: "
+        f"missing_rows={result.missing_count} "
+        f"orphan_rows={result.orphan_count} "
+        f"duplicate_rows={result.duplicate_count} "
+        f"mismatched_rows={result.mismatch_count}"
+    )
+    _print_search_index_section(
+        "missing rows preview",
+        result.missing_rows,
+        [
+            ("scryfall_id", "scryfall_id"),
+            ("name", "name"),
+            ("set_code", "set"),
+            ("collector_number", "number"),
+            ("lang", "lang"),
+        ],
+    )
+    _print_search_index_section(
+        "orphan rows preview",
+        result.orphan_rows,
+        [
+            ("scryfall_id", "scryfall_id"),
+            ("name", "name"),
+            ("set_code", "set"),
+            ("collector_number", "number"),
+            ("lang", "lang"),
+        ],
+    )
+    _print_search_index_section(
+        "duplicate rows preview",
+        result.duplicate_rows,
+        [
+            ("scryfall_id", "scryfall_id"),
+            ("row_count", "row_count"),
+        ],
+    )
+    _print_search_index_section(
+        "mismatched rows preview",
+        result.mismatch_rows,
+        [
+            ("scryfall_id", "scryfall_id"),
+            ("differences", "differences"),
+        ],
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Initialize and import the MTG MVP schema from local Scryfall and MTGJSON bulk files.",
@@ -503,6 +567,31 @@ def build_parser() -> argparse.ArgumentParser:
         help="MTGJSON AllPricesToday download URL.",
     )
 
+    check_search_index = subparsers.add_parser(
+        "check-search-index",
+        help="Verify that mtg_cards_fts matches the searchable card catalog rows.",
+    )
+    check_search_index.add_argument("--db", default=str(DEFAULT_DB_PATH), help="SQLite database path.")
+    check_search_index.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum preview rows to show for each drift category.",
+    )
+
+    rebuild_search_index = subparsers.add_parser(
+        "rebuild-search-index",
+        help="Rebuild mtg_cards_fts from the current mtg_cards rows.",
+    )
+    rebuild_search_index.add_argument("--db", default=str(DEFAULT_DB_PATH), help="SQLite database path.")
+    rebuild_search_index.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum preview rows to show in the post-rebuild verification report.",
+    )
+    rebuild_search_index.add_argument("--snapshot-dir", help="Optional override directory for snapshots.")
+
     return parser
 
 
@@ -527,6 +616,34 @@ def main() -> None:
                 print(f"Applied migrations: {details}")
             else:
                 print(f"Database at {Path(args.db)} is already at the current schema version.")
+            return
+
+        if args.command == "check-search-index":
+            require_current_schema(args.db)
+            result = check_card_search_index(args.db, limit=args.limit)
+            _print_search_index_check_result(result)
+            if not result.is_healthy:
+                raise SystemExit(1)
+            return
+
+        if args.command == "rebuild-search-index":
+            require_current_schema(args.db)
+            ensure_snapshot, get_snapshot = build_snapshot_callback(
+                args.db,
+                label="before_rebuild_search_index",
+                snapshot_dir=args.snapshot_dir,
+            )
+            snapshot = ensure_snapshot()
+            print(f"snapshot: {snapshot['snapshot_path']}")
+            rebuild_result = rebuild_card_search_index(args.db)
+            check_result = check_card_search_index(args.db, limit=args.limit)
+            print("rebuild-search-index completed")
+            print(f"previous_rows: {rebuild_result.previous_row_count}")
+            print(f"source_rows: {rebuild_result.source_row_count}")
+            print(f"rebuilt_rows: {rebuild_result.rebuilt_row_count}")
+            _print_search_index_check_result(check_result)
+            if not check_result.is_healthy:
+                raise SystemExit(1)
             return
 
         if args.command == "snapshot-db":

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -14,10 +14,13 @@ from ..importer.scryfall import import_scryfall_cards
 from ..importer.service import (
     DEFAULT_BULK_CACHE_DIR,
     DEFAULT_SCRYFALL_BULK_TYPE,
+    MTGJSON_IDENTIFIERS_CACHE_FILENAME,
     MTGJSON_IDENTIFIERS_URL,
+    MTGJSON_PRICES_CACHE_FILENAME,
     MTGJSON_PRICES_URL,
+    SCRYFALL_BULK_CACHE_FILENAME,
+    SCRYFALL_BULK_METADATA_CACHE_FILENAME,
     SCRYFALL_BULK_METADATA_URL,
-    find_scryfall_bulk_download_url,
     print_restore_snapshot_result,
     print_snapshot_created,
     print_snapshot_list,
@@ -159,6 +162,7 @@ def _summary_for_stats(**stats: Any) -> dict[str, Any]:
 def _artifact_role_for_download(label: str) -> str:
     return {
         "scryfall_default_cards.json": "scryfall_bulk",
+        "scryfall_bulk_metadata.json": "scryfall_bulk_metadata",
         "AllIdentifiers.json.gz": "mtgjson_identifiers",
         "AllPricesToday.json.gz": "mtgjson_prices",
     }.get(label, label)
@@ -190,6 +194,23 @@ def _download_hints_for_url(
         db_path,
         artifact_role=artifact_role,
         source_url=source_url,
+    )
+    if artifact is None:
+        return {}
+    return {
+        "etag": artifact.get("etag"),
+        "last_modified": artifact.get("last_modified"),
+    }
+
+
+def _download_hints_for_latest_role(
+    db_path: str | Path,
+    *,
+    artifact_role: str,
+) -> dict[str, str | None]:
+    artifact = latest_sync_artifact(
+        db_path,
+        artifact_role=artifact_role,
     )
     if artifact is None:
         return {}
@@ -727,22 +748,22 @@ def main() -> None:
                 limit_value=args.limit,
                 source_name=args.source_name,
             )
-            scryfall_download_url = find_scryfall_bulk_download_url(
-                args.scryfall_metadata_url,
-                bulk_type=args.scryfall_bulk_type,
-            )
             download_hints = {
-                "scryfall_default_cards.json": _download_hints_for_url(
+                SCRYFALL_BULK_METADATA_CACHE_FILENAME: _download_hints_for_url(
+                    args.db,
+                    artifact_role="scryfall_bulk_metadata",
+                    source_url=args.scryfall_metadata_url,
+                ),
+                SCRYFALL_BULK_CACHE_FILENAME: _download_hints_for_latest_role(
                     args.db,
                     artifact_role="scryfall_bulk",
-                    source_url=scryfall_download_url,
                 ),
-                "AllIdentifiers.json.gz": _download_hints_for_url(
+                MTGJSON_IDENTIFIERS_CACHE_FILENAME: _download_hints_for_url(
                     args.db,
                     artifact_role="mtgjson_identifiers",
                     source_url=args.mtgjson_identifiers_url,
                 ),
-                "AllPricesToday.json.gz": _download_hints_for_url(
+                MTGJSON_PRICES_CACHE_FILENAME: _download_hints_for_url(
                     args.db,
                     artifact_role="mtgjson_prices",
                     source_url=args.mtgjson_prices_url,
@@ -792,14 +813,14 @@ def main() -> None:
                 tracked_run_id,
                 limit_value=args.limit,
             )
-            scryfall_download_url = find_scryfall_bulk_download_url(
-                args.scryfall_metadata_url,
-                bulk_type=args.scryfall_bulk_type,
+            metadata_download_hints = _download_hints_for_url(
+                args.db,
+                artifact_role="scryfall_bulk_metadata",
+                source_url=args.scryfall_metadata_url,
             )
-            download_hints = _download_hints_for_url(
+            bulk_download_hints = _download_hints_for_latest_role(
                 args.db,
                 artifact_role="scryfall_bulk",
-                source_url=scryfall_download_url,
             )
             result = sync_scryfall(
                 args.db,
@@ -811,8 +832,10 @@ def main() -> None:
                 on_download=on_download,
                 on_step=on_step,
                 should_skip_step=should_skip_step,
-                if_none_match=download_hints.get("etag"),
-                if_modified_since=download_hints.get("last_modified"),
+                metadata_if_none_match=metadata_download_hints.get("etag"),
+                metadata_if_modified_since=metadata_download_hints.get("last_modified"),
+                bulk_if_none_match=bulk_download_hints.get("etag"),
+                bulk_if_modified_since=bulk_download_hints.get("last_modified"),
             )
             result["snapshot"] = get_snapshot()
             finish_sync_run(

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -20,8 +20,12 @@ from ..importer.service import (
     print_snapshot_created,
     print_snapshot_list,
     print_stats,
+    print_sync_result,
     print_sync_bulk_result,
     sync_bulk,
+    sync_identifiers,
+    sync_prices,
+    sync_scryfall,
 )
 from ..importer.sync_tracking import (
     file_artifact_info,
@@ -142,6 +146,80 @@ def _summary_for_stats(**stats: Any) -> dict[str, Any]:
     return {label: import_stats_dict(value) for label, value in stats.items()}
 
 
+def _artifact_role_for_download(label: str) -> str:
+    return {
+        "scryfall_default_cards.json": "scryfall_bulk",
+        "AllIdentifiers.json.gz": "mtgjson_identifiers",
+        "AllPricesToday.json.gz": "mtgjson_prices",
+    }.get(label, label)
+
+
+def _build_sync_tracking_callbacks(
+    db_path: str | Path,
+    run_id: int,
+) -> tuple[
+    Callable[[Any], None],
+    Callable[[str, str, Any | None, float, Exception | None], None],
+]:
+    def on_download(download: Any) -> None:
+        record_sync_artifact(
+            db_path,
+            run_id,
+            artifact_role=_artifact_role_for_download(download.label),
+            source_url=download.url,
+            local_path=str(download.path.resolve()),
+            bytes_written=download.bytes_written,
+            sha256=download.sha256,
+            etag=download.etag,
+            last_modified=download.last_modified,
+        )
+
+    def on_step(
+        step_name: str,
+        status: str,
+        stats: Any | None,
+        elapsed_seconds: float,
+        error: Exception | None,
+    ) -> None:
+        details = _merge_step_details(None, stats, elapsed_seconds=elapsed_seconds, error=error)
+        step_id = start_sync_step(
+            db_path,
+            run_id,
+            step_name=step_name,
+            details=details,
+        )
+        finish_sync_step(
+            db_path,
+            step_id,
+            status=status,
+            stats=stats,
+            details=details,
+        )
+
+    return on_download, on_step
+
+
+def _sync_summary_for_result(result: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "downloads": [
+            {
+                "label": download.label,
+                "bytes_written": download.bytes_written,
+                "sha256": download.sha256,
+            }
+            for download in result["downloads"]
+        ]
+    }
+    for label, key in (
+        ("import_scryfall", "scryfall_stats"),
+        ("import_identifiers", "identifier_stats"),
+        ("import_prices", "price_stats"),
+    ):
+        if key in result:
+            summary.update(_summary_for_stats(**{label: result[key]}))
+    return summary
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Initialize and import the MTG MVP schema from local Scryfall and MTGJSON bulk files.",
@@ -245,6 +323,67 @@ def build_parser() -> argparse.ArgumentParser:
         help="MTGJSON AllIdentifiers download URL.",
     )
     sync_bulk_parser.add_argument(
+        "--mtgjson-prices-url",
+        default=MTGJSON_PRICES_URL,
+        help="MTGJSON AllPricesToday download URL.",
+    )
+
+    sync_scryfall_parser = subparsers.add_parser(
+        "sync-scryfall",
+        help="Download the latest Scryfall bulk file and import it.",
+    )
+    sync_scryfall_parser.add_argument("--db", default=str(DEFAULT_DB_PATH), help="SQLite database path.")
+    sync_scryfall_parser.add_argument(
+        "--cache-dir",
+        default=str(DEFAULT_BULK_CACHE_DIR),
+        help="Directory to store the downloaded bulk files.",
+    )
+    sync_scryfall_parser.add_argument("--limit", type=int, help="Optional max number of rows to import.")
+    sync_scryfall_parser.add_argument(
+        "--scryfall-bulk-type",
+        default=DEFAULT_SCRYFALL_BULK_TYPE,
+        help="Scryfall bulk type to download, such as default_cards.",
+    )
+    sync_scryfall_parser.add_argument(
+        "--scryfall-metadata-url",
+        default=SCRYFALL_BULK_METADATA_URL,
+        help="Scryfall bulk metadata URL.",
+    )
+
+    sync_identifiers_parser = subparsers.add_parser(
+        "sync-identifiers",
+        help="Download the latest MTGJSON AllIdentifiers file and import it.",
+    )
+    sync_identifiers_parser.add_argument("--db", default=str(DEFAULT_DB_PATH), help="SQLite database path.")
+    sync_identifiers_parser.add_argument(
+        "--cache-dir",
+        default=str(DEFAULT_BULK_CACHE_DIR),
+        help="Directory to store the downloaded bulk files.",
+    )
+    sync_identifiers_parser.add_argument("--limit", type=int, help="Optional max number of rows to import.")
+    sync_identifiers_parser.add_argument(
+        "--mtgjson-identifiers-url",
+        default=MTGJSON_IDENTIFIERS_URL,
+        help="MTGJSON AllIdentifiers download URL.",
+    )
+
+    sync_prices_parser = subparsers.add_parser(
+        "sync-prices",
+        help="Download the latest MTGJSON AllPricesToday file and import it.",
+    )
+    sync_prices_parser.add_argument("--db", default=str(DEFAULT_DB_PATH), help="SQLite database path.")
+    sync_prices_parser.add_argument(
+        "--cache-dir",
+        default=str(DEFAULT_BULK_CACHE_DIR),
+        help="Directory to store the downloaded bulk files.",
+    )
+    sync_prices_parser.add_argument("--limit", type=int, help="Optional max number of rows to import.")
+    sync_prices_parser.add_argument(
+        "--source-name",
+        default="mtgjson_all_prices_today",
+        help="Source label stored in price_snapshots.source_name.",
+    )
+    sync_prices_parser.add_argument(
         "--mtgjson-prices-url",
         default=MTGJSON_PRICES_URL,
         help="MTGJSON AllPricesToday download URL.",
@@ -511,44 +650,7 @@ def main() -> None:
                 limit_value=args.limit,
             )
             print(f"run_id: {tracked_run_id}")
-            def on_download(download: Any) -> None:
-                artifact_role = {
-                    "scryfall_default_cards.json": "scryfall_bulk",
-                    "AllIdentifiers.json.gz": "mtgjson_identifiers",
-                    "AllPricesToday.json.gz": "mtgjson_prices",
-                }.get(download.label, download.label)
-                record_sync_artifact(
-                    args.db,
-                    tracked_run_id,
-                    artifact_role=artifact_role,
-                    source_url=download.url,
-                    local_path=str(download.path.resolve()),
-                    bytes_written=download.bytes_written,
-                    sha256=download.sha256,
-                    etag=download.etag,
-                    last_modified=download.last_modified,
-                )
-
-            def on_step(
-                step_name: str,
-                status: str,
-                stats: Any | None,
-                elapsed_seconds: float,
-                error: Exception | None,
-            ) -> None:
-                step_id = start_sync_step(
-                    args.db,
-                    tracked_run_id,
-                    step_name=step_name,
-                    details=_merge_step_details(None, stats, elapsed_seconds=elapsed_seconds, error=error),
-                )
-                finish_sync_step(
-                    args.db,
-                    step_id,
-                    status=status,
-                    stats=stats,
-                    details=_merge_step_details(None, stats, elapsed_seconds=elapsed_seconds, error=error),
-                )
+            on_download, on_step = _build_sync_tracking_callbacks(args.db, tracked_run_id)
 
             result = sync_bulk(
                 args.db,
@@ -569,24 +671,124 @@ def main() -> None:
                 tracked_run_id,
                 status="succeeded",
                 snapshot_path=result["snapshot"]["snapshot_path"] if result["snapshot"] is not None else None,
-                summary={
-                    "downloads": [
-                        {
-                            "label": download.label,
-                            "bytes_written": download.bytes_written,
-                            "sha256": download.sha256,
-                        }
-                        for download in result["downloads"]
-                    ],
-                    **_summary_for_stats(
-                        import_scryfall=result["scryfall_stats"],
-                        import_identifiers=result["identifier_stats"],
-                        import_prices=result["price_stats"],
-                    ),
-                },
+                summary=_sync_summary_for_result(result),
             )
             tracked_run_id = None
             print_sync_bulk_result(result)
+            return
+
+        if args.command == "sync-scryfall":
+            initialize_database(args.db)
+            ensure_snapshot, get_snapshot = build_snapshot_callback(args.db, label="before_sync_scryfall")
+            tracked_db_path = args.db
+            tracked_snapshot_getter = get_snapshot
+            tracked_run_id = start_sync_run(
+                args.db,
+                run_kind="sync_scryfall",
+                limit_value=args.limit,
+            )
+            print(f"run_id: {tracked_run_id}")
+            on_download, on_step = _build_sync_tracking_callbacks(args.db, tracked_run_id)
+            result = sync_scryfall(
+                args.db,
+                cache_dir=args.cache_dir,
+                scryfall_metadata_url=args.scryfall_metadata_url,
+                scryfall_bulk_type=args.scryfall_bulk_type,
+                limit=args.limit,
+                before_write=ensure_snapshot,
+                on_download=on_download,
+                on_step=on_step,
+            )
+            result["snapshot"] = get_snapshot()
+            finish_sync_run(
+                args.db,
+                tracked_run_id,
+                status="succeeded",
+                snapshot_path=result["snapshot"]["snapshot_path"] if result["snapshot"] is not None else None,
+                summary=_sync_summary_for_result(result),
+            )
+            tracked_run_id = None
+            print_sync_result(
+                "sync-scryfall",
+                result,
+                stat_labels=[("import-scryfall", "scryfall_stats")],
+            )
+            return
+
+        if args.command == "sync-identifiers":
+            initialize_database(args.db)
+            ensure_snapshot, get_snapshot = build_snapshot_callback(args.db, label="before_sync_identifiers")
+            tracked_db_path = args.db
+            tracked_snapshot_getter = get_snapshot
+            tracked_run_id = start_sync_run(
+                args.db,
+                run_kind="sync_identifiers",
+                limit_value=args.limit,
+            )
+            print(f"run_id: {tracked_run_id}")
+            on_download, on_step = _build_sync_tracking_callbacks(args.db, tracked_run_id)
+            result = sync_identifiers(
+                args.db,
+                cache_dir=args.cache_dir,
+                mtgjson_identifiers_url=args.mtgjson_identifiers_url,
+                limit=args.limit,
+                before_write=ensure_snapshot,
+                on_download=on_download,
+                on_step=on_step,
+            )
+            result["snapshot"] = get_snapshot()
+            finish_sync_run(
+                args.db,
+                tracked_run_id,
+                status="succeeded",
+                snapshot_path=result["snapshot"]["snapshot_path"] if result["snapshot"] is not None else None,
+                summary=_sync_summary_for_result(result),
+            )
+            tracked_run_id = None
+            print_sync_result(
+                "sync-identifiers",
+                result,
+                stat_labels=[("import-identifiers", "identifier_stats")],
+            )
+            return
+
+        if args.command == "sync-prices":
+            initialize_database(args.db)
+            ensure_snapshot, get_snapshot = build_snapshot_callback(args.db, label="before_sync_prices")
+            tracked_db_path = args.db
+            tracked_snapshot_getter = get_snapshot
+            tracked_run_id = start_sync_run(
+                args.db,
+                run_kind="sync_prices",
+                source_name=args.source_name,
+                limit_value=args.limit,
+            )
+            print(f"run_id: {tracked_run_id}")
+            on_download, on_step = _build_sync_tracking_callbacks(args.db, tracked_run_id)
+            result = sync_prices(
+                args.db,
+                cache_dir=args.cache_dir,
+                mtgjson_prices_url=args.mtgjson_prices_url,
+                limit=args.limit,
+                source_name=args.source_name,
+                before_write=ensure_snapshot,
+                on_download=on_download,
+                on_step=on_step,
+            )
+            result["snapshot"] = get_snapshot()
+            finish_sync_run(
+                args.db,
+                tracked_run_id,
+                status="succeeded",
+                snapshot_path=result["snapshot"]["snapshot_path"] if result["snapshot"] is not None else None,
+                summary=_sync_summary_for_result(result),
+            )
+            tracked_run_id = None
+            print_sync_result(
+                "sync-prices",
+                result,
+                stat_labels=[("import-prices", "price_stats")],
+            )
             return
 
         parser.error(f"Unknown command {args.command}")

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -82,6 +82,24 @@ def _record_local_artifact(
     )
 
 
+def _merge_step_details(
+    base_details: dict[str, Any] | None,
+    stats: Any | None = None,
+    *,
+    elapsed_seconds: float | None = None,
+    error: Exception | None = None,
+) -> dict[str, Any] | None:
+    merged: dict[str, Any] = dict(base_details or {})
+    result_details = getattr(stats, "details", None)
+    if isinstance(result_details, dict):
+        merged.update(result_details)
+    if elapsed_seconds is not None:
+        merged["elapsed_seconds"] = round(elapsed_seconds, 6)
+    if error is not None:
+        merged["error"] = str(error)
+    return merged or None
+
+
 def _run_tracked_step(
     db_path: str | Path,
     run_id: int,
@@ -98,7 +116,7 @@ def _run_tracked_step(
             db_path,
             step_id,
             status="failed",
-            details={**(details or {}), "error": str(exc)},
+            details=_merge_step_details(details, error=exc),
         )
         raise
 
@@ -108,7 +126,7 @@ def _run_tracked_step(
             step_id,
             status="succeeded",
             stats=result,
-            details=details,
+            details=_merge_step_details(details, result),
         )
     else:
         finish_sync_step(
@@ -493,18 +511,7 @@ def main() -> None:
                 limit_value=args.limit,
             )
             print(f"run_id: {tracked_run_id}")
-            result = sync_bulk(
-                args.db,
-                cache_dir=args.cache_dir,
-                scryfall_metadata_url=args.scryfall_metadata_url,
-                scryfall_bulk_type=args.scryfall_bulk_type,
-                mtgjson_identifiers_url=args.mtgjson_identifiers_url,
-                mtgjson_prices_url=args.mtgjson_prices_url,
-                limit=args.limit,
-                source_name=args.source_name,
-                before_write=ensure_snapshot,
-            )
-            for download in result["downloads"]:
+            def on_download(download: Any) -> None:
                 artifact_role = {
                     "scryfall_default_cards.json": "scryfall_bulk",
                     "AllIdentifiers.json.gz": "mtgjson_identifiers",
@@ -521,24 +528,41 @@ def main() -> None:
                     etag=download.etag,
                     last_modified=download.last_modified,
                 )
-            for step_name, stats_key, elapsed_key in (
-                ("import_scryfall", "scryfall_stats", "scryfall_elapsed_seconds"),
-                ("import_identifiers", "identifier_stats", "identifier_elapsed_seconds"),
-                ("import_prices", "price_stats", "price_elapsed_seconds"),
-            ):
+
+            def on_step(
+                step_name: str,
+                status: str,
+                stats: Any | None,
+                elapsed_seconds: float,
+                error: Exception | None,
+            ) -> None:
                 step_id = start_sync_step(
                     args.db,
                     tracked_run_id,
                     step_name=step_name,
-                    details={"elapsed_seconds": round(result[elapsed_key], 6)},
+                    details=_merge_step_details(None, stats, elapsed_seconds=elapsed_seconds, error=error),
                 )
                 finish_sync_step(
                     args.db,
                     step_id,
-                    status="succeeded",
-                    stats=result[stats_key],
-                    details={"elapsed_seconds": round(result[elapsed_key], 6)},
+                    status=status,
+                    stats=stats,
+                    details=_merge_step_details(None, stats, elapsed_seconds=elapsed_seconds, error=error),
                 )
+
+            result = sync_bulk(
+                args.db,
+                cache_dir=args.cache_dir,
+                scryfall_metadata_url=args.scryfall_metadata_url,
+                scryfall_bulk_type=args.scryfall_bulk_type,
+                mtgjson_identifiers_url=args.mtgjson_identifiers_url,
+                mtgjson_prices_url=args.mtgjson_prices_url,
+                limit=args.limit,
+                source_name=args.source_name,
+                before_write=ensure_snapshot,
+                on_download=on_download,
+                on_step=on_step,
+            )
             result["snapshot"] = get_snapshot()
             finish_sync_run(
                 args.db,

--- a/src/mtg_source_stack/db/migrations/0012_add_mtgjson_card_links.sql
+++ b/src/mtg_source_stack/db/migrations/0012_add_mtgjson_card_links.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS mtgjson_card_links (
+    mtgjson_uuid TEXT PRIMARY KEY,
+    scryfall_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (scryfall_id) REFERENCES mtg_cards (scryfall_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mtgjson_card_links_scryfall
+    ON mtgjson_card_links (scryfall_id);
+
+INSERT OR IGNORE INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
+SELECT mtgjson_uuid, scryfall_id
+FROM mtg_cards
+WHERE mtgjson_uuid IS NOT NULL
+  AND TRIM(mtgjson_uuid) <> '';

--- a/src/mtg_source_stack/db/migrations/0013_add_sync_run_tracking.sql
+++ b/src/mtg_source_stack/db/migrations/0013_add_sync_run_tracking.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS sync_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_kind TEXT NOT NULL,
+    status TEXT NOT NULL,
+    trigger_kind TEXT NOT NULL DEFAULT 'cli',
+    source_name TEXT,
+    limit_value INTEGER,
+    snapshot_path TEXT,
+    summary_json TEXT,
+    started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    finished_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_started_at
+    ON sync_runs (started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_kind_started_at
+    ON sync_runs (run_kind, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS sync_run_steps (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sync_run_id INTEGER NOT NULL,
+    step_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    rows_seen INTEGER,
+    rows_written INTEGER,
+    rows_skipped INTEGER,
+    details_json TEXT,
+    started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    finished_at TEXT,
+    FOREIGN KEY (sync_run_id) REFERENCES sync_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_run_steps_run_step
+    ON sync_run_steps (sync_run_id, step_name);
+
+CREATE TABLE IF NOT EXISTS sync_run_artifacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sync_run_id INTEGER NOT NULL,
+    artifact_role TEXT NOT NULL,
+    source_url TEXT,
+    local_path TEXT,
+    bytes_written INTEGER,
+    sha256 TEXT,
+    etag TEXT,
+    last_modified TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (sync_run_id) REFERENCES sync_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_run_artifacts_run_role
+    ON sync_run_artifacts (sync_run_id, artifact_role);
+
+CREATE TABLE IF NOT EXISTS sync_run_issues (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sync_run_id INTEGER NOT NULL,
+    step_name TEXT,
+    level TEXT NOT NULL,
+    code TEXT NOT NULL,
+    message TEXT NOT NULL,
+    payload_json TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (sync_run_id) REFERENCES sync_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_run_issues_run_created_at
+    ON sync_run_issues (sync_run_id, created_at);

--- a/src/mtg_source_stack/db/migrations/0014_narrow_card_search_fts_updates.sql
+++ b/src/mtg_source_stack/db/migrations/0014_narrow_card_search_fts_updates.sql
@@ -1,0 +1,18 @@
+DROP TRIGGER IF EXISTS trg_mtg_cards_au_fts;
+
+CREATE TRIGGER IF NOT EXISTS trg_mtg_cards_au_fts
+AFTER UPDATE OF scryfall_id, name, set_code, set_name, collector_number, lang ON mtg_cards
+WHEN
+    old.scryfall_id IS NOT new.scryfall_id
+    OR old.name IS NOT new.name
+    OR old.set_code IS NOT new.set_code
+    OR old.set_name IS NOT new.set_name
+    OR old.collector_number IS NOT new.collector_number
+    OR old.lang IS NOT new.lang
+BEGIN
+    DELETE FROM mtg_cards_fts
+    WHERE scryfall_id = old.scryfall_id;
+
+    INSERT INTO mtg_cards_fts (scryfall_id, name, set_code, set_name, collector_number, lang)
+    VALUES (new.scryfall_id, new.name, new.set_code, new.set_name, new.collector_number, new.lang);
+END;

--- a/src/mtg_source_stack/db/migrator.py
+++ b/src/mtg_source_stack/db/migrator.py
@@ -155,6 +155,17 @@ def _prepare_migration(connection: sqlite3.Connection, migration: MigrationFile)
                     ADD COLUMN {column_name} {column_type}
                     """
                 )
+    if (
+        migration.version == 12
+        and table_exists(connection, "mtg_cards")
+        and not column_exists(connection, "mtg_cards", "mtgjson_uuid")
+    ):
+        connection.execute(
+            """
+            ALTER TABLE mtg_cards
+            ADD COLUMN mtgjson_uuid TEXT
+            """
+        )
 
 
 def migrate_connection(connection: sqlite3.Connection) -> list[MigrationFile]:

--- a/src/mtg_source_stack/db/search_index.py
+++ b/src/mtg_source_stack/db/search_index.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .connection import connect
+
+
+SEARCH_INDEX_COLUMNS: tuple[str, ...] = (
+    "scryfall_id",
+    "name",
+    "set_code",
+    "set_name",
+    "collector_number",
+    "lang",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SearchIndexCheckResult:
+    missing_count: int
+    orphan_count: int
+    duplicate_count: int
+    mismatch_count: int
+    missing_rows: list[dict[str, Any]]
+    orphan_rows: list[dict[str, Any]]
+    duplicate_rows: list[dict[str, Any]]
+    mismatch_rows: list[dict[str, Any]]
+
+    @property
+    def is_healthy(self) -> bool:
+        return (
+            self.missing_count == 0
+            and self.orphan_count == 0
+            and self.duplicate_count == 0
+            and self.mismatch_count == 0
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SearchIndexRebuildResult:
+    previous_row_count: int
+    source_row_count: int
+    rebuilt_row_count: int
+
+
+def _validate_limit(limit: int) -> None:
+    if limit < 0:
+        raise ValueError("Preview limit must be zero or greater.")
+
+
+def _preview_value(value: Any) -> str:
+    if value is None:
+        return "(null)"
+    text = str(value)
+    return text if len(text) <= 40 else f"{text[:37]}..."
+
+
+def _difference_summary(card_row: dict[str, Any], fts_row: dict[str, Any]) -> str:
+    differences: list[str] = []
+    for column_name in SEARCH_INDEX_COLUMNS:
+        card_value = card_row[column_name]
+        fts_value = fts_row[column_name]
+        if card_value != fts_value:
+            differences.append(
+                f"{column_name}: card={_preview_value(card_value)} fts={_preview_value(fts_value)}"
+            )
+    return "; ".join(differences)
+
+
+def _rows_to_dicts(rows: list[Any]) -> list[dict[str, Any]]:
+    return [dict(row) for row in rows]
+
+
+def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIndexCheckResult:
+    _validate_limit(limit)
+
+    with connect(db_path) as connection:
+        missing_count = int(
+            connection.execute(
+                """
+                SELECT COUNT(*)
+                FROM mtg_cards AS cards
+                LEFT JOIN mtg_cards_fts AS fts
+                    ON fts.scryfall_id = cards.scryfall_id
+                WHERE fts.scryfall_id IS NULL
+                """
+            ).fetchone()[0]
+        )
+        missing_rows = _rows_to_dicts(
+            connection.execute(
+                """
+                SELECT
+                    cards.scryfall_id,
+                    cards.name,
+                    cards.set_code,
+                    cards.collector_number,
+                    cards.lang
+                FROM mtg_cards AS cards
+                LEFT JOIN mtg_cards_fts AS fts
+                    ON fts.scryfall_id = cards.scryfall_id
+                WHERE fts.scryfall_id IS NULL
+                ORDER BY cards.scryfall_id
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        )
+
+        orphan_count = int(
+            connection.execute(
+                """
+                SELECT COUNT(*)
+                FROM mtg_cards_fts AS fts
+                LEFT JOIN mtg_cards AS cards
+                    ON cards.scryfall_id = fts.scryfall_id
+                WHERE cards.scryfall_id IS NULL
+                """
+            ).fetchone()[0]
+        )
+        orphan_rows = _rows_to_dicts(
+            connection.execute(
+                """
+                SELECT
+                    fts.scryfall_id,
+                    fts.name,
+                    fts.set_code,
+                    fts.collector_number,
+                    fts.lang
+                FROM mtg_cards_fts AS fts
+                LEFT JOIN mtg_cards AS cards
+                    ON cards.scryfall_id = fts.scryfall_id
+                WHERE cards.scryfall_id IS NULL
+                ORDER BY fts.scryfall_id
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        )
+
+        duplicate_count = int(
+            connection.execute(
+                """
+                SELECT COUNT(*)
+                FROM (
+                    SELECT fts.scryfall_id
+                    FROM mtg_cards_fts AS fts
+                    GROUP BY fts.scryfall_id
+                    HAVING COUNT(*) > 1
+                )
+                """
+            ).fetchone()[0]
+        )
+        duplicate_rows = _rows_to_dicts(
+            connection.execute(
+                """
+                SELECT
+                    fts.scryfall_id,
+                    COUNT(*) AS row_count
+                FROM mtg_cards_fts AS fts
+                GROUP BY fts.scryfall_id
+                HAVING COUNT(*) > 1
+                ORDER BY row_count DESC, fts.scryfall_id
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        )
+
+        mismatch_query = """
+            SELECT
+                cards.scryfall_id,
+                cards.name AS card_name,
+                cards.set_code AS card_set_code,
+                cards.set_name AS card_set_name,
+                cards.collector_number AS card_collector_number,
+                cards.lang AS card_lang,
+                fts.name AS fts_name,
+                fts.set_code AS fts_set_code,
+                fts.set_name AS fts_set_name,
+                fts.collector_number AS fts_collector_number,
+                fts.lang AS fts_lang
+            FROM mtg_cards AS cards
+            JOIN mtg_cards_fts AS fts
+                ON fts.scryfall_id = cards.scryfall_id
+            WHERE
+                cards.name IS NOT fts.name
+                OR cards.set_code IS NOT fts.set_code
+                OR cards.set_name IS NOT fts.set_name
+                OR cards.collector_number IS NOT fts.collector_number
+                OR cards.lang IS NOT fts.lang
+            ORDER BY cards.scryfall_id, fts.rowid
+        """
+        mismatch_count = int(
+            connection.execute(
+                f"""
+                SELECT COUNT(*)
+                FROM ({mismatch_query})
+                """
+            ).fetchone()[0]
+        )
+        raw_mismatch_rows = _rows_to_dicts(
+            connection.execute(
+                f"""
+                {mismatch_query}
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        )
+
+    mismatch_rows: list[dict[str, Any]] = []
+    for row in raw_mismatch_rows:
+        mismatch_rows.append(
+            {
+                "scryfall_id": row["scryfall_id"],
+                "differences": _difference_summary(
+                    {
+                        "scryfall_id": row["scryfall_id"],
+                        "name": row["card_name"],
+                        "set_code": row["card_set_code"],
+                        "set_name": row["card_set_name"],
+                        "collector_number": row["card_collector_number"],
+                        "lang": row["card_lang"],
+                    },
+                    {
+                        "scryfall_id": row["scryfall_id"],
+                        "name": row["fts_name"],
+                        "set_code": row["fts_set_code"],
+                        "set_name": row["fts_set_name"],
+                        "collector_number": row["fts_collector_number"],
+                        "lang": row["fts_lang"],
+                    },
+                ),
+            }
+        )
+
+    return SearchIndexCheckResult(
+        missing_count=missing_count,
+        orphan_count=orphan_count,
+        duplicate_count=duplicate_count,
+        mismatch_count=mismatch_count,
+        missing_rows=missing_rows,
+        orphan_rows=orphan_rows,
+        duplicate_rows=duplicate_rows,
+        mismatch_rows=mismatch_rows,
+    )
+
+
+def rebuild_card_search_index(db_path: str | Path) -> SearchIndexRebuildResult:
+    with connect(db_path) as connection:
+        previous_row_count = int(connection.execute("SELECT COUNT(*) FROM mtg_cards_fts").fetchone()[0])
+        source_row_count = int(connection.execute("SELECT COUNT(*) FROM mtg_cards").fetchone()[0])
+        connection.execute("DELETE FROM mtg_cards_fts")
+        connection.execute(
+            """
+            INSERT INTO mtg_cards_fts (scryfall_id, name, set_code, set_name, collector_number, lang)
+            SELECT
+                scryfall_id,
+                name,
+                set_code,
+                set_name,
+                collector_number,
+                lang
+            FROM mtg_cards
+            ORDER BY scryfall_id
+            """
+        )
+        connection.commit()
+        rebuilt_row_count = int(connection.execute("SELECT COUNT(*) FROM mtg_cards_fts").fetchone()[0])
+
+    return SearchIndexRebuildResult(
+        previous_row_count=previous_row_count,
+        source_row_count=source_row_count,
+        rebuilt_row_count=rebuilt_row_count,
+    )

--- a/src/mtg_source_stack/importer/mtgjson.py
+++ b/src/mtg_source_stack/importer/mtgjson.py
@@ -11,7 +11,7 @@ from ..db.schema import initialize_database
 from ..inventory.money import coerce_decimal
 from ..inventory.normalize import normalize_price_snapshot_finish
 from ..pricing import DEFAULT_PRICE_CURRENCY
-from .service import ImportStats, first_non_empty, load_json, text_or_none
+from .service import ImportStats, first_non_empty, iter_json_object_items, text_or_none
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,6 +95,21 @@ def _price_uuid_preference(uuid: str, *, preferred_uuid: str | None) -> tuple[in
     return (0 if preferred_uuid is not None and uuid == preferred_uuid else 1, uuid)
 
 
+def _iter_mtgjson_data_items(
+    json_path: str | Path,
+    *,
+    payload_label: str,
+):
+    try:
+        yield from iter_json_object_items(json_path, top_level_key="data")
+    except ValueError as exc:
+        if str(exc) == "Expected JSON object to contain an object at payload['data'].":
+            raise ValueError(
+                f"Expected MTGJSON {payload_label} to contain an object at payload['data']."
+            ) from exc
+        raise
+
+
 def import_mtgjson_identifiers(
     db_path: str | Path,
     json_path: str | Path,
@@ -102,11 +117,6 @@ def import_mtgjson_identifiers(
     *,
     before_write: Callable[[], Any] | None = None,
 ) -> ImportStats:
-    payload = load_json(json_path)
-    data = payload.get("data", {}) if isinstance(payload, dict) else {}
-    if not isinstance(data, dict):
-        raise ValueError("Expected MTGJSON identifiers to contain an object at payload['data'].")
-
     stats = ImportStats()
     initialize_database(db_path)
     snapshot_taken = False
@@ -144,7 +154,10 @@ def import_mtgjson_identifiers(
 
     grouped_rows: dict[str, list[IdentifierImportRow]] = {}
 
-    for index, (uuid, identifier_record) in enumerate(data.items(), start=1):
+    for index, (uuid, identifier_record) in enumerate(
+        _iter_mtgjson_data_items(json_path, payload_label="identifiers"),
+        start=1,
+    ):
         if limit is not None and index > limit:
             break
 
@@ -415,11 +428,6 @@ def import_mtgjson_prices(
     *,
     before_write: Callable[[], Any] | None = None,
 ) -> ImportStats:
-    payload = load_json(json_path)
-    data = payload.get("data", {}) if isinstance(payload, dict) else {}
-    if not isinstance(data, dict):
-        raise ValueError("Expected MTGJSON prices to contain an object at payload['data'].")
-
     initialize_database(db_path)
     with connect(db_path) as connection:
         link_rows = connection.execute(
@@ -490,7 +498,10 @@ def import_mtgjson_prices(
         tuple[Any, str],
     ] = {}
 
-    for index, (uuid, price_formats) in enumerate(data.items(), start=1):
+    for index, (uuid, price_formats) in enumerate(
+        _iter_mtgjson_data_items(json_path, payload_label="prices"),
+        start=1,
+    ):
         if limit is not None and index > limit:
             break
 

--- a/src/mtg_source_stack/importer/mtgjson.py
+++ b/src/mtg_source_stack/importer/mtgjson.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import time
 from typing import Any, Callable
 
 from ..db.connection import connect
@@ -117,9 +118,11 @@ def import_mtgjson_identifiers(
     *,
     before_write: Callable[[], Any] | None = None,
 ) -> ImportStats:
+    total_started = time.perf_counter()
     stats = ImportStats()
     initialize_database(db_path)
     snapshot_taken = False
+    phase_seconds: dict[str, float] = {}
 
     def maybe_before_write() -> None:
         nonlocal snapshot_taken
@@ -127,6 +130,7 @@ def import_mtgjson_identifiers(
             before_write()
             snapshot_taken = True
 
+    preload_started = time.perf_counter()
     with connect(db_path) as connection:
         known_rows = connection.execute(
             """
@@ -151,9 +155,11 @@ def import_mtgjson_identifiers(
         scryfall_id = row["scryfall_id"]
         if mtgjson_uuid is not None and scryfall_id is not None:
             uuid_to_scryfall.setdefault(mtgjson_uuid, scryfall_id)
+    phase_seconds["preload"] = round(time.perf_counter() - preload_started, 6)
 
     grouped_rows: dict[str, list[IdentifierImportRow]] = {}
 
+    scan_started = time.perf_counter()
     for index, (uuid, identifier_record) in enumerate(
         _iter_mtgjson_data_items(json_path, payload_label="identifiers"),
         start=1,
@@ -180,7 +186,9 @@ def import_mtgjson_identifiers(
             continue
 
         grouped_rows.setdefault(target_scryfall_id, []).append(row)
+    phase_seconds["scan"] = round(time.perf_counter() - scan_started, 6)
 
+    merge_started = time.perf_counter()
     merged_rows = {
         scryfall_id: _merge_identifier_import_rows(rows_for_card)
         for scryfall_id, rows_for_card in grouped_rows.items()
@@ -193,14 +201,17 @@ def import_mtgjson_identifiers(
             if row.mtgjson_uuid is not None
         }
     )
+    phase_seconds["merge"] = round(time.perf_counter() - merge_started, 6)
     stats.details = {
         "matched_cards": len(grouped_rows),
         "staged_link_rows": len(link_rows),
+        "phase_seconds": phase_seconds,
     }
     if not merged_rows:
         stats.details["changed_cards"] = 0
         stats.details["no_op_cards"] = 0
         stats.details["link_rows_written"] = 0
+        stats.details["import_total_seconds"] = round(time.perf_counter() - total_started, 6)
         return stats
 
     card_change_predicate = """
@@ -224,6 +235,7 @@ def import_mtgjson_identifiers(
     """
 
     with connect(db_path) as connection:
+        stage_started = time.perf_counter()
         connection.executescript(
             """
             CREATE TEMP TABLE temp_identifier_card_updates (
@@ -284,6 +296,8 @@ def import_mtgjson_identifiers(
                 """,
                 link_rows,
             )
+        phase_seconds["stage"] = round(time.perf_counter() - stage_started, 6)
+        detect_started = time.perf_counter()
         connection.execute(
             f"""
             INSERT INTO temp_identifier_changed_cards (
@@ -335,6 +349,7 @@ def import_mtgjson_identifiers(
         link_rows_written = connection.execute(
             "SELECT COUNT(*) FROM temp_identifier_changed_links"
         ).fetchone()[0]
+        phase_seconds["detect_changes"] = round(time.perf_counter() - detect_started, 6)
         stats.rows_written = len(changed_card_ids)
         stats.details["changed_cards"] = stats.rows_written
         stats.details["no_op_cards"] = max(len(grouped_rows) - stats.rows_written, 0)
@@ -342,6 +357,7 @@ def import_mtgjson_identifiers(
 
         if changed_card_ids or link_rows_written:
             maybe_before_write()
+        write_started = time.perf_counter()
         if changed_card_ids:
             connection.execute(
                 """
@@ -416,7 +432,9 @@ def import_mtgjson_identifiers(
             )
 
         connection.commit()
+        phase_seconds["write"] = round(time.perf_counter() - write_started, 6)
 
+    stats.details["import_total_seconds"] = round(time.perf_counter() - total_started, 6)
     return stats
 
 
@@ -428,7 +446,10 @@ def import_mtgjson_prices(
     *,
     before_write: Callable[[], Any] | None = None,
 ) -> ImportStats:
+    total_started = time.perf_counter()
     initialize_database(db_path)
+    phase_seconds: dict[str, float] = {}
+    preload_started = time.perf_counter()
     with connect(db_path) as connection:
         link_rows = connection.execute(
             """
@@ -459,6 +480,7 @@ def import_mtgjson_prices(
             scryfall_id = row["scryfall_id"]
             if mtgjson_uuid is not None and scryfall_id is not None:
                 uuid_to_scryfall.setdefault(mtgjson_uuid, scryfall_id)
+    phase_seconds["preload"] = round(time.perf_counter() - preload_started, 6)
 
     stats = ImportStats()
     snapshot_taken = False
@@ -497,7 +519,9 @@ def import_mtgjson_prices(
         tuple[str, str, str, str, str, str, str],
         tuple[Any, str],
     ] = {}
+    conflict_rows = 0
 
+    scan_started = time.perf_counter()
     for index, (uuid, price_formats) in enumerate(
         _iter_mtgjson_data_items(json_path, payload_label="prices"),
         start=1,
@@ -578,11 +602,16 @@ def import_mtgjson_prices(
                                 and _price_uuid_preference(mtgjson_uuid, preferred_uuid=preferred_uuid)
                                 < _price_uuid_preference(existing_uuid, preferred_uuid=preferred_uuid)
                             ):
+                                conflict_rows += 1
                                 merged_price_rows[key] = (decimal_price, mtgjson_uuid)
+                            elif decimal_price != existing_price:
+                                conflict_rows += 1
 
         if not wrote_for_card:
             stats.rows_skipped += 1
+    phase_seconds["scan"] = round(time.perf_counter() - scan_started, 6)
 
+    write_started = time.perf_counter()
     with connect(db_path) as connection:
         if merged_price_rows:
             maybe_before_write()
@@ -613,5 +642,12 @@ def import_mtgjson_prices(
             stats.rows_written = len(merged_price_rows)
 
         connection.commit()
+    phase_seconds["write"] = round(time.perf_counter() - write_started, 6)
+    stats.details = {
+        "merged_price_rows": len(merged_price_rows),
+        "conflict_rows": conflict_rows,
+        "phase_seconds": phase_seconds,
+        "import_total_seconds": round(time.perf_counter() - total_started, 6),
+    }
 
     return stats

--- a/src/mtg_source_stack/importer/mtgjson.py
+++ b/src/mtg_source_stack/importer/mtgjson.py
@@ -91,6 +91,10 @@ def _merge_identifier_import_rows(rows: list[IdentifierImportRow]) -> Identifier
     )
 
 
+def _price_uuid_preference(uuid: str, *, preferred_uuid: str | None) -> tuple[int, str]:
+    return (0 if preferred_uuid is not None and uuid == preferred_uuid else 1, uuid)
+
+
 def import_mtgjson_identifiers(
     db_path: str | Path,
     json_path: str | Path,
@@ -227,16 +231,35 @@ def import_mtgjson_prices(
 
     initialize_database(db_path)
     with connect(db_path) as connection:
-        rows = connection.execute(
+        link_rows = connection.execute(
             """
             SELECT mtgjson_uuid, scryfall_id
+            FROM mtgjson_card_links
+            """
+        ).fetchall()
+        card_rows = connection.execute(
+            """
+            SELECT scryfall_id, mtgjson_uuid
             FROM mtg_cards
-            WHERE mtgjson_uuid IS NOT NULL
             """
         ).fetchall()
         # MTGJSON price payloads are keyed by UUID, so build the lookup once
         # instead of querying the catalog row-by-row during import.
-        uuid_to_scryfall = {row["mtgjson_uuid"]: row["scryfall_id"] for row in rows}
+        uuid_to_scryfall = {
+            row["mtgjson_uuid"]: row["scryfall_id"]
+            for row in link_rows
+            if row["mtgjson_uuid"] is not None and row["scryfall_id"] is not None
+        }
+        preferred_uuid_by_scryfall = {
+            row["scryfall_id"]: row["mtgjson_uuid"]
+            for row in card_rows
+            if row["scryfall_id"] is not None and row["mtgjson_uuid"] is not None
+        }
+        for row in card_rows:
+            mtgjson_uuid = row["mtgjson_uuid"]
+            scryfall_id = row["scryfall_id"]
+            if mtgjson_uuid is not None and scryfall_id is not None:
+                uuid_to_scryfall.setdefault(mtgjson_uuid, scryfall_id)
 
     stats = ImportStats()
     snapshot_taken = False
@@ -271,74 +294,121 @@ def import_mtgjson_prices(
         price_value = excluded.price_value
     """
 
-    with connect(db_path) as connection:
-        for index, (uuid, price_formats) in enumerate(data.items(), start=1):
-            if limit is not None and index > limit:
-                break
+    merged_price_rows: dict[
+        tuple[str, str, str, str, str, str, str],
+        tuple[Any, str],
+    ] = {}
 
-            stats.rows_seen += 1
-            if not isinstance(price_formats, dict):
-                stats.rows_skipped += 1
+    for index, (uuid, price_formats) in enumerate(data.items(), start=1):
+        if limit is not None and index > limit:
+            break
+
+        stats.rows_seen += 1
+        if not isinstance(price_formats, dict):
+            stats.rows_skipped += 1
+            continue
+
+        mtgjson_uuid = str(uuid)
+        scryfall_id = uuid_to_scryfall.get(mtgjson_uuid)
+        if scryfall_id is None:
+            stats.rows_skipped += 1
+            continue
+
+        wrote_for_card = False
+        for channel_payload in price_formats.values():
+            if not isinstance(channel_payload, dict):
                 continue
 
-            scryfall_id = uuid_to_scryfall.get(str(uuid))
-            if scryfall_id is None:
-                stats.rows_skipped += 1
-                continue
-
-            wrote_for_card = False
-            for channel_payload in price_formats.values():
-                if not isinstance(channel_payload, dict):
+            for provider, provider_payload in channel_payload.items():
+                if not isinstance(provider_payload, dict):
                     continue
 
-                for provider, provider_payload in channel_payload.items():
-                    if not isinstance(provider_payload, dict):
+                currency = str(first_non_empty(provider_payload.get("currency"), DEFAULT_PRICE_CURRENCY)).upper()
+                # Step 2 intentionally constrains imported market data to a
+                # single currency so downstream pricing reads stay
+                # unambiguous. Non-USD snapshots are ignored for now.
+                if currency != DEFAULT_PRICE_CURRENCY:
+                    continue
+                for price_kind in ("retail", "buylist"):
+                    price_points = provider_payload.get(price_kind)
+                    if not isinstance(price_points, dict):
                         continue
 
-                    currency = str(first_non_empty(provider_payload.get("currency"), DEFAULT_PRICE_CURRENCY)).upper()
-                    # Step 2 intentionally constrains imported market data to a
-                    # single currency so downstream pricing reads stay
-                    # unambiguous. Non-USD snapshots are ignored for now.
-                    if currency != DEFAULT_PRICE_CURRENCY:
-                        continue
-                    for price_kind in ("retail", "buylist"):
-                        price_points = provider_payload.get(price_kind)
-                        if not isinstance(price_points, dict):
+                    for finish, dated_points in price_points.items():
+                        normalized_finish = normalize_price_snapshot_finish(str(finish))
+                        if normalized_finish is None:
                             continue
+                        if isinstance(dated_points, dict):
+                            items = dated_points.items()
+                        else:
+                            items = []
 
-                        for finish, dated_points in price_points.items():
-                            normalized_finish = normalize_price_snapshot_finish(str(finish))
-                            if normalized_finish is None:
+                        for snapshot_date, price_value in items:
+                            decimal_price = coerce_decimal(price_value)
+                            if decimal_price is None:
                                 continue
-                            if isinstance(dated_points, dict):
-                                items = dated_points.items()
-                            else:
-                                items = []
 
-                            for snapshot_date, price_value in items:
-                                decimal_price = coerce_decimal(price_value)
-                                if decimal_price is None:
-                                    continue
+                            wrote_for_card = True
+                            key = (
+                                scryfall_id,
+                                provider,
+                                price_kind,
+                                normalized_finish,
+                                currency,
+                                str(snapshot_date),
+                                source_name,
+                            )
+                            existing_entry = merged_price_rows.get(key)
+                            if existing_entry is None:
+                                merged_price_rows[key] = (decimal_price, mtgjson_uuid)
+                                continue
 
-                                maybe_before_write()
-                                connection.execute(
-                                    sql,
-                                    (
-                                        scryfall_id,
-                                        provider,
-                                        price_kind,
-                                        normalized_finish,
-                                        currency,
-                                        str(snapshot_date),
-                                        decimal_price,
-                                        source_name,
-                                    ),
-                                )
-                                wrote_for_card = True
-                                stats.rows_written += 1
+                            existing_price, existing_uuid = existing_entry
+                            preferred_uuid = preferred_uuid_by_scryfall.get(scryfall_id)
+                            if (
+                                decimal_price == existing_price
+                                and _price_uuid_preference(mtgjson_uuid, preferred_uuid=preferred_uuid)
+                                < _price_uuid_preference(existing_uuid, preferred_uuid=preferred_uuid)
+                            ):
+                                merged_price_rows[key] = (decimal_price, mtgjson_uuid)
+                            elif (
+                                decimal_price != existing_price
+                                and _price_uuid_preference(mtgjson_uuid, preferred_uuid=preferred_uuid)
+                                < _price_uuid_preference(existing_uuid, preferred_uuid=preferred_uuid)
+                            ):
+                                merged_price_rows[key] = (decimal_price, mtgjson_uuid)
 
-            if not wrote_for_card:
-                stats.rows_skipped += 1
+        if not wrote_for_card:
+            stats.rows_skipped += 1
+
+    with connect(db_path) as connection:
+        if merged_price_rows:
+            maybe_before_write()
+            connection.executemany(
+                sql,
+                [
+                    (
+                        scryfall_id,
+                        provider,
+                        price_kind,
+                        finish,
+                        currency,
+                        snapshot_date,
+                        price_value,
+                        row_source_name,
+                    )
+                    for (
+                        scryfall_id,
+                        provider,
+                        price_kind,
+                        finish,
+                        currency,
+                        snapshot_date,
+                        row_source_name,
+                    ), (price_value, _source_uuid) in sorted(merged_price_rows.items())
+                ],
+            )
+            stats.rows_written = len(merged_price_rows)
 
         connection.commit()
 

--- a/src/mtg_source_stack/importer/mtgjson.py
+++ b/src/mtg_source_stack/importer/mtgjson.py
@@ -168,48 +168,239 @@ def import_mtgjson_identifiers(
 
         grouped_rows.setdefault(target_scryfall_id, []).append(row)
 
+    merged_rows = {
+        scryfall_id: _merge_identifier_import_rows(rows_for_card)
+        for scryfall_id, rows_for_card in grouped_rows.items()
+    }
+    link_rows = sorted(
+        {
+            (row.mtgjson_uuid, scryfall_id)
+            for scryfall_id, rows_for_card in grouped_rows.items()
+            for row in rows_for_card
+            if row.mtgjson_uuid is not None
+        }
+    )
+    stats.details = {
+        "matched_cards": len(grouped_rows),
+        "staged_link_rows": len(link_rows),
+    }
+    if not merged_rows:
+        stats.details["changed_cards"] = 0
+        stats.details["no_op_cards"] = 0
+        stats.details["link_rows_written"] = 0
+        return stats
+
+    card_change_predicate = """
+        (updates.mtgjson_uuid IS NOT NULL AND COALESCE(cards.mtgjson_uuid, '') <> updates.mtgjson_uuid)
+        OR (
+            updates.tcgplayer_product_id IS NOT NULL
+            AND COALESCE(cards.tcgplayer_product_id, '') <> updates.tcgplayer_product_id
+        )
+        OR (
+            updates.cardkingdom_id IS NOT NULL
+            AND COALESCE(cards.cardkingdom_id, '') <> updates.cardkingdom_id
+        )
+        OR (
+            updates.cardmarket_id IS NOT NULL
+            AND COALESCE(cards.cardmarket_id, '') <> updates.cardmarket_id
+        )
+        OR (
+            updates.cardsphere_id IS NOT NULL
+            AND COALESCE(cards.cardsphere_id, '') <> updates.cardsphere_id
+        )
+    """
+
     with connect(db_path) as connection:
-        for scryfall_id, rows_for_card in grouped_rows.items():
-            merged_row = _merge_identifier_import_rows(rows_for_card)
-            maybe_before_write()
-            cursor = connection.execute(
-                """
-                UPDATE mtg_cards
-                SET
-                    mtgjson_uuid = COALESCE(?, mtgjson_uuid),
-                    tcgplayer_product_id = COALESCE(?, tcgplayer_product_id),
-                    cardkingdom_id = COALESCE(?, cardkingdom_id),
-                    cardmarket_id = COALESCE(?, cardmarket_id),
-                    cardsphere_id = COALESCE(?, cardsphere_id),
-                    updated_at = CURRENT_TIMESTAMP
-                WHERE scryfall_id = ?
-                """,
+        connection.executescript(
+            """
+            CREATE TEMP TABLE temp_identifier_card_updates (
+                scryfall_id TEXT PRIMARY KEY,
+                mtgjson_uuid TEXT,
+                tcgplayer_product_id TEXT,
+                cardkingdom_id TEXT,
+                cardmarket_id TEXT,
+                cardsphere_id TEXT
+            );
+            CREATE TEMP TABLE temp_identifier_links (
+                mtgjson_uuid TEXT PRIMARY KEY,
+                scryfall_id TEXT NOT NULL
+            );
+            CREATE TEMP TABLE temp_identifier_changed_cards (
+                scryfall_id TEXT PRIMARY KEY,
+                mtgjson_uuid TEXT,
+                tcgplayer_product_id TEXT,
+                cardkingdom_id TEXT,
+                cardmarket_id TEXT,
+                cardsphere_id TEXT
+            );
+            CREATE TEMP TABLE temp_identifier_changed_links (
+                mtgjson_uuid TEXT PRIMARY KEY,
+                scryfall_id TEXT NOT NULL
+            );
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO temp_identifier_card_updates (
+                scryfall_id,
+                mtgjson_uuid,
+                tcgplayer_product_id,
+                cardkingdom_id,
+                cardmarket_id,
+                cardsphere_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            [
                 (
+                    scryfall_id,
                     merged_row.mtgjson_uuid,
                     merged_row.tcgplayer_product_id,
                     merged_row.cardkingdom_id,
                     merged_row.cardmarket_id,
                     merged_row.cardsphere_id,
-                    scryfall_id,
-                ),
+                )
+                for scryfall_id, merged_row in sorted(merged_rows.items())
+            ],
+        )
+        if link_rows:
+            connection.executemany(
+                """
+                INSERT INTO temp_identifier_links (mtgjson_uuid, scryfall_id)
+                VALUES (?, ?)
+                """,
+                link_rows,
             )
-            if not cursor.rowcount:
-                continue
+        connection.execute(
+            f"""
+            INSERT INTO temp_identifier_changed_cards (
+                scryfall_id,
+                mtgjson_uuid,
+                tcgplayer_product_id,
+                cardkingdom_id,
+                cardmarket_id,
+                cardsphere_id
+            )
+            SELECT
+                updates.scryfall_id,
+                updates.mtgjson_uuid,
+                updates.tcgplayer_product_id,
+                updates.cardkingdom_id,
+                updates.cardmarket_id,
+                updates.cardsphere_id
+            FROM temp_identifier_card_updates AS updates
+            JOIN mtg_cards AS cards
+                ON cards.scryfall_id = updates.scryfall_id
+            WHERE {card_change_predicate}
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO temp_identifier_changed_links (mtgjson_uuid, scryfall_id)
+            SELECT
+                links.mtgjson_uuid,
+                links.scryfall_id
+            FROM temp_identifier_links AS links
+            LEFT JOIN mtgjson_card_links AS existing
+                ON existing.mtgjson_uuid = links.mtgjson_uuid
+            WHERE existing.mtgjson_uuid IS NULL OR existing.scryfall_id <> links.scryfall_id
+            """
+        )
 
+        changed_card_ids = {
+            row["scryfall_id"]
+            for row in connection.execute(
+                """
+                SELECT scryfall_id
+                FROM temp_identifier_changed_cards
+                UNION
+                SELECT DISTINCT scryfall_id
+                FROM temp_identifier_changed_links
+                """
+            ).fetchall()
+        }
+        link_rows_written = connection.execute(
+            "SELECT COUNT(*) FROM temp_identifier_changed_links"
+        ).fetchone()[0]
+        stats.rows_written = len(changed_card_ids)
+        stats.details["changed_cards"] = stats.rows_written
+        stats.details["no_op_cards"] = max(len(grouped_rows) - stats.rows_written, 0)
+        stats.details["link_rows_written"] = int(link_rows_written)
+
+        if changed_card_ids or link_rows_written:
+            maybe_before_write()
+        if changed_card_ids:
+            connection.execute(
+                """
+                UPDATE mtg_cards
+                SET
+                    mtgjson_uuid = COALESCE(
+                        (
+                            SELECT updates.mtgjson_uuid
+                            FROM temp_identifier_changed_cards AS updates
+                            WHERE updates.scryfall_id = mtg_cards.scryfall_id
+                        ),
+                        mtgjson_uuid
+                    ),
+                    tcgplayer_product_id = COALESCE(
+                        (
+                            SELECT updates.tcgplayer_product_id
+                            FROM temp_identifier_changed_cards AS updates
+                            WHERE updates.scryfall_id = mtg_cards.scryfall_id
+                        ),
+                        tcgplayer_product_id
+                    ),
+                    cardkingdom_id = COALESCE(
+                        (
+                            SELECT updates.cardkingdom_id
+                            FROM temp_identifier_changed_cards AS updates
+                            WHERE updates.scryfall_id = mtg_cards.scryfall_id
+                        ),
+                        cardkingdom_id
+                    ),
+                    cardmarket_id = COALESCE(
+                        (
+                            SELECT updates.cardmarket_id
+                            FROM temp_identifier_changed_cards AS updates
+                            WHERE updates.scryfall_id = mtg_cards.scryfall_id
+                        ),
+                        cardmarket_id
+                    ),
+                    cardsphere_id = COALESCE(
+                        (
+                            SELECT updates.cardsphere_id
+                            FROM temp_identifier_changed_cards AS updates
+                            WHERE updates.scryfall_id = mtg_cards.scryfall_id
+                        ),
+                        cardsphere_id
+                    ),
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE scryfall_id IN (
+                    SELECT scryfall_id
+                    FROM temp_identifier_changed_cards
+                )
+                """
+            )
+        if link_rows_written:
             connection.executemany(
                 """
                 INSERT INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
                 VALUES (?, ?)
                 ON CONFLICT(mtgjson_uuid) DO UPDATE SET
                     scryfall_id = excluded.scryfall_id
+                WHERE mtgjson_card_links.scryfall_id <> excluded.scryfall_id
                 """,
                 [
-                    (row.mtgjson_uuid, scryfall_id)
-                    for row in rows_for_card
-                    if row.mtgjson_uuid is not None
+                    (row["mtgjson_uuid"], row["scryfall_id"])
+                    for row in connection.execute(
+                        """
+                        SELECT mtgjson_uuid, scryfall_id
+                        FROM temp_identifier_changed_links
+                        ORDER BY mtgjson_uuid
+                        """
+                    ).fetchall()
                 ],
             )
-            stats.rows_written += 1
 
         connection.commit()
 

--- a/src/mtg_source_stack/importer/mtgjson.py
+++ b/src/mtg_source_stack/importer/mtgjson.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -11,6 +12,83 @@ from ..inventory.money import coerce_decimal
 from ..inventory.normalize import normalize_price_snapshot_finish
 from ..pricing import DEFAULT_PRICE_CURRENCY
 from .service import ImportStats, first_non_empty, load_json, text_or_none
+
+
+@dataclass(frozen=True, slots=True)
+class IdentifierImportRow:
+    mtgjson_uuid: str | None
+    scryfall_id: str | None
+    tcgplayer_product_id: str | None
+    cardkingdom_id: str | None
+    cardmarket_id: str | None
+    cardsphere_id: str | None
+    side: str | None
+
+
+def _normalize_identifier_import_row(uuid: Any, identifier_record: Any) -> IdentifierImportRow | None:
+    if not isinstance(identifier_record, dict):
+        return None
+
+    identifiers = identifier_record.get("identifiers")
+    if not isinstance(identifiers, dict):
+        identifiers = identifier_record
+
+    return IdentifierImportRow(
+        mtgjson_uuid=text_or_none(uuid),
+        scryfall_id=text_or_none(identifiers.get("scryfallId")),
+        tcgplayer_product_id=first_non_empty(
+            identifiers.get("tcgplayerProductId"),
+            identifiers.get("tcgplayerEtchedProductId"),
+            identifiers.get("tcgplayerAlternativeFoilProductId"),
+        ),
+        cardkingdom_id=first_non_empty(
+            identifiers.get("cardKingdomId"),
+            identifiers.get("cardKingdomFoilId"),
+            identifiers.get("cardKingdomEtchedId"),
+        ),
+        cardmarket_id=first_non_empty(
+            identifiers.get("mcmId"),
+            identifiers.get("mcmMetaId"),
+        ),
+        cardsphere_id=first_non_empty(
+            identifiers.get("cardsphereId"),
+            identifiers.get("cardsphereFoilId"),
+        ),
+        side=text_or_none(identifier_record.get("side")),
+    )
+
+
+def _identifier_import_row_sort_key(row: IdentifierImportRow) -> tuple[int, int, str]:
+    provider_count = sum(
+        value is not None
+        for value in (
+            row.tcgplayer_product_id,
+            row.cardkingdom_id,
+            row.cardmarket_id,
+            row.cardsphere_id,
+        )
+    )
+    normalized_side = row.side.lower() if row.side is not None else None
+    side_rank = 0 if normalized_side == "a" else 1
+    uuid_text = row.mtgjson_uuid or ""
+    return (-provider_count, side_rank, uuid_text)
+
+
+def _merge_identifier_import_rows(rows: list[IdentifierImportRow]) -> IdentifierImportRow:
+    ordered_rows = sorted(rows, key=_identifier_import_row_sort_key)
+    compatibility_row = next(
+        (row for row in ordered_rows if row.mtgjson_uuid is not None),
+        ordered_rows[0],
+    )
+    return IdentifierImportRow(
+        mtgjson_uuid=compatibility_row.mtgjson_uuid,
+        scryfall_id=compatibility_row.scryfall_id,
+        tcgplayer_product_id=first_non_empty(*(row.tcgplayer_product_id for row in ordered_rows)),
+        cardkingdom_id=first_non_empty(*(row.cardkingdom_id for row in ordered_rows)),
+        cardmarket_id=first_non_empty(*(row.cardmarket_id for row in ordered_rows)),
+        cardsphere_id=first_non_empty(*(row.cardsphere_id for row in ordered_rows)),
+        side=compatibility_row.side,
+    )
 
 
 def import_mtgjson_identifiers(
@@ -42,117 +120,92 @@ def import_mtgjson_identifiers(
             FROM mtg_cards
             """
         ).fetchall()
+        known_link_rows = connection.execute(
+            """
+            SELECT mtgjson_uuid, scryfall_id
+            FROM mtgjson_card_links
+            """
+        ).fetchall()
     known_scryfall_ids = {row["scryfall_id"] for row in known_rows if row["scryfall_id"] is not None}
-    known_mtgjson_uuids = {row["mtgjson_uuid"] for row in known_rows if row["mtgjson_uuid"] is not None}
+    uuid_to_scryfall = {
+        row["mtgjson_uuid"]: row["scryfall_id"]
+        for row in known_link_rows
+        if row["mtgjson_uuid"] is not None and row["scryfall_id"] is not None
+    }
+    for row in known_rows:
+        mtgjson_uuid = row["mtgjson_uuid"]
+        scryfall_id = row["scryfall_id"]
+        if mtgjson_uuid is not None and scryfall_id is not None:
+            uuid_to_scryfall.setdefault(mtgjson_uuid, scryfall_id)
+
+    grouped_rows: dict[str, list[IdentifierImportRow]] = {}
+
+    for index, (uuid, identifier_record) in enumerate(data.items(), start=1):
+        if limit is not None and index > limit:
+            break
+
+        stats.rows_seen += 1
+        row = _normalize_identifier_import_row(uuid, identifier_record)
+        if row is None:
+            stats.rows_skipped += 1
+            continue
+
+        target_scryfall_id: str | None = None
+        if row.scryfall_id is not None and row.scryfall_id in known_scryfall_ids:
+            target_scryfall_id = row.scryfall_id
+            if row.mtgjson_uuid is not None:
+                uuid_to_scryfall[row.mtgjson_uuid] = row.scryfall_id
+        elif row.mtgjson_uuid is not None:
+            target_scryfall_id = uuid_to_scryfall.get(row.mtgjson_uuid)
+
+        if target_scryfall_id is None:
+            stats.rows_skipped += 1
+            continue
+
+        grouped_rows.setdefault(target_scryfall_id, []).append(row)
 
     with connect(db_path) as connection:
-        for index, (uuid, identifier_record) in enumerate(data.items(), start=1):
-            if limit is not None and index > limit:
-                break
-
-            stats.rows_seen += 1
-            if not isinstance(identifier_record, dict):
-                stats.rows_skipped += 1
+        for scryfall_id, rows_for_card in grouped_rows.items():
+            merged_row = _merge_identifier_import_rows(rows_for_card)
+            maybe_before_write()
+            cursor = connection.execute(
+                """
+                UPDATE mtg_cards
+                SET
+                    mtgjson_uuid = COALESCE(?, mtgjson_uuid),
+                    tcgplayer_product_id = COALESCE(?, tcgplayer_product_id),
+                    cardkingdom_id = COALESCE(?, cardkingdom_id),
+                    cardmarket_id = COALESCE(?, cardmarket_id),
+                    cardsphere_id = COALESCE(?, cardsphere_id),
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE scryfall_id = ?
+                """,
+                (
+                    merged_row.mtgjson_uuid,
+                    merged_row.tcgplayer_product_id,
+                    merged_row.cardkingdom_id,
+                    merged_row.cardmarket_id,
+                    merged_row.cardsphere_id,
+                    scryfall_id,
+                ),
+            )
+            if not cursor.rowcount:
                 continue
 
-            identifiers = identifier_record.get("identifiers")
-            if not isinstance(identifiers, dict):
-                identifiers = identifier_record
-
-            scryfall_id = text_or_none(identifiers.get("scryfallId"))
-            mtgjson_uuid = text_or_none(uuid)
-
-            if scryfall_id is not None:
-                # Prefer joining on Scryfall id when possible because it is the
-                # canonical key already stored on catalog rows.
-                if scryfall_id in known_scryfall_ids:
-                    maybe_before_write()
-                cursor = connection.execute(
-                    """
-                    UPDATE mtg_cards
-                    SET
-                        mtgjson_uuid = COALESCE(?, mtgjson_uuid),
-                        tcgplayer_product_id = COALESCE(?, tcgplayer_product_id),
-                        cardkingdom_id = COALESCE(?, cardkingdom_id),
-                        cardmarket_id = COALESCE(?, cardmarket_id),
-                        cardsphere_id = COALESCE(?, cardsphere_id),
-                        updated_at = CURRENT_TIMESTAMP
-                    WHERE scryfall_id = ?
-                    """,
-                    (
-                        mtgjson_uuid,
-                        first_non_empty(
-                            identifiers.get("tcgplayerProductId"),
-                            identifiers.get("tcgplayerEtchedProductId"),
-                            identifiers.get("tcgplayerAlternativeFoilProductId"),
-                        ),
-                        first_non_empty(
-                            identifiers.get("cardKingdomId"),
-                            identifiers.get("cardKingdomFoilId"),
-                            identifiers.get("cardKingdomEtchedId"),
-                        ),
-                        first_non_empty(
-                            identifiers.get("mcmId"),
-                            identifiers.get("mcmMetaId"),
-                        ),
-                        first_non_empty(
-                            identifiers.get("cardsphereId"),
-                            identifiers.get("cardsphereFoilId"),
-                        ),
-                        scryfall_id,
-                    ),
-                )
-                if cursor.rowcount:
-                    stats.rows_written += 1
-                else:
-                    stats.rows_skipped += 1
-                continue
-
-            if mtgjson_uuid is not None:
-                # Some older rows may already have the MTGJSON UUID even when the
-                # identifier payload does not repeat a usable Scryfall id.
-                if mtgjson_uuid in known_mtgjson_uuids:
-                    maybe_before_write()
-                cursor = connection.execute(
-                    """
-                    UPDATE mtg_cards
-                    SET
-                        tcgplayer_product_id = COALESCE(?, tcgplayer_product_id),
-                        cardkingdom_id = COALESCE(?, cardkingdom_id),
-                        cardmarket_id = COALESCE(?, cardmarket_id),
-                        cardsphere_id = COALESCE(?, cardsphere_id),
-                        updated_at = CURRENT_TIMESTAMP
-                    WHERE mtgjson_uuid = ?
-                    """,
-                    (
-                        first_non_empty(
-                            identifiers.get("tcgplayerProductId"),
-                            identifiers.get("tcgplayerEtchedProductId"),
-                            identifiers.get("tcgplayerAlternativeFoilProductId"),
-                        ),
-                        first_non_empty(
-                            identifiers.get("cardKingdomId"),
-                            identifiers.get("cardKingdomFoilId"),
-                            identifiers.get("cardKingdomEtchedId"),
-                        ),
-                        first_non_empty(
-                            identifiers.get("mcmId"),
-                            identifiers.get("mcmMetaId"),
-                        ),
-                        first_non_empty(
-                            identifiers.get("cardsphereId"),
-                            identifiers.get("cardsphereFoilId"),
-                        ),
-                        mtgjson_uuid,
-                    ),
-                )
-                if cursor.rowcount:
-                    stats.rows_written += 1
-                else:
-                    stats.rows_skipped += 1
-                continue
-
-            stats.rows_skipped += 1
+            connection.executemany(
+                """
+                INSERT INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
+                VALUES (?, ?)
+                ON CONFLICT(mtgjson_uuid) DO UPDATE SET
+                    scryfall_id = excluded.scryfall_id
+                """,
+                [
+                    (row.mtgjson_uuid, scryfall_id)
+                    for row in rows_for_card
+                    if row.mtgjson_uuid is not None
+                ],
+            )
+            stats.rows_written += 1
 
         connection.commit()
 

--- a/src/mtg_source_stack/importer/service.py
+++ b/src/mtg_source_stack/importer/service.py
@@ -598,6 +598,7 @@ def sync_scryfall(
     should_skip_step: Callable[[str, DownloadResult], str | None] | None = None,
     metadata_if_none_match: str | None = None,
     metadata_if_modified_since: str | None = None,
+    bulk_hint_url: str | None = None,
     bulk_if_none_match: str | None = None,
     bulk_if_modified_since: str | None = None,
 ) -> dict[str, Any]:
@@ -612,12 +613,16 @@ def sync_scryfall(
         if_none_match=metadata_if_none_match,
         if_modified_since=metadata_if_modified_since,
     )
+    bulk_if_none_match_to_use = bulk_if_none_match if bulk_hint_url == scryfall_download_url else None
+    bulk_if_modified_since_to_use = (
+        bulk_if_modified_since if bulk_hint_url == scryfall_download_url else None
+    )
     download = _download_sync_artifact(
         scryfall_download_url,
         cache_path / SCRYFALL_BULK_CACHE_FILENAME,
         on_download=on_download,
-        if_none_match=bulk_if_none_match,
-        if_modified_since=bulk_if_modified_since,
+        if_none_match=bulk_if_none_match_to_use,
+        if_modified_since=bulk_if_modified_since_to_use,
     )
     scryfall_stats, scryfall_elapsed_seconds = _run_or_skip_sync_step(
         "import_scryfall",
@@ -731,6 +736,7 @@ def sync_bulk(
     on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
     should_skip_step: Callable[[str, DownloadResult], str | None] | None = None,
     download_hints: dict[str, dict[str, str | None]] | None = None,
+    scryfall_bulk_hint_url: str | None = None,
 ) -> dict[str, Any]:
     from .mtgjson import import_mtgjson_identifiers, import_mtgjson_prices
     from .scryfall import import_scryfall_cards
@@ -757,6 +763,8 @@ def sync_bulk(
         (mtgjson_prices_url, cache_path / MTGJSON_PRICES_CACHE_FILENAME),
     ):
         hints = (download_hints or {}).get(destination.name, {})
+        if destination.name == SCRYFALL_BULK_CACHE_FILENAME and scryfall_bulk_hint_url != download_url:
+            hints = {}
         download = _download_sync_artifact(
             download_url,
             destination,

--- a/src/mtg_source_stack/importer/service.py
+++ b/src/mtg_source_stack/importer/service.py
@@ -22,6 +22,7 @@ HTTP_HEADERS = {
     "User-Agent": "mtg-source-stack-sync/0.1 (+local bulk refresh)",
     "Accept": "application/json",
 }
+SCRYFALL_BULK_METADATA_CACHE_FILENAME = "scryfall_bulk_metadata.json"
 SCRYFALL_BULK_CACHE_FILENAME = "scryfall_default_cards.json"
 MTGJSON_IDENTIFIERS_CACHE_FILENAME = "AllIdentifiers.json.gz"
 MTGJSON_PRICES_CACHE_FILENAME = "AllPricesToday.json.gz"
@@ -379,6 +380,14 @@ def find_scryfall_bulk_download_url(
     bulk_type: str,
 ) -> str:
     payload = load_json_url(metadata_url, headers=HTTP_HEADERS, timeout=60)
+    return find_scryfall_bulk_download_url_from_payload(payload, bulk_type=bulk_type)
+
+
+def find_scryfall_bulk_download_url_from_payload(
+    payload: Any,
+    *,
+    bulk_type: str,
+) -> str:
     if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
         raise ValueError("Expected Scryfall bulk metadata to contain a data list.")
 
@@ -392,6 +401,15 @@ def find_scryfall_bulk_download_url(
             return download_url
 
     raise ValueError(f"Could not find Scryfall bulk type '{bulk_type}' in metadata.")
+
+
+def find_scryfall_bulk_download_url_in_file(
+    metadata_path: str | Path,
+    *,
+    bulk_type: str,
+) -> str:
+    payload = load_json(metadata_path)
+    return find_scryfall_bulk_download_url_from_payload(payload, bulk_type=bulk_type)
 
 
 def format_bytes(num_bytes: int) -> str:
@@ -507,6 +525,26 @@ def _download_sync_artifact(
     return download
 
 
+def _download_scryfall_metadata(
+    metadata_url: str,
+    destination: str | Path,
+    *,
+    bulk_type: str,
+    on_download: Callable[[DownloadResult], None] | None = None,
+    if_none_match: str | None = None,
+    if_modified_since: str | None = None,
+) -> tuple[DownloadResult, str]:
+    metadata_download = _download_sync_artifact(
+        metadata_url,
+        destination,
+        on_download=on_download,
+        if_none_match=if_none_match,
+        if_modified_since=if_modified_since,
+    )
+    download_url = find_scryfall_bulk_download_url_in_file(metadata_download.path, bulk_type=bulk_type)
+    return metadata_download, download_url
+
+
 def _run_sync_step(
     step_name: str,
     operation: Callable[[], ImportStats],
@@ -558,22 +596,28 @@ def sync_scryfall(
     on_download: Callable[[DownloadResult], None] | None = None,
     on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
     should_skip_step: Callable[[str, DownloadResult], str | None] | None = None,
-    if_none_match: str | None = None,
-    if_modified_since: str | None = None,
+    metadata_if_none_match: str | None = None,
+    metadata_if_modified_since: str | None = None,
+    bulk_if_none_match: str | None = None,
+    bulk_if_modified_since: str | None = None,
 ) -> dict[str, Any]:
     from .scryfall import import_scryfall_cards
 
     cache_path = _ensure_cache_dir(cache_dir)
-    scryfall_download_url = find_scryfall_bulk_download_url(
+    metadata_download, scryfall_download_url = _download_scryfall_metadata(
         scryfall_metadata_url,
+        cache_path / SCRYFALL_BULK_METADATA_CACHE_FILENAME,
         bulk_type=scryfall_bulk_type,
+        on_download=on_download,
+        if_none_match=metadata_if_none_match,
+        if_modified_since=metadata_if_modified_since,
     )
     download = _download_sync_artifact(
         scryfall_download_url,
         cache_path / SCRYFALL_BULK_CACHE_FILENAME,
         on_download=on_download,
-        if_none_match=if_none_match,
-        if_modified_since=if_modified_since,
+        if_none_match=bulk_if_none_match,
+        if_modified_since=bulk_if_modified_since,
     )
     scryfall_stats, scryfall_elapsed_seconds = _run_or_skip_sync_step(
         "import_scryfall",
@@ -585,7 +629,7 @@ def sync_scryfall(
     return {
         "db_path": str(Path(db_path)),
         "cache_dir": str(cache_path),
-        "downloads": [download],
+        "downloads": [metadata_download, download],
         "scryfall_stats": scryfall_stats,
         "scryfall_elapsed_seconds": scryfall_elapsed_seconds,
         "scryfall_bulk_type": scryfall_bulk_type,
@@ -693,14 +737,20 @@ def sync_bulk(
 
     cache_path = _ensure_cache_dir(cache_dir)
 
-    scryfall_download_url = find_scryfall_bulk_download_url(
-        scryfall_metadata_url,
-        bulk_type=scryfall_bulk_type,
-    )
-
     # Download first and import from the cached artifacts so reruns can inspect
     # the exact files that were used to populate the database.
     downloads: list[DownloadResult] = []
+    metadata_hints = (download_hints or {}).get(SCRYFALL_BULK_METADATA_CACHE_FILENAME, {})
+    metadata_download, scryfall_download_url = _download_scryfall_metadata(
+        scryfall_metadata_url,
+        cache_path / SCRYFALL_BULK_METADATA_CACHE_FILENAME,
+        bulk_type=scryfall_bulk_type,
+        on_download=on_download,
+        if_none_match=metadata_hints.get("etag"),
+        if_modified_since=metadata_hints.get("last_modified"),
+    )
+    downloads.append(metadata_download)
+    bulk_downloads: list[DownloadResult] = []
     for download_url, destination in (
         (scryfall_download_url, cache_path / SCRYFALL_BULK_CACHE_FILENAME),
         (mtgjson_identifiers_url, cache_path / MTGJSON_IDENTIFIERS_CACHE_FILENAME),
@@ -715,27 +765,28 @@ def sync_bulk(
             if_modified_since=hints.get("last_modified"),
         )
         downloads.append(download)
+        bulk_downloads.append(download)
 
     # The imports are ordered to establish catalog rows first, then enrich them
     # with identifier crosswalks, and finally attach price snapshots.
     scryfall_stats, scryfall_elapsed_seconds = _run_or_skip_sync_step(
         "import_scryfall",
-        downloads[0],
-        lambda: import_scryfall_cards(db_path, downloads[0].path, limit, before_write=before_write),
+        bulk_downloads[0],
+        lambda: import_scryfall_cards(db_path, bulk_downloads[0].path, limit, before_write=before_write),
         should_skip_step=should_skip_step,
         on_step=on_step,
     )
     identifier_stats, identifier_elapsed_seconds = _run_or_skip_sync_step(
         "import_identifiers",
-        downloads[1],
-        lambda: import_mtgjson_identifiers(db_path, downloads[1].path, limit, before_write=before_write),
+        bulk_downloads[1],
+        lambda: import_mtgjson_identifiers(db_path, bulk_downloads[1].path, limit, before_write=before_write),
         should_skip_step=should_skip_step,
         on_step=on_step,
     )
     price_stats, price_elapsed_seconds = _run_or_skip_sync_step(
         "import_prices",
-        downloads[2],
-        lambda: import_mtgjson_prices(db_path, downloads[2].path, limit, source_name, before_write=before_write),
+        bulk_downloads[2],
+        lambda: import_mtgjson_prices(db_path, bulk_downloads[2].path, limit, source_name, before_write=before_write),
         should_skip_step=should_skip_step,
         on_step=on_step,
     )

--- a/src/mtg_source_stack/importer/service.py
+++ b/src/mtg_source_stack/importer/service.py
@@ -47,6 +47,19 @@ class DownloadResult:
     downloaded: bool
 
 
+def _merge_import_stats_details(
+    stats: ImportStats,
+    extra_details: dict[str, Any] | None = None,
+) -> ImportStats:
+    merged: dict[str, Any] = {}
+    if isinstance(stats.details, dict):
+        merged.update(stats.details)
+    if extra_details:
+        merged.update(extra_details)
+    stats.details = merged or None
+    return stats
+
+
 def file_digest_info(path: str | Path) -> dict[str, Any]:
     file_path = Path(path)
     digest = hashlib.sha256()
@@ -395,11 +408,39 @@ def format_bytes(num_bytes: int) -> str:
 def print_stats(label: str, stats: ImportStats) -> None:
     summary = f"{label}: seen={stats.rows_seen} written={stats.rows_written} skipped={stats.rows_skipped}"
     skip_reason = None
+    elapsed_seconds = None
+    phase_seconds = None
+    detail_parts: list[str] = []
     if isinstance(stats.details, dict):
         skip_reason = stats.details.get("skip_reason")
+        elapsed_seconds = stats.details.get("elapsed_seconds")
+        phase_seconds = stats.details.get("phase_seconds")
+        for detail_key in (
+            "matched_cards",
+            "changed_cards",
+            "no_op_cards",
+            "staged_link_rows",
+            "link_rows_written",
+            "merged_price_rows",
+            "conflict_rows",
+        ):
+            if detail_key in stats.details:
+                detail_parts.append(f"{detail_key}={stats.details[detail_key]}")
     if skip_reason:
         summary = f"{summary} ({skip_reason})"
     print(summary)
+    if isinstance(elapsed_seconds, (int, float)):
+        print(f"  elapsed: {elapsed_seconds:.3f}s")
+    if isinstance(phase_seconds, dict) and phase_seconds:
+        phase_summary = " ".join(
+            f"{phase_name}={float(seconds):.3f}s"
+            for phase_name, seconds in phase_seconds.items()
+            if isinstance(seconds, (int, float))
+        )
+        if phase_summary:
+            print(f"  phases: {phase_summary}")
+    if detail_parts:
+        print(f"  details: {' '.join(detail_parts)}")
 
 
 def format_snapshot_brief(snapshot: dict[str, Any]) -> str:
@@ -481,6 +522,7 @@ def _run_sync_step(
             on_step(step_name, "failed", None, elapsed_seconds, exc)
         raise
     elapsed_seconds = time.perf_counter() - started
+    _merge_import_stats_details(stats, {"elapsed_seconds": round(elapsed_seconds, 6)})
     if on_step is not None:
         on_step(step_name, "succeeded", stats, elapsed_seconds, None)
     return stats, elapsed_seconds
@@ -498,6 +540,7 @@ def _run_or_skip_sync_step(
     if skip_reason is not None:
         stats = ImportStats(details={"skip_reason": skip_reason})
         elapsed_seconds = 0.0
+        _merge_import_stats_details(stats, {"elapsed_seconds": round(elapsed_seconds, 6)})
         if on_step is not None:
             on_step(step_name, "skipped", stats, elapsed_seconds, None)
         return stats, elapsed_seconds

--- a/src/mtg_source_stack/importer/service.py
+++ b/src/mtg_source_stack/importer/service.py
@@ -8,7 +8,7 @@ import json
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterator, TextIO
 from urllib.error import HTTPError
 from urllib.parse import unquote, urlparse
 from urllib.request import Request, urlopen
@@ -83,6 +83,152 @@ def load_json(path: str | Path) -> Any:
         raise ValueError(
             f"Could not parse JSON file '{path}': {exc.msg} at line {exc.lineno}, column {exc.colno}."
         ) from exc
+
+
+class _JsonValueStream:
+    def __init__(self, handle: TextIO, *, chunk_size: int = 1024 * 1024) -> None:
+        self._handle = handle
+        self._chunk_size = chunk_size
+        self._decoder = json.JSONDecoder()
+        self._buffer = ""
+        self._position = 0
+        self._eof = False
+
+    def _read_more(self) -> bool:
+        if self._eof:
+            return False
+        chunk = self._handle.read(self._chunk_size)
+        if chunk == "":
+            self._eof = True
+            return False
+        self._buffer += chunk
+        return True
+
+    def _compact(self) -> None:
+        if self._position > self._chunk_size:
+            self._buffer = self._buffer[self._position :]
+            self._position = 0
+
+    def _ensure_buffered(self) -> bool:
+        while self._position >= len(self._buffer):
+            if not self._read_more():
+                return False
+        return True
+
+    def skip_whitespace(self) -> None:
+        while True:
+            if not self._ensure_buffered():
+                return
+            start = self._position
+            while self._position < len(self._buffer) and self._buffer[self._position].isspace():
+                self._position += 1
+            if self._position < len(self._buffer) or self._eof:
+                self._compact()
+                return
+            if self._position == start and not self._read_more():
+                return
+
+    def _require_char(self, expected: str) -> None:
+        self.skip_whitespace()
+        if not self._ensure_buffered():
+            raise ValueError("Unexpected end of JSON input.")
+        actual = self._buffer[self._position]
+        if actual != expected:
+            raise ValueError(f"Expected '{expected}' in JSON input, found '{actual}'.")
+        self._position += 1
+        self._compact()
+
+    def _consume_char(self, expected: str) -> bool:
+        self.skip_whitespace()
+        if not self._ensure_buffered():
+            return False
+        if self._buffer[self._position] != expected:
+            return False
+        self._position += 1
+        self._compact()
+        return True
+
+    def peek_char(self) -> str:
+        self.skip_whitespace()
+        if not self._ensure_buffered():
+            raise ValueError("Unexpected end of JSON input.")
+        return self._buffer[self._position]
+
+    def decode_value(self) -> Any:
+        self.skip_whitespace()
+        while True:
+            if not self._ensure_buffered():
+                raise ValueError("Unexpected end of JSON input.")
+            try:
+                value, end = self._decoder.raw_decode(self._buffer, self._position)
+            except json.JSONDecodeError as exc:
+                if not self._read_more():
+                    raise ValueError(f"Could not parse JSON input: {exc.msg}.") from exc
+                continue
+            self._position = end
+            self._compact()
+            return value
+
+    def ensure_root_object(self) -> None:
+        self._require_char("{")
+
+    def ensure_input_consumed(self) -> None:
+        self.skip_whitespace()
+        if self._ensure_buffered():
+            raise ValueError("Expected end of JSON input after top-level object.")
+
+    def iter_object_items(self) -> Iterator[tuple[str, Any]]:
+        self._require_char("{")
+        if self._consume_char("}"):
+            return
+        while True:
+            key = self.decode_value()
+            if not isinstance(key, str):
+                raise ValueError("Expected object keys in JSON input to be strings.")
+            self._require_char(":")
+            value = self.decode_value()
+            yield key, value
+            if self._consume_char(","):
+                continue
+            self._require_char("}")
+            return
+
+
+def iter_json_object_items(
+    path: str | Path,
+    *,
+    top_level_key: str,
+) -> Iterator[tuple[str, Any]]:
+    try:
+        with open_text(path) as handle:
+            stream = _JsonValueStream(handle)
+            stream.ensure_root_object()
+            found_key = False
+            if stream._consume_char("}"):
+                raise ValueError(f"Expected JSON object to contain an object at payload['{top_level_key}'].")
+            while True:
+                key = stream.decode_value()
+                if not isinstance(key, str):
+                    raise ValueError("Expected object keys in JSON input to be strings.")
+                stream._require_char(":")
+                if key == top_level_key:
+                    if stream.peek_char() != "{":
+                        raise ValueError(
+                            f"Expected JSON object to contain an object at payload['{top_level_key}']."
+                        )
+                    found_key = True
+                    yield from stream.iter_object_items()
+                else:
+                    stream.decode_value()
+                if stream._consume_char(","):
+                    continue
+                stream._require_char("}")
+                break
+            if not found_key:
+                raise ValueError(f"Expected JSON object to contain an object at payload['{top_level_key}'].")
+            stream.ensure_input_consumed()
+    except OSError as exc:
+        raise ValueError(f"Could not read JSON file '{path}'.") from exc
 
 
 def open_url(url: str, headers: dict[str, str] | None = None, timeout: int = 120):

--- a/src/mtg_source_stack/importer/service.py
+++ b/src/mtg_source_stack/importer/service.py
@@ -9,6 +9,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
+from urllib.error import HTTPError
+from urllib.parse import unquote, urlparse
 from urllib.request import Request, urlopen
 
 DEFAULT_BULK_CACHE_DIR = Path("var") / "bulk_cache" / "latest"
@@ -42,6 +44,24 @@ class DownloadResult:
     sha256: str
     etag: str | None
     last_modified: str | None
+    downloaded: bool
+
+
+def file_digest_info(path: str | Path) -> dict[str, Any]:
+    file_path = Path(path)
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return {
+        "path": file_path,
+        "bytes_written": file_path.stat().st_size,
+        "sha256": digest.hexdigest(),
+        "last_modified": str(int(file_path.stat().st_mtime)),
+    }
 
 
 def open_text(path: str | Path):
@@ -88,11 +108,70 @@ def download_to_path(
     *,
     headers: dict[str, str] | None = None,
     timeout: int = 120,
+    if_none_match: str | None = None,
+    if_modified_since: str | None = None,
 ) -> DownloadResult:
     path = Path(destination)
     path.parent.mkdir(parents=True, exist_ok=True)
+    parsed_url = urlparse(url)
+    if parsed_url.scheme == "file":
+        source_path = Path(unquote(parsed_url.path))
+        source_info = file_digest_info(source_path)
+        if path.exists():
+            destination_info = file_digest_info(path)
+            if destination_info["sha256"] == source_info["sha256"]:
+                return DownloadResult(
+                    label=path.name,
+                    url=url,
+                    path=path,
+                    bytes_written=destination_info["bytes_written"],
+                    sha256=destination_info["sha256"],
+                    etag=None,
+                    last_modified=source_info["last_modified"],
+                    downloaded=False,
+                )
+        with source_path.open("rb") as source_handle, path.open("wb") as destination_handle:
+            while True:
+                chunk = source_handle.read(1024 * 1024)
+                if not chunk:
+                    break
+                destination_handle.write(chunk)
+        destination_info = file_digest_info(path)
+        return DownloadResult(
+            label=path.name,
+            url=url,
+            path=path,
+            bytes_written=destination_info["bytes_written"],
+            sha256=destination_info["sha256"],
+            etag=None,
+            last_modified=source_info["last_modified"],
+            downloaded=True,
+        )
+
     digest = hashlib.sha256()
-    with open_url(url, headers=headers, timeout=timeout) as response, path.open("wb") as handle:
+    request_headers = dict(headers or {})
+    if path.exists():
+        if if_none_match is not None:
+            request_headers["If-None-Match"] = if_none_match
+        if if_modified_since is not None:
+            request_headers["If-Modified-Since"] = if_modified_since
+    try:
+        response_context = open_url(url, headers=request_headers, timeout=timeout)
+    except HTTPError as exc:
+        if exc.code == 304 and path.exists():
+            destination_info = file_digest_info(path)
+            return DownloadResult(
+                label=path.name,
+                url=url,
+                path=path,
+                bytes_written=destination_info["bytes_written"],
+                sha256=destination_info["sha256"],
+                etag=exc.headers.get("ETag") or if_none_match,
+                last_modified=exc.headers.get("Last-Modified") or if_modified_since,
+                downloaded=False,
+            )
+        raise
+    with response_context as response, path.open("wb") as handle:
         total = 0
         response_headers = response.headers
         while True:
@@ -110,6 +189,7 @@ def download_to_path(
         sha256=digest.hexdigest(),
         etag=response_headers.get("ETag"),
         last_modified=response_headers.get("Last-Modified"),
+        downloaded=True,
     )
 
 
@@ -167,7 +247,13 @@ def format_bytes(num_bytes: int) -> str:
 
 
 def print_stats(label: str, stats: ImportStats) -> None:
-    print(f"{label}: seen={stats.rows_seen} written={stats.rows_written} skipped={stats.rows_skipped}")
+    summary = f"{label}: seen={stats.rows_seen} written={stats.rows_written} skipped={stats.rows_skipped}"
+    skip_reason = None
+    if isinstance(stats.details, dict):
+        skip_reason = stats.details.get("skip_reason")
+    if skip_reason:
+        summary = f"{summary} ({skip_reason})"
+    print(summary)
 
 
 def format_snapshot_brief(snapshot: dict[str, Any]) -> str:
@@ -218,12 +304,16 @@ def _download_sync_artifact(
     destination: str | Path,
     *,
     on_download: Callable[[DownloadResult], None] | None = None,
+    if_none_match: str | None = None,
+    if_modified_since: str | None = None,
 ) -> DownloadResult:
     download = download_to_path(
         url,
         destination,
         headers=HTTP_HEADERS,
         timeout=300,
+        if_none_match=if_none_match,
+        if_modified_since=if_modified_since,
     )
     if on_download is not None:
         on_download(download)
@@ -250,6 +340,24 @@ def _run_sync_step(
     return stats, elapsed_seconds
 
 
+def _run_or_skip_sync_step(
+    step_name: str,
+    download: DownloadResult,
+    operation: Callable[[], ImportStats],
+    *,
+    should_skip_step: Callable[[str, DownloadResult], str | None] | None = None,
+    on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+) -> tuple[ImportStats, float]:
+    skip_reason = should_skip_step(step_name, download) if should_skip_step is not None else None
+    if skip_reason is not None:
+        stats = ImportStats(details={"skip_reason": skip_reason})
+        elapsed_seconds = 0.0
+        if on_step is not None:
+            on_step(step_name, "skipped", stats, elapsed_seconds, None)
+        return stats, elapsed_seconds
+    return _run_sync_step(step_name, operation, on_step=on_step)
+
+
 def sync_scryfall(
     db_path: str | Path,
     *,
@@ -260,6 +368,9 @@ def sync_scryfall(
     before_write: Callable[[], Any] | None = None,
     on_download: Callable[[DownloadResult], None] | None = None,
     on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+    should_skip_step: Callable[[str, DownloadResult], str | None] | None = None,
+    if_none_match: str | None = None,
+    if_modified_since: str | None = None,
 ) -> dict[str, Any]:
     from .scryfall import import_scryfall_cards
 
@@ -272,10 +383,14 @@ def sync_scryfall(
         scryfall_download_url,
         cache_path / SCRYFALL_BULK_CACHE_FILENAME,
         on_download=on_download,
+        if_none_match=if_none_match,
+        if_modified_since=if_modified_since,
     )
-    scryfall_stats, scryfall_elapsed_seconds = _run_sync_step(
+    scryfall_stats, scryfall_elapsed_seconds = _run_or_skip_sync_step(
         "import_scryfall",
+        download,
         lambda: import_scryfall_cards(db_path, download.path, limit, before_write=before_write),
+        should_skip_step=should_skip_step,
         on_step=on_step,
     )
     return {
@@ -297,6 +412,9 @@ def sync_identifiers(
     before_write: Callable[[], Any] | None = None,
     on_download: Callable[[DownloadResult], None] | None = None,
     on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+    should_skip_step: Callable[[str, DownloadResult], str | None] | None = None,
+    if_none_match: str | None = None,
+    if_modified_since: str | None = None,
 ) -> dict[str, Any]:
     from .mtgjson import import_mtgjson_identifiers
 
@@ -305,10 +423,14 @@ def sync_identifiers(
         mtgjson_identifiers_url,
         cache_path / MTGJSON_IDENTIFIERS_CACHE_FILENAME,
         on_download=on_download,
+        if_none_match=if_none_match,
+        if_modified_since=if_modified_since,
     )
-    identifier_stats, identifier_elapsed_seconds = _run_sync_step(
+    identifier_stats, identifier_elapsed_seconds = _run_or_skip_sync_step(
         "import_identifiers",
+        download,
         lambda: import_mtgjson_identifiers(db_path, download.path, limit, before_write=before_write),
+        should_skip_step=should_skip_step,
         on_step=on_step,
     )
     return {
@@ -330,6 +452,9 @@ def sync_prices(
     before_write: Callable[[], Any] | None = None,
     on_download: Callable[[DownloadResult], None] | None = None,
     on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+    should_skip_step: Callable[[str, DownloadResult], str | None] | None = None,
+    if_none_match: str | None = None,
+    if_modified_since: str | None = None,
 ) -> dict[str, Any]:
     from .mtgjson import import_mtgjson_prices
 
@@ -338,10 +463,14 @@ def sync_prices(
         mtgjson_prices_url,
         cache_path / MTGJSON_PRICES_CACHE_FILENAME,
         on_download=on_download,
+        if_none_match=if_none_match,
+        if_modified_since=if_modified_since,
     )
-    price_stats, price_elapsed_seconds = _run_sync_step(
+    price_stats, price_elapsed_seconds = _run_or_skip_sync_step(
         "import_prices",
+        download,
         lambda: import_mtgjson_prices(db_path, download.path, limit, source_name, before_write=before_write),
+        should_skip_step=should_skip_step,
         on_step=on_step,
     )
     return {
@@ -367,6 +496,8 @@ def sync_bulk(
     before_write: Callable[[], Any] | None = None,
     on_download: Callable[[DownloadResult], None] | None = None,
     on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+    should_skip_step: Callable[[str, DownloadResult], str | None] | None = None,
+    download_hints: dict[str, dict[str, str | None]] | None = None,
 ) -> dict[str, Any]:
     from .mtgjson import import_mtgjson_identifiers, import_mtgjson_prices
     from .scryfall import import_scryfall_cards
@@ -382,32 +513,41 @@ def sync_bulk(
     # the exact files that were used to populate the database.
     downloads: list[DownloadResult] = []
     for download_url, destination in (
-        (scryfall_download_url, cache_path / "scryfall_default_cards.json"),
-        (mtgjson_identifiers_url, cache_path / "AllIdentifiers.json.gz"),
-        (mtgjson_prices_url, cache_path / "AllPricesToday.json.gz"),
+        (scryfall_download_url, cache_path / SCRYFALL_BULK_CACHE_FILENAME),
+        (mtgjson_identifiers_url, cache_path / MTGJSON_IDENTIFIERS_CACHE_FILENAME),
+        (mtgjson_prices_url, cache_path / MTGJSON_PRICES_CACHE_FILENAME),
     ):
+        hints = (download_hints or {}).get(destination.name, {})
         download = _download_sync_artifact(
             download_url,
             destination,
             on_download=on_download,
+            if_none_match=hints.get("etag"),
+            if_modified_since=hints.get("last_modified"),
         )
         downloads.append(download)
 
     # The imports are ordered to establish catalog rows first, then enrich them
     # with identifier crosswalks, and finally attach price snapshots.
-    scryfall_stats, scryfall_elapsed_seconds = _run_sync_step(
+    scryfall_stats, scryfall_elapsed_seconds = _run_or_skip_sync_step(
         "import_scryfall",
+        downloads[0],
         lambda: import_scryfall_cards(db_path, downloads[0].path, limit, before_write=before_write),
+        should_skip_step=should_skip_step,
         on_step=on_step,
     )
-    identifier_stats, identifier_elapsed_seconds = _run_sync_step(
+    identifier_stats, identifier_elapsed_seconds = _run_or_skip_sync_step(
         "import_identifiers",
+        downloads[1],
         lambda: import_mtgjson_identifiers(db_path, downloads[1].path, limit, before_write=before_write),
+        should_skip_step=should_skip_step,
         on_step=on_step,
     )
-    price_stats, price_elapsed_seconds = _run_sync_step(
+    price_stats, price_elapsed_seconds = _run_or_skip_sync_step(
         "import_prices",
+        downloads[2],
         lambda: import_mtgjson_prices(db_path, downloads[2].path, limit, source_name, before_write=before_write),
+        should_skip_step=should_skip_step,
         on_step=on_step,
     )
 

--- a/src/mtg_source_stack/importer/service.py
+++ b/src/mtg_source_stack/importer/service.py
@@ -27,6 +27,7 @@ class ImportStats:
     rows_seen: int = 0
     rows_written: int = 0
     rows_skipped: int = 0
+    details: dict[str, Any] | None = None
 
 
 @dataclass(slots=True)
@@ -214,6 +215,8 @@ def sync_bulk(
     limit: int | None = None,
     source_name: str = "mtgjson_all_prices_today",
     before_write: Callable[[], Any] | None = None,
+    on_download: Callable[[DownloadResult], None] | None = None,
+    on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
 ) -> dict[str, Any]:
     from .mtgjson import import_mtgjson_identifiers, import_mtgjson_prices
     from .scryfall import import_scryfall_cards
@@ -228,40 +231,50 @@ def sync_bulk(
 
     # Download first and import from the cached artifacts so reruns can inspect
     # the exact files that were used to populate the database.
-    downloads = [
-        download_to_path(
-            scryfall_download_url,
-            cache_path / "scryfall_default_cards.json",
+    downloads: list[DownloadResult] = []
+    for download_url, destination in (
+        (scryfall_download_url, cache_path / "scryfall_default_cards.json"),
+        (mtgjson_identifiers_url, cache_path / "AllIdentifiers.json.gz"),
+        (mtgjson_prices_url, cache_path / "AllPricesToday.json.gz"),
+    ):
+        download = download_to_path(
+            download_url,
+            destination,
             headers=HTTP_HEADERS,
             timeout=300,
-        ),
-        download_to_path(
-            mtgjson_identifiers_url,
-            cache_path / "AllIdentifiers.json.gz",
-            headers=HTTP_HEADERS,
-            timeout=300,
-        ),
-        download_to_path(
-            mtgjson_prices_url,
-            cache_path / "AllPricesToday.json.gz",
-            headers=HTTP_HEADERS,
-            timeout=300,
-        ),
-    ]
+        )
+        downloads.append(download)
+        if on_download is not None:
+            on_download(download)
 
     # The imports are ordered to establish catalog rows first, then enrich them
     # with identifier crosswalks, and finally attach price snapshots.
-    scryfall_started = time.perf_counter()
-    scryfall_stats = import_scryfall_cards(db_path, downloads[0].path, limit, before_write=before_write)
-    scryfall_elapsed_seconds = time.perf_counter() - scryfall_started
+    def run_step(step_name: str, operation: Callable[[], ImportStats]) -> tuple[ImportStats, float]:
+        started = time.perf_counter()
+        try:
+            stats = operation()
+        except Exception as exc:
+            elapsed_seconds = time.perf_counter() - started
+            if on_step is not None:
+                on_step(step_name, "failed", None, elapsed_seconds, exc)
+            raise
+        elapsed_seconds = time.perf_counter() - started
+        if on_step is not None:
+            on_step(step_name, "succeeded", stats, elapsed_seconds, None)
+        return stats, elapsed_seconds
 
-    identifier_started = time.perf_counter()
-    identifier_stats = import_mtgjson_identifiers(db_path, downloads[1].path, limit, before_write=before_write)
-    identifier_elapsed_seconds = time.perf_counter() - identifier_started
-
-    price_started = time.perf_counter()
-    price_stats = import_mtgjson_prices(db_path, downloads[2].path, limit, source_name, before_write=before_write)
-    price_elapsed_seconds = time.perf_counter() - price_started
+    scryfall_stats, scryfall_elapsed_seconds = run_step(
+        "import_scryfall",
+        lambda: import_scryfall_cards(db_path, downloads[0].path, limit, before_write=before_write),
+    )
+    identifier_stats, identifier_elapsed_seconds = run_step(
+        "import_identifiers",
+        lambda: import_mtgjson_identifiers(db_path, downloads[1].path, limit, before_write=before_write),
+    )
+    price_stats, price_elapsed_seconds = run_step(
+        "import_prices",
+        lambda: import_mtgjson_prices(db_path, downloads[2].path, limit, source_name, before_write=before_write),
+    )
 
     return {
         "db_path": str(Path(db_path)),

--- a/src/mtg_source_stack/importer/service.py
+++ b/src/mtg_source_stack/importer/service.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import gzip
+import hashlib
 import json
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
@@ -33,6 +35,9 @@ class DownloadResult:
     url: str
     path: Path
     bytes_written: int
+    sha256: str
+    etag: str | None
+    last_modified: str | None
 
 
 def open_text(path: str | Path):
@@ -82,19 +87,25 @@ def download_to_path(
 ) -> DownloadResult:
     path = Path(destination)
     path.parent.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha256()
     with open_url(url, headers=headers, timeout=timeout) as response, path.open("wb") as handle:
         total = 0
+        response_headers = response.headers
         while True:
             chunk = response.read(1024 * 1024)
             if not chunk:
                 break
             handle.write(chunk)
+            digest.update(chunk)
             total += len(chunk)
     return DownloadResult(
         label=path.name,
         url=url,
         path=path,
         bytes_written=total,
+        sha256=digest.hexdigest(),
+        etag=response_headers.get("ETag"),
+        last_modified=response_headers.get("Last-Modified"),
     )
 
 
@@ -240,17 +251,28 @@ def sync_bulk(
 
     # The imports are ordered to establish catalog rows first, then enrich them
     # with identifier crosswalks, and finally attach price snapshots.
+    scryfall_started = time.perf_counter()
     scryfall_stats = import_scryfall_cards(db_path, downloads[0].path, limit, before_write=before_write)
+    scryfall_elapsed_seconds = time.perf_counter() - scryfall_started
+
+    identifier_started = time.perf_counter()
     identifier_stats = import_mtgjson_identifiers(db_path, downloads[1].path, limit, before_write=before_write)
+    identifier_elapsed_seconds = time.perf_counter() - identifier_started
+
+    price_started = time.perf_counter()
     price_stats = import_mtgjson_prices(db_path, downloads[2].path, limit, source_name, before_write=before_write)
+    price_elapsed_seconds = time.perf_counter() - price_started
 
     return {
         "db_path": str(Path(db_path)),
         "cache_dir": str(cache_path),
         "downloads": downloads,
         "scryfall_stats": scryfall_stats,
+        "scryfall_elapsed_seconds": scryfall_elapsed_seconds,
         "identifier_stats": identifier_stats,
+        "identifier_elapsed_seconds": identifier_elapsed_seconds,
         "price_stats": price_stats,
+        "price_elapsed_seconds": price_elapsed_seconds,
         "source_name": source_name,
         "scryfall_bulk_type": scryfall_bulk_type,
     }

--- a/src/mtg_source_stack/importer/service.py
+++ b/src/mtg_source_stack/importer/service.py
@@ -20,6 +20,9 @@ HTTP_HEADERS = {
     "User-Agent": "mtg-source-stack-sync/0.1 (+local bulk refresh)",
     "Accept": "application/json",
 }
+SCRYFALL_BULK_CACHE_FILENAME = "scryfall_default_cards.json"
+MTGJSON_IDENTIFIERS_CACHE_FILENAME = "AllIdentifiers.json.gz"
+MTGJSON_PRICES_CACHE_FILENAME = "AllPricesToday.json.gz"
 
 
 @dataclass(slots=True)
@@ -204,6 +207,153 @@ def print_restore_snapshot_result(result: dict[str, Any]) -> None:
         print(f"pre_restore_snapshot: {pre_restore_snapshot['snapshot_path']}")
 
 
+def _ensure_cache_dir(cache_dir: str | Path) -> Path:
+    cache_path = Path(cache_dir)
+    cache_path.mkdir(parents=True, exist_ok=True)
+    return cache_path
+
+
+def _download_sync_artifact(
+    url: str,
+    destination: str | Path,
+    *,
+    on_download: Callable[[DownloadResult], None] | None = None,
+) -> DownloadResult:
+    download = download_to_path(
+        url,
+        destination,
+        headers=HTTP_HEADERS,
+        timeout=300,
+    )
+    if on_download is not None:
+        on_download(download)
+    return download
+
+
+def _run_sync_step(
+    step_name: str,
+    operation: Callable[[], ImportStats],
+    *,
+    on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+) -> tuple[ImportStats, float]:
+    started = time.perf_counter()
+    try:
+        stats = operation()
+    except Exception as exc:
+        elapsed_seconds = time.perf_counter() - started
+        if on_step is not None:
+            on_step(step_name, "failed", None, elapsed_seconds, exc)
+        raise
+    elapsed_seconds = time.perf_counter() - started
+    if on_step is not None:
+        on_step(step_name, "succeeded", stats, elapsed_seconds, None)
+    return stats, elapsed_seconds
+
+
+def sync_scryfall(
+    db_path: str | Path,
+    *,
+    cache_dir: str | Path,
+    scryfall_metadata_url: str = SCRYFALL_BULK_METADATA_URL,
+    scryfall_bulk_type: str = DEFAULT_SCRYFALL_BULK_TYPE,
+    limit: int | None = None,
+    before_write: Callable[[], Any] | None = None,
+    on_download: Callable[[DownloadResult], None] | None = None,
+    on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+) -> dict[str, Any]:
+    from .scryfall import import_scryfall_cards
+
+    cache_path = _ensure_cache_dir(cache_dir)
+    scryfall_download_url = find_scryfall_bulk_download_url(
+        scryfall_metadata_url,
+        bulk_type=scryfall_bulk_type,
+    )
+    download = _download_sync_artifact(
+        scryfall_download_url,
+        cache_path / SCRYFALL_BULK_CACHE_FILENAME,
+        on_download=on_download,
+    )
+    scryfall_stats, scryfall_elapsed_seconds = _run_sync_step(
+        "import_scryfall",
+        lambda: import_scryfall_cards(db_path, download.path, limit, before_write=before_write),
+        on_step=on_step,
+    )
+    return {
+        "db_path": str(Path(db_path)),
+        "cache_dir": str(cache_path),
+        "downloads": [download],
+        "scryfall_stats": scryfall_stats,
+        "scryfall_elapsed_seconds": scryfall_elapsed_seconds,
+        "scryfall_bulk_type": scryfall_bulk_type,
+    }
+
+
+def sync_identifiers(
+    db_path: str | Path,
+    *,
+    cache_dir: str | Path,
+    mtgjson_identifiers_url: str = MTGJSON_IDENTIFIERS_URL,
+    limit: int | None = None,
+    before_write: Callable[[], Any] | None = None,
+    on_download: Callable[[DownloadResult], None] | None = None,
+    on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+) -> dict[str, Any]:
+    from .mtgjson import import_mtgjson_identifiers
+
+    cache_path = _ensure_cache_dir(cache_dir)
+    download = _download_sync_artifact(
+        mtgjson_identifiers_url,
+        cache_path / MTGJSON_IDENTIFIERS_CACHE_FILENAME,
+        on_download=on_download,
+    )
+    identifier_stats, identifier_elapsed_seconds = _run_sync_step(
+        "import_identifiers",
+        lambda: import_mtgjson_identifiers(db_path, download.path, limit, before_write=before_write),
+        on_step=on_step,
+    )
+    return {
+        "db_path": str(Path(db_path)),
+        "cache_dir": str(cache_path),
+        "downloads": [download],
+        "identifier_stats": identifier_stats,
+        "identifier_elapsed_seconds": identifier_elapsed_seconds,
+    }
+
+
+def sync_prices(
+    db_path: str | Path,
+    *,
+    cache_dir: str | Path,
+    mtgjson_prices_url: str = MTGJSON_PRICES_URL,
+    limit: int | None = None,
+    source_name: str = "mtgjson_all_prices_today",
+    before_write: Callable[[], Any] | None = None,
+    on_download: Callable[[DownloadResult], None] | None = None,
+    on_step: Callable[[str, str, ImportStats | None, float, Exception | None], None] | None = None,
+) -> dict[str, Any]:
+    from .mtgjson import import_mtgjson_prices
+
+    cache_path = _ensure_cache_dir(cache_dir)
+    download = _download_sync_artifact(
+        mtgjson_prices_url,
+        cache_path / MTGJSON_PRICES_CACHE_FILENAME,
+        on_download=on_download,
+    )
+    price_stats, price_elapsed_seconds = _run_sync_step(
+        "import_prices",
+        lambda: import_mtgjson_prices(db_path, download.path, limit, source_name, before_write=before_write),
+        on_step=on_step,
+    )
+    return {
+        "db_path": str(Path(db_path)),
+        "cache_dir": str(cache_path),
+        "downloads": [download],
+        "price_stats": price_stats,
+        "price_elapsed_seconds": price_elapsed_seconds,
+        "source_name": source_name,
+    }
+
+
 def sync_bulk(
     db_path: str | Path,
     *,
@@ -221,8 +371,7 @@ def sync_bulk(
     from .mtgjson import import_mtgjson_identifiers, import_mtgjson_prices
     from .scryfall import import_scryfall_cards
 
-    cache_path = Path(cache_dir)
-    cache_path.mkdir(parents=True, exist_ok=True)
+    cache_path = _ensure_cache_dir(cache_dir)
 
     scryfall_download_url = find_scryfall_bulk_download_url(
         scryfall_metadata_url,
@@ -237,43 +386,29 @@ def sync_bulk(
         (mtgjson_identifiers_url, cache_path / "AllIdentifiers.json.gz"),
         (mtgjson_prices_url, cache_path / "AllPricesToday.json.gz"),
     ):
-        download = download_to_path(
+        download = _download_sync_artifact(
             download_url,
             destination,
-            headers=HTTP_HEADERS,
-            timeout=300,
+            on_download=on_download,
         )
         downloads.append(download)
-        if on_download is not None:
-            on_download(download)
 
     # The imports are ordered to establish catalog rows first, then enrich them
     # with identifier crosswalks, and finally attach price snapshots.
-    def run_step(step_name: str, operation: Callable[[], ImportStats]) -> tuple[ImportStats, float]:
-        started = time.perf_counter()
-        try:
-            stats = operation()
-        except Exception as exc:
-            elapsed_seconds = time.perf_counter() - started
-            if on_step is not None:
-                on_step(step_name, "failed", None, elapsed_seconds, exc)
-            raise
-        elapsed_seconds = time.perf_counter() - started
-        if on_step is not None:
-            on_step(step_name, "succeeded", stats, elapsed_seconds, None)
-        return stats, elapsed_seconds
-
-    scryfall_stats, scryfall_elapsed_seconds = run_step(
+    scryfall_stats, scryfall_elapsed_seconds = _run_sync_step(
         "import_scryfall",
         lambda: import_scryfall_cards(db_path, downloads[0].path, limit, before_write=before_write),
+        on_step=on_step,
     )
-    identifier_stats, identifier_elapsed_seconds = run_step(
+    identifier_stats, identifier_elapsed_seconds = _run_sync_step(
         "import_identifiers",
         lambda: import_mtgjson_identifiers(db_path, downloads[1].path, limit, before_write=before_write),
+        on_step=on_step,
     )
-    price_stats, price_elapsed_seconds = run_step(
+    price_stats, price_elapsed_seconds = _run_sync_step(
         "import_prices",
         lambda: import_mtgjson_prices(db_path, downloads[2].path, limit, source_name, before_write=before_write),
+        on_step=on_step,
     )
 
     return {
@@ -291,8 +426,13 @@ def sync_bulk(
     }
 
 
-def print_sync_bulk_result(result: dict[str, Any]) -> None:
-    print("sync-bulk completed")
+def print_sync_result(
+    command_name: str,
+    result: dict[str, Any],
+    *,
+    stat_labels: list[tuple[str, str]],
+) -> None:
+    print(f"{command_name} completed")
     print(f"database: {result['db_path']}")
     if result.get("snapshot") is not None:
         print(f"snapshot: {result['snapshot']['snapshot_path']}")
@@ -300,6 +440,18 @@ def print_sync_bulk_result(result: dict[str, Any]) -> None:
     print("downloads:")
     for download in result["downloads"]:
         print(f"  {download.label}: {download.path} ({format_bytes(download.bytes_written)})")
-    print_stats("import-scryfall", result["scryfall_stats"])
-    print_stats("import-identifiers", result["identifier_stats"])
-    print_stats("import-prices", result["price_stats"])
+    for label, key in stat_labels:
+        if key in result:
+            print_stats(label, result[key])
+
+
+def print_sync_bulk_result(result: dict[str, Any]) -> None:
+    print_sync_result(
+        "sync-bulk",
+        result,
+        stat_labels=[
+            ("import-scryfall", "scryfall_stats"),
+            ("import-identifiers", "identifier_stats"),
+            ("import-prices", "price_stats"),
+        ],
+    )

--- a/src/mtg_source_stack/importer/sync_tracking.py
+++ b/src/mtg_source_stack/importer/sync_tracking.py
@@ -217,3 +217,95 @@ def record_sync_issue(
             (run_id, step_name, level, code, message, _json_text(payload)),
         )
         connection.commit()
+
+
+def latest_sync_artifact(
+    db_path: str | Path,
+    *,
+    artifact_role: str,
+    source_url: str,
+) -> dict[str, Any] | None:
+    with connect(db_path) as connection:
+        row = connection.execute(
+            """
+            SELECT
+                artifacts.id,
+                artifacts.sync_run_id,
+                artifacts.source_url,
+                artifacts.local_path,
+                artifacts.bytes_written,
+                artifacts.sha256,
+                artifacts.etag,
+                artifacts.last_modified
+            FROM sync_run_artifacts AS artifacts
+            WHERE artifacts.artifact_role = ?
+              AND artifacts.source_url = ?
+            ORDER BY artifacts.id DESC
+            LIMIT 1
+            """,
+            (artifact_role, source_url),
+        ).fetchone()
+    return dict(row) if row is not None else None
+
+
+def unchanged_import_skip_reason(
+    db_path: str | Path,
+    *,
+    step_name: str,
+    artifact_role: str,
+    source_url: str,
+    sha256: str,
+    limit_value: int | None,
+    source_name: str | None = None,
+    invalidated_by_steps: tuple[str, ...] = (),
+) -> str | None:
+    with connect(db_path) as connection:
+        row = connection.execute(
+            """
+            SELECT
+                runs.id AS run_id,
+                runs.limit_value,
+                runs.source_name,
+                artifacts.sha256
+            FROM sync_runs AS runs
+            JOIN sync_run_steps AS steps
+                ON steps.sync_run_id = runs.id
+            JOIN sync_run_artifacts AS artifacts
+                ON artifacts.sync_run_id = runs.id
+            WHERE runs.status = 'succeeded'
+              AND steps.status = 'succeeded'
+              AND steps.step_name = ?
+              AND artifacts.artifact_role = ?
+              AND artifacts.source_url = ?
+            ORDER BY runs.id DESC
+            LIMIT 1
+            """,
+            (step_name, artifact_role, source_url),
+        ).fetchone()
+        if row is None:
+            return None
+        if row["sha256"] != sha256:
+            return None
+        if row["limit_value"] != limit_value:
+            return None
+        if source_name is not None and row["source_name"] != source_name:
+            return None
+        if invalidated_by_steps:
+            placeholders = ",".join("?" for _ in invalidated_by_steps)
+            invalidation_row = connection.execute(
+                f"""
+                SELECT 1
+                FROM sync_runs AS runs
+                JOIN sync_run_steps AS steps
+                    ON steps.sync_run_id = runs.id
+                WHERE runs.status = 'succeeded'
+                  AND steps.status = 'succeeded'
+                  AND steps.step_name IN ({placeholders})
+                  AND runs.id > ?
+                LIMIT 1
+                """,
+                (*invalidated_by_steps, row["run_id"]),
+            ).fetchone()
+            if invalidation_row is not None:
+                return None
+    return f"artifact unchanged since run {row['run_id']}"

--- a/src/mtg_source_stack/importer/sync_tracking.py
+++ b/src/mtg_source_stack/importer/sync_tracking.py
@@ -1,0 +1,219 @@
+"""Bookkeeping helpers for importer and sync runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from ..db.connection import connect
+from .service import ImportStats
+
+
+def _json_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+def file_artifact_info(path: str | Path) -> dict[str, Any]:
+    file_path = Path(path)
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return {
+        "local_path": str(file_path.resolve()),
+        "bytes_written": file_path.stat().st_size,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def import_stats_dict(stats: ImportStats) -> dict[str, int]:
+    return {
+        "rows_seen": stats.rows_seen,
+        "rows_written": stats.rows_written,
+        "rows_skipped": stats.rows_skipped,
+    }
+
+
+def start_sync_run(
+    db_path: str | Path,
+    *,
+    run_kind: str,
+    trigger_kind: str = "cli",
+    source_name: str | None = None,
+    limit_value: int | None = None,
+) -> int:
+    with connect(db_path) as connection:
+        row = connection.execute(
+            """
+            INSERT INTO sync_runs (
+                run_kind,
+                status,
+                trigger_kind,
+                source_name,
+                limit_value
+            )
+            VALUES (?, 'running', ?, ?, ?)
+            RETURNING id
+            """,
+            (run_kind, trigger_kind, source_name, limit_value),
+        ).fetchone()
+        connection.commit()
+    return int(row["id"])
+
+
+def finish_sync_run(
+    db_path: str | Path,
+    run_id: int,
+    *,
+    status: str,
+    snapshot_path: str | None = None,
+    summary: dict[str, Any] | None = None,
+) -> None:
+    with connect(db_path) as connection:
+        connection.execute(
+            """
+            UPDATE sync_runs
+            SET
+                status = ?,
+                snapshot_path = ?,
+                summary_json = ?,
+                finished_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (status, snapshot_path, _json_text(summary), run_id),
+        )
+        connection.commit()
+
+
+def start_sync_step(
+    db_path: str | Path,
+    run_id: int,
+    *,
+    step_name: str,
+    details: dict[str, Any] | None = None,
+) -> int:
+    with connect(db_path) as connection:
+        row = connection.execute(
+            """
+            INSERT INTO sync_run_steps (
+                sync_run_id,
+                step_name,
+                status,
+                details_json
+            )
+            VALUES (?, ?, 'running', ?)
+            RETURNING id
+            """,
+            (run_id, step_name, _json_text(details)),
+        ).fetchone()
+        connection.commit()
+    return int(row["id"])
+
+
+def finish_sync_step(
+    db_path: str | Path,
+    step_id: int,
+    *,
+    status: str,
+    stats: ImportStats | None = None,
+    details: dict[str, Any] | None = None,
+) -> None:
+    with connect(db_path) as connection:
+        connection.execute(
+            """
+            UPDATE sync_run_steps
+            SET
+                status = ?,
+                rows_seen = ?,
+                rows_written = ?,
+                rows_skipped = ?,
+                details_json = ?,
+                finished_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (
+                status,
+                stats.rows_seen if stats is not None else None,
+                stats.rows_written if stats is not None else None,
+                stats.rows_skipped if stats is not None else None,
+                _json_text(details),
+                step_id,
+            ),
+        )
+        connection.commit()
+
+
+def record_sync_artifact(
+    db_path: str | Path,
+    run_id: int,
+    *,
+    artifact_role: str,
+    source_url: str | None = None,
+    local_path: str | None = None,
+    bytes_written: int | None = None,
+    sha256: str | None = None,
+    etag: str | None = None,
+    last_modified: str | None = None,
+) -> None:
+    with connect(db_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sync_run_artifacts (
+                sync_run_id,
+                artifact_role,
+                source_url,
+                local_path,
+                bytes_written,
+                sha256,
+                etag,
+                last_modified
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                run_id,
+                artifact_role,
+                source_url,
+                local_path,
+                bytes_written,
+                sha256,
+                etag,
+                last_modified,
+            ),
+        )
+        connection.commit()
+
+
+def record_sync_issue(
+    db_path: str | Path,
+    run_id: int,
+    *,
+    level: str,
+    code: str,
+    message: str,
+    step_name: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    with connect(db_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO sync_run_issues (
+                sync_run_id,
+                step_name,
+                level,
+                code,
+                message,
+                payload_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (run_id, step_name, level, code, message, _json_text(payload)),
+        )
+        connection.commit()

--- a/src/mtg_source_stack/importer/sync_tracking.py
+++ b/src/mtg_source_stack/importer/sync_tracking.py
@@ -223,28 +223,28 @@ def latest_sync_artifact(
     db_path: str | Path,
     *,
     artifact_role: str,
-    source_url: str,
+    source_url: str | None = None,
 ) -> dict[str, Any] | None:
+    query = """
+        SELECT
+            artifacts.id,
+            artifacts.sync_run_id,
+            artifacts.source_url,
+            artifacts.local_path,
+            artifacts.bytes_written,
+            artifacts.sha256,
+            artifacts.etag,
+            artifacts.last_modified
+        FROM sync_run_artifacts AS artifacts
+        WHERE artifacts.artifact_role = ?
+    """
+    params: list[Any] = [artifact_role]
+    if source_url is not None:
+        query += " AND artifacts.source_url = ?"
+        params.append(source_url)
+    query += " ORDER BY artifacts.id DESC LIMIT 1"
     with connect(db_path) as connection:
-        row = connection.execute(
-            """
-            SELECT
-                artifacts.id,
-                artifacts.sync_run_id,
-                artifacts.source_url,
-                artifacts.local_path,
-                artifacts.bytes_written,
-                artifacts.sha256,
-                artifacts.etag,
-                artifacts.last_modified
-            FROM sync_run_artifacts AS artifacts
-            WHERE artifacts.artifact_role = ?
-              AND artifacts.source_url = ?
-            ORDER BY artifacts.id DESC
-            LIMIT 1
-            """,
-            (artifact_role, source_url),
-        ).fetchone()
+        row = connection.execute(query, params).fetchone()
     return dict(row) if row is not None else None
 
 

--- a/src/mtg_source_stack/importer/sync_tracking.py
+++ b/src/mtg_source_stack/importer/sync_tracking.py
@@ -17,6 +17,12 @@ def _json_text(value: Any) -> str | None:
     return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
 
 
+def _json_value(value: str | None) -> Any:
+    if value is None:
+        return None
+    return json.loads(value)
+
+
 def file_artifact_info(path: str | Path) -> dict[str, Any]:
     file_path = Path(path)
     digest = hashlib.sha256()
@@ -309,3 +315,195 @@ def unchanged_import_skip_reason(
             if invalidation_row is not None:
                 return None
     return f"artifact unchanged since run {row['run_id']}"
+
+
+def list_sync_runs(
+    db_path: str | Path,
+    *,
+    limit: int = 20,
+    run_kind: str | None = None,
+    status: str | None = None,
+) -> list[dict[str, Any]]:
+    query = """
+        SELECT
+            runs.id,
+            runs.run_kind,
+            runs.status,
+            runs.trigger_kind,
+            runs.source_name,
+            runs.limit_value,
+            runs.snapshot_path,
+            runs.started_at,
+            runs.finished_at,
+            ROUND((julianday(COALESCE(runs.finished_at, CURRENT_TIMESTAMP)) - julianday(runs.started_at)) * 86400.0, 3)
+                AS duration_seconds,
+            COALESCE(step_counts.step_count, 0) AS step_count,
+            COALESCE(artifact_counts.artifact_count, 0) AS artifact_count,
+            COALESCE(issue_counts.issue_count, 0) AS issue_count,
+            runs.summary_json
+        FROM sync_runs AS runs
+        LEFT JOIN (
+            SELECT sync_run_id, COUNT(*) AS step_count
+            FROM sync_run_steps
+            GROUP BY sync_run_id
+        ) AS step_counts
+            ON step_counts.sync_run_id = runs.id
+        LEFT JOIN (
+            SELECT sync_run_id, COUNT(*) AS artifact_count
+            FROM sync_run_artifacts
+            GROUP BY sync_run_id
+        ) AS artifact_counts
+            ON artifact_counts.sync_run_id = runs.id
+        LEFT JOIN (
+            SELECT sync_run_id, COUNT(*) AS issue_count
+            FROM sync_run_issues
+            GROUP BY sync_run_id
+        ) AS issue_counts
+            ON issue_counts.sync_run_id = runs.id
+        WHERE 1 = 1
+    """
+    params: list[Any] = []
+    if run_kind is not None:
+        query += " AND runs.run_kind = ?"
+        params.append(run_kind)
+    if status is not None:
+        query += " AND runs.status = ?"
+        params.append(status)
+    query += " ORDER BY runs.id DESC LIMIT ?"
+    params.append(limit)
+
+    with connect(db_path) as connection:
+        run_rows = [dict(row) for row in connection.execute(query, params).fetchall()]
+        run_ids = [row["id"] for row in run_rows]
+        step_rows: dict[int, list[dict[str, Any]]] = {run_id: [] for run_id in run_ids}
+        if run_ids:
+            placeholders = ",".join("?" for _ in run_ids)
+            for row in connection.execute(
+                f"""
+                SELECT
+                    sync_run_id,
+                    step_name,
+                    status,
+                    rows_seen,
+                    rows_written,
+                    rows_skipped,
+                    details_json
+                FROM sync_run_steps
+                WHERE sync_run_id IN ({placeholders})
+                ORDER BY id
+                """,
+                run_ids,
+            ).fetchall():
+                step_rows[int(row["sync_run_id"])].append(dict(row))
+
+    for row in run_rows:
+        row["summary"] = _json_value(row.pop("summary_json"))
+        row["steps"] = step_rows.get(int(row["id"]), [])
+
+    return run_rows
+
+
+def get_sync_run_report(db_path: str | Path, *, run_id: int) -> dict[str, Any] | None:
+    with connect(db_path) as connection:
+        run_row = connection.execute(
+            """
+            SELECT
+                id,
+                run_kind,
+                status,
+                trigger_kind,
+                source_name,
+                limit_value,
+                snapshot_path,
+                started_at,
+                finished_at,
+                ROUND((julianday(COALESCE(finished_at, CURRENT_TIMESTAMP)) - julianday(started_at)) * 86400.0, 3)
+                    AS duration_seconds,
+                summary_json
+            FROM sync_runs
+            WHERE id = ?
+            """,
+            (run_id,),
+        ).fetchone()
+        if run_row is None:
+            return None
+
+        steps = [
+            {
+                **dict(row),
+                "details": _json_value(row["details_json"]),
+            }
+            for row in connection.execute(
+                """
+                SELECT
+                    step_name,
+                    status,
+                    rows_seen,
+                    rows_written,
+                    rows_skipped,
+                    details_json,
+                    started_at,
+                    finished_at,
+                    ROUND((julianday(COALESCE(finished_at, CURRENT_TIMESTAMP)) - julianday(started_at)) * 86400.0, 3)
+                        AS duration_seconds
+                FROM sync_run_steps
+                WHERE sync_run_id = ?
+                ORDER BY id
+                """,
+                (run_id,),
+            ).fetchall()
+        ]
+        for step in steps:
+            step.pop("details_json", None)
+
+        artifacts = [
+            dict(row)
+            for row in connection.execute(
+                """
+                SELECT
+                    artifact_role,
+                    source_url,
+                    local_path,
+                    bytes_written,
+                    sha256,
+                    etag,
+                    last_modified,
+                    created_at
+                FROM sync_run_artifacts
+                WHERE sync_run_id = ?
+                ORDER BY id
+                """,
+                (run_id,),
+            ).fetchall()
+        ]
+
+        issues = [
+            {
+                **dict(row),
+                "payload": _json_value(row["payload_json"]),
+            }
+            for row in connection.execute(
+                """
+                SELECT
+                    step_name,
+                    level,
+                    code,
+                    message,
+                    payload_json,
+                    created_at
+                FROM sync_run_issues
+                WHERE sync_run_id = ?
+                ORDER BY id
+                """,
+                (run_id,),
+            ).fetchall()
+        ]
+        for issue in issues:
+            issue.pop("payload_json", None)
+
+    report = dict(run_row)
+    report["summary"] = _json_value(report.pop("summary_json"))
+    report["steps"] = steps
+    report["artifacts"] = artifacts
+    report["issues"] = issues
+    return report

--- a/src/mtg_source_stack/inventory/mutations.py
+++ b/src/mtg_source_stack/inventory/mutations.py
@@ -1376,7 +1376,7 @@ def add_card_with_connection(
     condition_code: str,
     finish: str,
     language_code: str | None,
-    location: str,
+    location: str | None,
     acquisition_price: Decimal | None,
     acquisition_currency: str | None,
     notes: str | None,

--- a/src/mtg_source_stack/mtg_mvp_schema.sql
+++ b/src/mtg_source_stack/mtg_mvp_schema.sql
@@ -51,6 +51,16 @@ CREATE INDEX IF NOT EXISTS idx_mtg_cards_oracle_id
 CREATE INDEX IF NOT EXISTS idx_mtg_cards_set_collector
     ON mtg_cards (set_code, collector_number);
 
+CREATE TABLE IF NOT EXISTS mtgjson_card_links (
+    mtgjson_uuid TEXT PRIMARY KEY,
+    scryfall_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (scryfall_id) REFERENCES mtg_cards (scryfall_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_mtgjson_card_links_scryfall
+    ON mtgjson_card_links (scryfall_id);
+
 CREATE TABLE IF NOT EXISTS price_snapshots (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     scryfall_id TEXT NOT NULL,

--- a/src/mtg_source_stack/mtg_mvp_schema.sql
+++ b/src/mtg_source_stack/mtg_mvp_schema.sql
@@ -90,6 +90,74 @@ CREATE INDEX IF NOT EXISTS idx_price_snapshots_card_date
 CREATE INDEX IF NOT EXISTS idx_price_snapshots_provider_date
     ON price_snapshots (provider, snapshot_date DESC);
 
+CREATE TABLE IF NOT EXISTS sync_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_kind TEXT NOT NULL,
+    status TEXT NOT NULL,
+    trigger_kind TEXT NOT NULL DEFAULT 'cli',
+    source_name TEXT,
+    limit_value INTEGER,
+    snapshot_path TEXT,
+    summary_json TEXT,
+    started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    finished_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_started_at
+    ON sync_runs (started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_kind_started_at
+    ON sync_runs (run_kind, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS sync_run_steps (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sync_run_id INTEGER NOT NULL,
+    step_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    rows_seen INTEGER,
+    rows_written INTEGER,
+    rows_skipped INTEGER,
+    details_json TEXT,
+    started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    finished_at TEXT,
+    FOREIGN KEY (sync_run_id) REFERENCES sync_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_run_steps_run_step
+    ON sync_run_steps (sync_run_id, step_name);
+
+CREATE TABLE IF NOT EXISTS sync_run_artifacts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sync_run_id INTEGER NOT NULL,
+    artifact_role TEXT NOT NULL,
+    source_url TEXT,
+    local_path TEXT,
+    bytes_written INTEGER,
+    sha256 TEXT,
+    etag TEXT,
+    last_modified TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (sync_run_id) REFERENCES sync_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_run_artifacts_run_role
+    ON sync_run_artifacts (sync_run_id, artifact_role);
+
+CREATE TABLE IF NOT EXISTS sync_run_issues (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sync_run_id INTEGER NOT NULL,
+    step_name TEXT,
+    level TEXT NOT NULL,
+    code TEXT NOT NULL,
+    message TEXT NOT NULL,
+    payload_json TEXT,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (sync_run_id) REFERENCES sync_runs (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_run_issues_run_created_at
+    ON sync_run_issues (sync_run_id, created_at);
+
 CREATE TABLE IF NOT EXISTS inventories (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     slug TEXT NOT NULL UNIQUE,

--- a/src/mtg_source_stack/mvp_importer.py
+++ b/src/mtg_source_stack/mvp_importer.py
@@ -42,7 +42,11 @@ from .importer.service import (
     print_snapshot_created,
     print_snapshot_list,
     print_stats,
+    print_sync_result,
     print_sync_bulk_result,
+    sync_identifiers,
+    sync_prices,
+    sync_scryfall,
     sync_bulk,
     text_or_none,
 )

--- a/tests/fixtures/frontend_demo_full_catalog/identifiers.json
+++ b/tests/fixtures/frontend_demo_full_catalog/identifiers.json
@@ -1,0 +1,52 @@
+{
+  "data": {
+    "uuid-brainstorm-1": {
+      "name": "Brainstorm",
+      "setCode": "ice",
+      "identifiers": {
+        "scryfallId": "fixture-brainstorm-en",
+        "tcgplayerProductId": "2001"
+      }
+    },
+    "uuid-bolt-mainstream-1": {
+      "name": "Lightning Bolt",
+      "setCode": "m11",
+      "identifiers": {
+        "scryfallId": "fixture-bolt-mainstream-en",
+        "tcgplayerProductId": "2002"
+      }
+    },
+    "uuid-counterspell-1": {
+      "name": "Counterspell",
+      "setCode": "7ed",
+      "identifiers": {
+        "scryfallId": "fixture-counterspell-modern-en",
+        "tcgplayerProductId": "2003"
+      }
+    },
+    "uuid-forest-1": {
+      "name": "Forest",
+      "setCode": "m10",
+      "identifiers": {
+        "scryfallId": "fixture-forest-modern-en",
+        "tcgplayerProductId": "2004"
+      }
+    },
+    "uuid-swords-ja-1": {
+      "name": "Swords to Plowshares",
+      "setCode": "sta",
+      "identifiers": {
+        "scryfallId": "fixture-swords-ja-modern",
+        "tcgplayerProductId": "2005"
+      }
+    },
+    "uuid-sol-ring-mainstream-1": {
+      "name": "Sol Ring",
+      "setCode": "cmr",
+      "identifiers": {
+        "scryfallId": "fixture-sol-ring-mainstream-en",
+        "tcgplayerProductId": "2006"
+      }
+    }
+  }
+}

--- a/tests/fixtures/frontend_demo_full_catalog/prices.json
+++ b/tests/fixtures/frontend_demo_full_catalog/prices.json
@@ -1,0 +1,82 @@
+{
+  "data": {
+    "uuid-brainstorm-1": {
+      "paper": {
+        "tcgplayer": {
+          "currency": "USD",
+          "retail": {
+            "normal": {
+              "2026-04-02": 1.11
+            }
+          }
+        }
+      }
+    },
+    "uuid-bolt-mainstream-1": {
+      "paper": {
+        "tcgplayer": {
+          "currency": "USD",
+          "retail": {
+            "normal": {
+              "2026-04-02": 3.33
+            },
+            "foil": {
+              "2026-04-02": 7.10
+            }
+          }
+        }
+      }
+    },
+    "uuid-counterspell-1": {
+      "paper": {
+        "tcgplayer": {
+          "currency": "USD",
+          "retail": {
+            "normal": {
+              "2026-04-02": 1.99
+            }
+          }
+        }
+      }
+    },
+    "uuid-forest-1": {
+      "paper": {
+        "tcgplayer": {
+          "currency": "USD",
+          "retail": {
+            "normal": {
+              "2026-04-02": 0.22
+            }
+          }
+        }
+      }
+    },
+    "uuid-swords-ja-1": {
+      "paper": {
+        "tcgplayer": {
+          "currency": "USD",
+          "retail": {
+            "normal": {
+              "2026-04-02": 4.44
+            }
+          }
+        }
+      }
+    },
+    "uuid-sol-ring-mainstream-1": {
+      "paper": {
+        "tcgplayer": {
+          "currency": "USD",
+          "retail": {
+            "normal": {
+              "2026-04-02": 2.05
+            },
+            "etched": {
+              "2026-04-02": 5.40
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -479,6 +479,7 @@ class ApiContractTest(RepoSmokeTestCase):
         self.assertEqual("NM", add_properties["condition_code"]["default"])
         self.assertIn("Canonical condition codes: M, NM, LP, MP, HP, DMG", add_properties["condition_code"]["description"])
         self.assertIsNone(add_properties["language_code"]["default"])
+        self.assertIsNone(add_properties["location"]["default"])
         self.assertIn("inherits the resolved printing language", add_properties["language_code"]["description"])
         self.assertEqual({"type": "string"}, add_properties["oracle_id"]["anyOf"][0])
         self.assertIn("prefers English mainstream-paper printings", add_properties["oracle_id"]["description"])

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -108,6 +108,7 @@ class CliSmokeTest(RepoSmokeTestCase):
             self.assertIn("0010 add inventory printing selection mode", migrate_output)
             self.assertIn("0011 add inventory metadata defaults", migrate_output)
             self.assertIn("0012 add mtgjson card links", migrate_output)
+            self.assertIn("0013 add sync run tracking", migrate_output)
 
             search_output = self.run_cli(
                 "search-cards",
@@ -527,6 +528,7 @@ class CliSmokeTest(RepoSmokeTestCase):
                 "--prices-json",
                 str(prices_path),
             )
+            self.assertIn("run_id:", import_output)
             self.assertIn("import-scryfall: seen=1 written=1 skipped=0", import_output)
             self.assertIn("import-identifiers: seen=1 written=1 skipped=0", import_output)
             self.assertIn("import-prices: seen=1 written=2 skipped=0", import_output)

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -107,6 +107,7 @@ class CliSmokeTest(RepoSmokeTestCase):
             self.assertIn("0009 add catalog relevance rank", migrate_output)
             self.assertIn("0010 add inventory printing selection mode", migrate_output)
             self.assertIn("0011 add inventory metadata defaults", migrate_output)
+            self.assertIn("0012 add mtgjson card links", migrate_output)
 
             search_output = self.run_cli(
                 "search-cards",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -109,6 +109,7 @@ class CliSmokeTest(RepoSmokeTestCase):
             self.assertIn("0011 add inventory metadata defaults", migrate_output)
             self.assertIn("0012 add mtgjson card links", migrate_output)
             self.assertIn("0013 add sync run tracking", migrate_output)
+            self.assertIn("0014 narrow card search fts updates", migrate_output)
 
             search_output = self.run_cli(
                 "search-cards",

--- a/tests/test_frontend_demo_bootstrap.py
+++ b/tests/test_frontend_demo_bootstrap.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 import json
 import subprocess
 import sys
@@ -118,6 +119,7 @@ class FrontendDemoBootstrapTest(unittest.TestCase):
             self.assertIn("Catalog mode: full", result.stdout)
             self.assertIn("Inventories seeded: personal, trade-binder", result.stdout)
             self.assertIn("Scryfall cards imported: 12", result.stdout)
+            self.assertIn("Price mode: curated demo seed pricing.", result.stdout)
             self.assertIn("Curated owned-item demo rows resolved from imported catalog printings.", result.stdout)
             self.assertIn("npm run backend:demo -- --db", result.stdout)
             self.assert_richer_demo_dataset(db_path)
@@ -166,6 +168,86 @@ class FrontendDemoBootstrapTest(unittest.TestCase):
             self.assertEqual(1, brainstorm_rows)
             self.assertEqual(0, owned_demo_rows)
 
+    def test_bootstrap_full_catalog_mode_can_import_real_prices(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "frontend_demo_full_real_prices.db"
+            scryfall_json = fixture_path("frontend_demo_full_catalog", "scryfall.json")
+            identifiers_json = fixture_path("frontend_demo_full_catalog", "identifiers.json")
+            prices_json = fixture_path("frontend_demo_full_catalog", "prices.json")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/bootstrap_frontend_demo.py",
+                    "--db",
+                    str(db_path),
+                    "--force",
+                    "--full-catalog",
+                    "--scryfall-json",
+                    str(scryfall_json),
+                    "--identifiers-json",
+                    str(identifiers_json),
+                    "--prices-json",
+                    str(prices_json),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            self.assertIn("Catalog mode: full", result.stdout)
+            self.assertIn("MTGJSON identifier links imported: 6", result.stdout)
+            self.assertIn("MTGJSON price snapshots imported: 8", result.stdout)
+            self.assertIn("Price mode: imported MTGJSON pricing.", result.stdout)
+            self.assert_richer_demo_dataset(db_path)
+
+            owned_rows = list_owned_filtered(
+                db_path,
+                inventory_slug="personal",
+                provider="tcgplayer",
+                limit=None,
+                query=None,
+                set_code=None,
+                rarity=None,
+                finish=None,
+                condition_code=None,
+                language_code=None,
+                location=None,
+                tags=None,
+            )
+            owned_by_name = {row.name: row for row in owned_rows}
+            self.assertEqual(Decimal("7.10"), owned_by_name["Lightning Bolt"].unit_price)
+            self.assertEqual(Decimal("1.99"), owned_by_name["Counterspell"].unit_price)
+            self.assertEqual(Decimal("4.44"), owned_by_name["Swords to Plowshares"].unit_price)
+            self.assertEqual(Decimal("5.40"), owned_by_name["Sol Ring"].unit_price)
+
+            with connect(db_path) as connection:
+                mtgjson_price_rows = connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM price_snapshots
+                    WHERE source_name = 'mtgjson_all_prices_today'
+                    """
+                ).fetchone()[0]
+                demo_seed_price_rows = connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM price_snapshots
+                    WHERE source_name = 'demo-seed'
+                    """
+                ).fetchone()[0]
+                brainstorm_price_rows = connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM price_snapshots
+                    WHERE scryfall_id = 'fixture-brainstorm-en'
+                    """
+                ).fetchone()[0]
+
+            self.assertEqual(8, mtgjson_price_rows)
+            self.assertEqual(0, demo_seed_price_rows)
+            self.assertEqual(1, brainstorm_price_rows)
+
     def test_bootstrap_full_catalog_mode_requires_scryfall_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "frontend_demo_missing_fixture.db"
@@ -186,6 +268,36 @@ class FrontendDemoBootstrapTest(unittest.TestCase):
 
             self.assertNotEqual(0, result.returncode)
             self.assertIn("--scryfall-json is required with --full-catalog", result.stderr)
+
+    def test_bootstrap_full_catalog_mode_requires_identifiers_and_prices_together(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "frontend_demo_missing_prices.db"
+            scryfall_json = fixture_path("frontend_demo_full_catalog", "scryfall.json")
+            identifiers_json = fixture_path("frontend_demo_full_catalog", "identifiers.json")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/bootstrap_frontend_demo.py",
+                    "--db",
+                    str(db_path),
+                    "--force",
+                    "--full-catalog",
+                    "--scryfall-json",
+                    str(scryfall_json),
+                    "--identifiers-json",
+                    str(identifiers_json),
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn(
+                "--identifiers-json and --prices-json must be provided together with --full-catalog.",
+                result.stderr,
+            )
 
     def test_bootstrap_full_catalog_mode_fails_fast_when_demo_finish_constraints_cannot_resolve(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_frontend_demo_bootstrap.py
+++ b/tests/test_frontend_demo_bootstrap.py
@@ -91,6 +91,7 @@ class FrontendDemoBootstrapTest(unittest.TestCase):
 
             self.assertIn("Inventories seeded: personal, trade-binder", result.stdout)
             self.assertIn("Catalog mode: small", result.stdout)
+            self.assertIn("npm run backend:demo -- --db", result.stdout)
             self.assert_richer_demo_dataset(db_path)
 
     def test_bootstrap_full_catalog_mode_imports_real_cards_without_demo_catalog_rows(self) -> None:
@@ -118,6 +119,7 @@ class FrontendDemoBootstrapTest(unittest.TestCase):
             self.assertIn("Inventories seeded: personal, trade-binder", result.stdout)
             self.assertIn("Scryfall cards imported: 12", result.stdout)
             self.assertIn("Curated owned-item demo rows resolved from imported catalog printings.", result.stdout)
+            self.assertIn("npm run backend:demo -- --db", result.stdout)
             self.assert_richer_demo_dataset(db_path)
 
             owned_rows = list_owned_filtered(

--- a/tests/test_frontend_demo_scripts.py
+++ b/tests/test_frontend_demo_scripts.py
@@ -1,0 +1,135 @@
+"""Regression coverage for frontend demo shell launchers."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.common import REPO_ROOT
+
+
+def _write_fake_python(path: Path, *, fail_fastapi_check: bool = False) -> None:
+    script = """#!/usr/bin/env bash
+set -euo pipefail
+if [ "${FAIL_FASTAPI_CHECK:-0}" = "1" ] && [ "${1:-}" = "-c" ] && [[ "${2:-}" == *"import fastapi, uvicorn, pydantic"* ]]; then
+  exit 1
+fi
+printf '%s\n' "$@" > "${FAKE_PYTHON_ARGS_FILE}"
+"""
+    path.write_text(script, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class FrontendDemoScriptsTest(unittest.TestCase):
+    def test_run_demo_backend_uses_override_python_and_injects_default_db(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            fake_python = tmp / "fake-python.sh"
+            args_file = tmp / "args.txt"
+            _write_fake_python(fake_python)
+
+            env = os.environ.copy()
+            env["MTG_FRONTEND_PYTHON"] = str(fake_python)
+            env["FAKE_PYTHON_ARGS_FILE"] = str(args_file)
+
+            subprocess.run(
+                ["bash", "frontend/scripts/run_demo_backend.sh", "--host", "127.0.0.1"],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            argv = args_file.read_text(encoding="utf-8").splitlines()
+            self.assertEqual("-c", argv[0])
+            self.assertIn("from mtg_source_stack.api.app import main", argv[1])
+            self.assertIn("--db", argv)
+            self.assertIn(str(REPO_ROOT / "var/db/frontend_demo.db"), argv)
+            self.assertEqual("127.0.0.1", argv[-1])
+
+    def test_run_demo_backend_preserves_explicit_db_argument(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            fake_python = tmp / "fake-python.sh"
+            args_file = tmp / "args.txt"
+            custom_db = tmp / "custom.db"
+            _write_fake_python(fake_python)
+
+            env = os.environ.copy()
+            env["MTG_FRONTEND_PYTHON"] = str(fake_python)
+            env["FAKE_PYTHON_ARGS_FILE"] = str(args_file)
+
+            subprocess.run(
+                ["bash", "frontend/scripts/run_demo_backend.sh", "--db", str(custom_db), "--port", "8001"],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            argv = args_file.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(1, argv.count("--db"))
+            self.assertIn(str(custom_db), argv)
+            self.assertIn("8001", argv)
+
+    def test_run_demo_backend_surfaces_helpful_dependency_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            fake_python = tmp / "fake-python.sh"
+            args_file = tmp / "args.txt"
+            _write_fake_python(fake_python, fail_fastapi_check=True)
+
+            env = os.environ.copy()
+            env["MTG_FRONTEND_PYTHON"] = str(fake_python)
+            env["FAKE_PYTHON_ARGS_FILE"] = str(args_file)
+            env["FAIL_FASTAPI_CHECK"] = "1"
+
+            result = subprocess.run(
+                ["bash", "frontend/scripts/run_demo_backend.sh"],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(1, result.returncode)
+            self.assertIn("missing the FastAPI web dependencies", result.stderr)
+            self.assertIn("MTG_FRONTEND_PYTHON", result.stderr)
+
+    def test_bootstrap_demo_db_uses_override_python_and_injects_default_db(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            fake_python = tmp / "fake-python.sh"
+            args_file = tmp / "args.txt"
+            _write_fake_python(fake_python)
+
+            env = os.environ.copy()
+            env["MTG_FRONTEND_PYTHON"] = str(fake_python)
+            env["FAKE_PYTHON_ARGS_FILE"] = str(args_file)
+
+            subprocess.run(
+                ["bash", "frontend/scripts/bootstrap_demo_db.sh", "--force"],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            argv = args_file.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(str(REPO_ROOT / "scripts/bootstrap_frontend_demo.py"), argv[0])
+            self.assertIn("--db", argv)
+            self.assertIn(str(REPO_ROOT / "var/db/frontend_demo.db"), argv)
+            self.assertIn("--force", argv)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -2524,6 +2524,165 @@ class ImporterTest(RepoSmokeTestCase):
 
             self.assertEqual(("uuid-sync-identifiers-dependency-2", "11401"), (row["mtgjson_uuid"], row["tcgplayer_product_id"]))
 
+    def test_check_search_index_reports_healthy_catalog(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES (
+                        'search-healthy-1',
+                        'oracle-search-healthy-1',
+                        'Healthy Search Card',
+                        'hlt',
+                        'Healthy Set',
+                        '1'
+                    )
+                    """
+                )
+                connection.commit()
+
+            output = self.run_importer(
+                "check-search-index",
+                "--db",
+                str(db_path),
+            )
+
+            self.assertIn("check-search-index completed", output)
+            self.assertIn("status: healthy", output)
+            self.assertIn("missing_rows=0 orphan_rows=0 duplicate_rows=0 mismatched_rows=0", output)
+
+    def test_check_search_index_detects_missing_orphan_duplicate_and_mismatched_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.executemany(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES (?, ?, ?, 'drf', 'Drift Set', ?)
+                    """,
+                    [
+                        ("search-missing-1", "oracle-search-missing-1", "Missing Search Card", "1"),
+                        ("search-mismatch-1", "oracle-search-mismatch-1", "Mismatch Search Card", "2"),
+                        ("search-duplicate-1", "oracle-search-duplicate-1", "Duplicate Search Card", "3"),
+                    ],
+                )
+                connection.execute(
+                    "DELETE FROM mtg_cards_fts WHERE scryfall_id = 'search-missing-1'"
+                )
+                connection.execute(
+                    """
+                    UPDATE mtg_cards_fts
+                    SET name = 'Mismatch Search Card Drifted'
+                    WHERE scryfall_id = 'search-mismatch-1'
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards_fts (scryfall_id, name, set_code, set_name, collector_number, lang)
+                    SELECT scryfall_id, name, set_code, set_name, collector_number, lang
+                    FROM mtg_cards_fts
+                    WHERE scryfall_id = 'search-duplicate-1'
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards_fts (scryfall_id, name, set_code, set_name, collector_number, lang)
+                    VALUES ('search-orphan-1', 'Orphan Search Card', 'drf', 'Drift Set', '9', 'en')
+                    """
+                )
+                connection.commit()
+
+            result = self.run_failing_importer(
+                "check-search-index",
+                "--db",
+                str(db_path),
+            )
+
+            self.assertEqual(1, result.returncode)
+            self.assertIn("status: drift_detected", result.stdout)
+            self.assertIn("missing_rows=1 orphan_rows=1 duplicate_rows=1 mismatched_rows=1", result.stdout)
+            self.assertIn("missing rows preview:", result.stdout)
+            self.assertIn("orphan rows preview:", result.stdout)
+            self.assertIn("duplicate rows preview:", result.stdout)
+            self.assertIn("mismatched rows preview:", result.stdout)
+
+    def test_rebuild_search_index_repairs_detected_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.executemany(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES (?, ?, ?, 'fix', 'Fix Set', ?)
+                    """,
+                    [
+                        ("search-fix-1", "oracle-search-fix-1", "Fix Search Card", "1"),
+                        ("search-fix-2", "oracle-search-fix-2", "Fix Search Card Two", "2"),
+                    ],
+                )
+                connection.execute("DELETE FROM mtg_cards_fts WHERE scryfall_id = 'search-fix-1'")
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards_fts (scryfall_id, name, set_code, set_name, collector_number, lang)
+                    VALUES ('search-orphan-fix', 'Orphan Fix Card', 'fix', 'Fix Set', '8', 'en')
+                    """
+                )
+                connection.commit()
+
+            rebuild_output = self.run_importer(
+                "rebuild-search-index",
+                "--db",
+                str(db_path),
+            )
+
+            self.assertIn("snapshot:", rebuild_output)
+            self.assertIn("rebuild-search-index completed", rebuild_output)
+            self.assertIn("status: healthy", rebuild_output)
+            self.assertIn("missing_rows=0 orphan_rows=0 duplicate_rows=0 mismatched_rows=0", rebuild_output)
+
+            check_output = self.run_importer(
+                "check-search-index",
+                "--db",
+                str(db_path),
+            )
+            self.assertIn("status: healthy", check_output)
+
+            with connect(db_path) as connection:
+                mtg_card_count = connection.execute("SELECT COUNT(*) FROM mtg_cards").fetchone()[0]
+                fts_count = connection.execute("SELECT COUNT(*) FROM mtg_cards_fts").fetchone()[0]
+
+            self.assertEqual(mtg_card_count, fts_count)
+
     def test_remove_card_creates_snapshot_and_restore_snapshot_recovers_inventory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp = Path(tmp_dir)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -854,6 +854,234 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(0, stats.rows_skipped)
             self.assertEqual(("tcgplayer", 2.25), (row["provider"], row["price_value"]))
 
+    def test_import_all_records_sync_run_steps_and_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            scryfall_path = tmp / "scryfall.json"
+            identifiers_path = tmp / "identifiers.json"
+            prices_path = tmp / "prices.json"
+
+            scryfall_payload = [
+                {
+                    "id": "tracked-1",
+                    "oracle_id": "tracked-oracle-1",
+                    "name": "Tracked Test Card",
+                    "set": "trk",
+                    "set_name": "Tracked Set",
+                    "collector_number": "1",
+                    "lang": "en",
+                    "rarity": "rare",
+                    "released_at": "2026-01-01",
+                    "colors": ["U"],
+                    "color_identity": ["U"],
+                    "finishes": ["nonfoil"],
+                    "legalities": {"commander": "legal"},
+                    "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                }
+            ]
+            identifiers_payload = {
+                "data": {
+                    "uuid-tracked-1": {
+                        "identifiers": {
+                            "scryfallId": "tracked-1",
+                            "tcgplayerProductId": "4001",
+                        }
+                    }
+                }
+            }
+            prices_payload = {
+                "data": {
+                    "uuid-tracked-1": {
+                        "paper": {
+                            "tcgplayer": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 8.5}},
+                            }
+                        }
+                    }
+                }
+            }
+
+            scryfall_path.write_text(json.dumps(scryfall_payload), encoding="utf-8")
+            identifiers_path.write_text(json.dumps(identifiers_payload), encoding="utf-8")
+            prices_path.write_text(json.dumps(prices_payload), encoding="utf-8")
+
+            import_output = self.run_importer(
+                "import-all",
+                "--db",
+                str(db_path),
+                "--scryfall-json",
+                str(scryfall_path),
+                "--identifiers-json",
+                str(identifiers_path),
+                "--prices-json",
+                str(prices_path),
+            )
+
+            self.assertIn("run_id:", import_output)
+
+            with connect(db_path) as connection:
+                run_row = connection.execute(
+                    """
+                    SELECT run_kind, status, snapshot_path, summary_json
+                    FROM sync_runs
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                step_rows = connection.execute(
+                    """
+                    SELECT step_name, status, rows_seen, rows_written, rows_skipped
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+                artifact_rows = connection.execute(
+                    """
+                    SELECT artifact_role, local_path, bytes_written, sha256
+                    FROM sync_run_artifacts
+                    ORDER BY artifact_role
+                    """
+                ).fetchall()
+
+            summary = json.loads(run_row["summary_json"])
+            self.assertEqual(("import_all", "succeeded"), (run_row["run_kind"], run_row["status"]))
+            self.assertIsNotNone(run_row["snapshot_path"])
+            self.assertEqual(
+                {
+                    "import_scryfall": {"rows_seen": 1, "rows_written": 1, "rows_skipped": 0},
+                    "import_identifiers": {"rows_seen": 1, "rows_written": 1, "rows_skipped": 0},
+                    "import_prices": {"rows_seen": 1, "rows_written": 1, "rows_skipped": 0},
+                },
+                summary,
+            )
+            self.assertEqual(
+                [
+                    ("import_scryfall", "succeeded", 1, 1, 0),
+                    ("import_identifiers", "succeeded", 1, 1, 0),
+                    ("import_prices", "succeeded", 1, 1, 0),
+                ],
+                [
+                    (
+                        row["step_name"],
+                        row["status"],
+                        row["rows_seen"],
+                        row["rows_written"],
+                        row["rows_skipped"],
+                    )
+                    for row in step_rows
+                ],
+            )
+            self.assertEqual(
+                ["mtgjson_identifiers", "mtgjson_prices", "scryfall_json"],
+                [row["artifact_role"] for row in artifact_rows],
+            )
+            self.assertTrue(all(row["local_path"] for row in artifact_rows))
+            self.assertTrue(all(row["bytes_written"] > 0 for row in artifact_rows))
+            self.assertTrue(all(row["sha256"] for row in artifact_rows))
+
+    def test_import_all_records_failed_sync_run_when_late_step_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            scryfall_path = tmp / "scryfall.json"
+            identifiers_path = tmp / "identifiers.json"
+            prices_path = tmp / "prices.json"
+
+            scryfall_payload = [
+                {
+                    "id": "tracked-fail-1",
+                    "oracle_id": "tracked-fail-oracle-1",
+                    "name": "Tracked Failure Card",
+                    "set": "trk",
+                    "set_name": "Tracked Set",
+                    "collector_number": "2",
+                    "lang": "en",
+                    "rarity": "rare",
+                    "released_at": "2026-01-01",
+                    "colors": ["U"],
+                    "color_identity": ["U"],
+                    "finishes": ["nonfoil"],
+                    "legalities": {"commander": "legal"},
+                    "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                }
+            ]
+            identifiers_payload = {
+                "data": {
+                    "uuid-tracked-fail-1": {
+                        "identifiers": {
+                            "scryfallId": "tracked-fail-1",
+                            "tcgplayerProductId": "4002",
+                        }
+                    }
+                }
+            }
+            prices_payload = {"data": []}
+
+            scryfall_path.write_text(json.dumps(scryfall_payload), encoding="utf-8")
+            identifiers_path.write_text(json.dumps(identifiers_payload), encoding="utf-8")
+            prices_path.write_text(json.dumps(prices_payload), encoding="utf-8")
+
+            result = self.run_failing_importer(
+                "import-all",
+                "--db",
+                str(db_path),
+                "--scryfall-json",
+                str(scryfall_path),
+                "--identifiers-json",
+                str(identifiers_path),
+                "--prices-json",
+                str(prices_path),
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertIn("Expected MTGJSON prices to contain an object", result.stderr)
+            self.assertTrue(db_path.exists())
+
+            with connect(db_path) as connection:
+                run_row = connection.execute(
+                    """
+                    SELECT run_kind, status, summary_json
+                    FROM sync_runs
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                step_rows = connection.execute(
+                    """
+                    SELECT step_name, status
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+                issue_row = connection.execute(
+                    """
+                    SELECT level, code, message
+                    FROM sync_run_issues
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+
+            self.assertEqual(("import_all", "failed"), (run_row["run_kind"], run_row["status"]))
+            self.assertEqual(
+                {"error": "Expected MTGJSON prices to contain an object at payload['data']."},
+                json.loads(run_row["summary_json"]),
+            )
+            self.assertEqual(
+                [
+                    ("import_scryfall", "succeeded"),
+                    ("import_identifiers", "succeeded"),
+                    ("import_prices", "failed"),
+                ],
+                [(row["step_name"], row["status"]) for row in step_rows],
+            )
+            self.assertEqual(
+                ("error", "ValueError", "Expected MTGJSON prices to contain an object at payload['data']."),
+                (issue_row["level"], issue_row["code"], issue_row["message"]),
+            )
+
     def test_sync_bulk_downloads_and_imports_from_override_urls(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp = Path(tmp_dir)
@@ -940,6 +1168,7 @@ class ImporterTest(RepoSmokeTestCase):
             )
 
             self.assertIn("sync-bulk completed", sync_output)
+            self.assertIn("run_id:", sync_output)
             self.assertIn("import-scryfall: seen=1 written=1 skipped=0", sync_output)
             self.assertIn("import-identifiers: seen=1 written=1 skipped=0", sync_output)
             self.assertIn("import-prices: seen=1 written=1 skipped=0", sync_output)
@@ -953,11 +1182,49 @@ class ImporterTest(RepoSmokeTestCase):
             uuid_count = connection.execute(
                 "SELECT COUNT(*) FROM mtg_cards WHERE mtgjson_uuid IS NOT NULL"
             ).fetchone()[0]
+            sync_run = connection.execute(
+                """
+                SELECT run_kind, status
+                FROM sync_runs
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            ).fetchone()
+            sync_steps = connection.execute(
+                """
+                SELECT step_name, status
+                FROM sync_run_steps
+                ORDER BY id
+                """
+            ).fetchall()
+            artifacts = connection.execute(
+                """
+                SELECT artifact_role, source_url, bytes_written, sha256
+                FROM sync_run_artifacts
+                ORDER BY artifact_role
+                """
+            ).fetchall()
             connection.close()
 
             self.assertEqual(1, mtg_cards)
             self.assertEqual(1, price_snapshots)
             self.assertEqual(1, uuid_count)
+            self.assertEqual(("sync_bulk", "succeeded"), (sync_run[0], sync_run[1]))
+            self.assertEqual(
+                [
+                    ("import_scryfall", "succeeded"),
+                    ("import_identifiers", "succeeded"),
+                    ("import_prices", "succeeded"),
+                ],
+                [(row[0], row[1]) for row in sync_steps],
+            )
+            self.assertEqual(
+                ["mtgjson_identifiers", "mtgjson_prices", "scryfall_bulk"],
+                [row[0] for row in artifacts],
+            )
+            self.assertTrue(all(row[1] for row in artifacts))
+            self.assertTrue(all(row[2] > 0 for row in artifacts))
+            self.assertTrue(all(row[3] for row in artifacts))
 
     def test_remove_card_creates_snapshot_and_restore_snapshot_recovers_inventory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -670,6 +670,76 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(("uuid-noop", "7001", "2000-01-01 00:00:00"), tuple(row))
             self.assertEqual(1, link_count)
 
+    def test_import_mtgjson_identifiers_does_not_rebuild_fts_rows_for_identifier_only_updates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            identifiers_path = Path(tmp_dir) / "identifiers.json"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.executemany(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES (?, ?, ?, 'tst', 'Test Set', ?)
+                    """,
+                    [
+                        ("card-search", "oracle-search", "Searchable Card", "1"),
+                        ("card-other", "oracle-other", "Other Card", "2"),
+                    ],
+                )
+                before_row = connection.execute(
+                    """
+                    SELECT rowid, scryfall_id, name, set_code, set_name, collector_number, lang
+                    FROM mtg_cards_fts
+                    WHERE scryfall_id = 'card-search'
+                    """
+                ).fetchone()
+
+            identifiers_payload = {
+                "data": {
+                    "uuid-search": {
+                        "identifiers": {
+                            "scryfallId": "card-search",
+                            "tcgplayerProductId": "123",
+                            "cardKingdomId": "456",
+                        }
+                    }
+                }
+            }
+            identifiers_path.write_text(json.dumps(identifiers_payload), encoding="utf-8")
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_identifiers
+
+            stats = import_mtgjson_identifiers(db_path, identifiers_path)
+
+            with connect(db_path) as connection:
+                after_row = connection.execute(
+                    """
+                    SELECT rowid, scryfall_id, name, set_code, set_name, collector_number, lang
+                    FROM mtg_cards_fts
+                    WHERE scryfall_id = 'card-search'
+                    """
+                ).fetchone()
+                search_match = connection.execute(
+                    """
+                    SELECT scryfall_id
+                    FROM mtg_cards_fts
+                    WHERE mtg_cards_fts MATCH 'Searchable'
+                    ORDER BY scryfall_id
+                    """
+                ).fetchall()
+
+            self.assertEqual(1, stats.rows_written)
+            self.assertEqual(tuple(before_row), tuple(after_row))
+            self.assertEqual([("card-search",)], [tuple(row) for row in search_match])
+
     def test_import_mtgjson_identifiers_reports_phase_timings(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "collection.db"
@@ -718,6 +788,60 @@ class ImporterTest(RepoSmokeTestCase):
             for value in stats.details["phase_seconds"].values():
                 self.assertIsInstance(value, float)
                 self.assertGreaterEqual(value, 0.0)
+
+    def test_name_updates_refresh_card_search_fts_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('card-fts', 'oracle-fts', 'Original Search Name', 'tst', 'Test Set', '1')
+                    """
+                )
+                original_match = connection.execute(
+                    """
+                    SELECT scryfall_id
+                    FROM mtg_cards_fts
+                    WHERE mtg_cards_fts MATCH 'Original'
+                    """
+                ).fetchall()
+
+                connection.execute(
+                    """
+                    UPDATE mtg_cards
+                    SET name = 'Updated Search Name'
+                    WHERE scryfall_id = 'card-fts'
+                    """
+                )
+
+                updated_match = connection.execute(
+                    """
+                    SELECT scryfall_id
+                    FROM mtg_cards_fts
+                    WHERE mtg_cards_fts MATCH 'Updated'
+                    """
+                ).fetchall()
+                stale_match = connection.execute(
+                    """
+                    SELECT scryfall_id
+                    FROM mtg_cards_fts
+                    WHERE mtg_cards_fts MATCH 'Original'
+                    """
+                ).fetchall()
+
+            self.assertEqual([("card-fts",)], [tuple(row) for row in original_match])
+            self.assertEqual([("card-fts",)], [tuple(row) for row in updated_match])
+            self.assertEqual([], stale_match)
 
     def test_iter_json_object_items_reads_gzip_data_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -666,6 +666,86 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(("uuid-noop", "7001", "2000-01-01 00:00:00"), tuple(row))
             self.assertEqual(1, link_count)
 
+    def test_iter_json_object_items_reads_gzip_data_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            payload_path = Path(tmp_dir) / "payload.json.gz"
+            payload = {
+                "meta": {"date": "2026-04-12", "version": "5.2.2"},
+                "data": {
+                    "uuid-stream-1": {"name": "Stream Card One", "identifiers": {"scryfallId": "stream-1"}},
+                    "uuid-stream-2": {"name": "Stream Card Two", "identifiers": {"scryfallId": "stream-2"}},
+                },
+                "links": {"self": "https://example.test/all-identifiers"},
+            }
+            with gzip.open(payload_path, mode="wt", encoding="utf-8") as handle:
+                json.dump(payload, handle)
+
+            from mtg_source_stack.importer.service import iter_json_object_items
+
+            items = list(iter_json_object_items(payload_path, top_level_key="data"))
+
+            self.assertEqual(
+                [
+                    ("uuid-stream-1", {"name": "Stream Card One", "identifiers": {"scryfallId": "stream-1"}}),
+                    ("uuid-stream-2", {"name": "Stream Card Two", "identifiers": {"scryfallId": "stream-2"}}),
+                ],
+                items,
+            )
+
+    def test_import_mtgjson_identifiers_accepts_gzip_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            identifiers_path = Path(tmp_dir) / "identifiers.json.gz"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('card-gzip', 'oracle-gzip', 'Gzip Identifier Card', 'tst', 'Test Set', '8')
+                    """
+                )
+                connection.commit()
+
+            identifiers_payload = {
+                "meta": {"date": "2026-04-12"},
+                "data": {
+                    "uuid-gzip": {
+                        "identifiers": {
+                            "scryfallId": "card-gzip",
+                            "tcgplayerProductId": "8001",
+                        }
+                    }
+                },
+            }
+            with gzip.open(identifiers_path, mode="wt", encoding="utf-8") as handle:
+                json.dump(identifiers_payload, handle)
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_identifiers
+
+            stats = import_mtgjson_identifiers(db_path, identifiers_path)
+
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    """
+                    SELECT mtgjson_uuid, tcgplayer_product_id
+                    FROM mtg_cards
+                    WHERE scryfall_id = 'card-gzip'
+                    """
+                ).fetchone()
+
+            self.assertEqual(1, stats.rows_seen)
+            self.assertEqual(1, stats.rows_written)
+            self.assertEqual(0, stats.rows_skipped)
+            self.assertEqual(("uuid-gzip", "8001"), (row["mtgjson_uuid"], row["tcgplayer_product_id"]))
+
     def test_import_mtgjson_prices_skips_non_usd_provider_payloads(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "collection.db"
@@ -767,6 +847,69 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(1, stats.rows_written)
             self.assertEqual(0, stats.rows_skipped)
             self.assertEqual([("normal", 3.5)], [(row["finish"], row["price_value"]) for row in rows])
+
+    def test_import_mtgjson_prices_accepts_gzip_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            prices_path = Path(tmp_dir) / "prices.json.gz"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        mtgjson_uuid,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('card-gzip-price', 'oracle-gzip-price', 'uuid-gzip-price', 'Gzip Price Card', 'tst', 'Test Set', '9')
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
+                    VALUES ('uuid-gzip-price', 'card-gzip-price')
+                    """
+                )
+                connection.commit()
+
+            prices_payload = {
+                "meta": {"date": "2026-04-12"},
+                "data": {
+                    "uuid-gzip-price": {
+                        "paper": {
+                            "tcgplayer": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 9.75}},
+                            }
+                        }
+                    }
+                },
+            }
+            with gzip.open(prices_path, mode="wt", encoding="utf-8") as handle:
+                json.dump(prices_payload, handle)
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_prices
+
+            stats = import_mtgjson_prices(db_path, prices_path)
+
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    """
+                    SELECT provider, price_value
+                    FROM price_snapshots
+                    WHERE scryfall_id = 'card-gzip-price'
+                    """
+                ).fetchone()
+
+            self.assertEqual(1, stats.rows_seen)
+            self.assertEqual(1, stats.rows_written)
+            self.assertEqual(0, stats.rows_skipped)
+            self.assertEqual(("tcgplayer", 9.75), (row["provider"], row["price_value"]))
 
     def test_import_mtgjson_prices_unions_linked_uuid_provider_coverage(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1441,7 +1441,10 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(("sync_bulk", "failed"), (run_row["run_kind"], run_row["status"]))
             self.assertEqual(0, step_count)
             self.assertEqual(
-                [("scryfall_bulk", str((cache_dir / "scryfall_default_cards.json").resolve()))],
+                [
+                    ("scryfall_bulk", str((cache_dir / "scryfall_default_cards.json").resolve())),
+                    ("scryfall_bulk_metadata", str((cache_dir / "scryfall_bulk_metadata.json").resolve())),
+                ],
                 [(row["artifact_role"], row["local_path"]) for row in artifact_rows],
             )
 
@@ -1551,7 +1554,7 @@ class ImporterTest(RepoSmokeTestCase):
                 [(row["step_name"], row["status"]) for row in step_rows],
             )
             self.assertEqual(
-                ["mtgjson_identifiers", "mtgjson_prices", "scryfall_bulk"],
+                ["mtgjson_identifiers", "mtgjson_prices", "scryfall_bulk", "scryfall_bulk_metadata"],
                 [row["artifact_role"] for row in artifact_rows],
             )
 
@@ -1645,6 +1648,7 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertIn("import-scryfall: seen=1 written=1 skipped=0", sync_output)
             self.assertIn("import-identifiers: seen=1 written=1 skipped=0", sync_output)
             self.assertIn("import-prices: seen=1 written=1 skipped=0", sync_output)
+            self.assertTrue((cache_dir / "scryfall_bulk_metadata.json").exists())
             self.assertTrue((cache_dir / "scryfall_default_cards.json").exists())
             self.assertTrue((cache_dir / "AllIdentifiers.json.gz").exists())
             self.assertTrue((cache_dir / "AllPricesToday.json.gz").exists())
@@ -1692,7 +1696,7 @@ class ImporterTest(RepoSmokeTestCase):
                 [(row[0], row[1]) for row in sync_steps],
             )
             self.assertEqual(
-                ["mtgjson_identifiers", "mtgjson_prices", "scryfall_bulk"],
+                ["mtgjson_identifiers", "mtgjson_prices", "scryfall_bulk", "scryfall_bulk_metadata"],
                 [row[0] for row in artifacts],
             )
             self.assertTrue(all(row[1] for row in artifacts))
@@ -1751,6 +1755,7 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertIn("run_id:", sync_output)
             self.assertIn("import-scryfall: seen=1 written=1 skipped=0", sync_output)
             self.assertIn("elapsed:", sync_output)
+            self.assertTrue((cache_dir / "scryfall_bulk_metadata.json").exists())
             self.assertTrue((cache_dir / "scryfall_default_cards.json").exists())
 
             with connect(db_path) as connection:
@@ -1781,7 +1786,10 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(1, mtg_cards)
             self.assertEqual(("sync_scryfall", "succeeded"), (sync_run["run_kind"], sync_run["status"]))
             self.assertEqual([("import_scryfall", "succeeded")], [(row["step_name"], row["status"]) for row in sync_steps])
-            self.assertEqual(["scryfall_bulk"], [row["artifact_role"] for row in artifacts])
+            self.assertEqual(
+                ["scryfall_bulk", "scryfall_bulk_metadata"],
+                [row["artifact_role"] for row in artifacts],
+            )
 
     def test_sync_identifiers_downloads_and_imports_from_override_url(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1384,6 +1384,188 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertTrue(all(row["bytes_written"] > 0 for row in artifact_rows))
             self.assertTrue(all(row["sha256"] for row in artifact_rows))
 
+    def test_list_sync_runs_prints_human_friendly_history(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            scryfall_path = tmp / "scryfall.json"
+            identifiers_path = tmp / "identifiers.json"
+            prices_path = tmp / "prices.json"
+
+            scryfall_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "id": "history-card-1",
+                            "oracle_id": "history-oracle-1",
+                            "name": "History Test Card",
+                            "set": "hst",
+                            "set_name": "History Set",
+                            "collector_number": "1",
+                            "lang": "en",
+                            "rarity": "rare",
+                            "released_at": "2026-01-01",
+                            "colors": ["U"],
+                            "color_identity": ["U"],
+                            "finishes": ["nonfoil"],
+                            "legalities": {"commander": "legal"},
+                            "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            identifiers_path.write_text(
+                json.dumps(
+                    {
+                        "data": {
+                            "uuid-history-1": {
+                                "identifiers": {
+                                    "scryfallId": "history-card-1",
+                                    "tcgplayerProductId": "5101",
+                                }
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            prices_path.write_text(
+                json.dumps(
+                    {
+                        "data": {
+                            "uuid-history-1": {
+                                "paper": {
+                                    "tcgplayer": {
+                                        "currency": "USD",
+                                        "retail": {"normal": {"2026-03-27": 4.25}},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.run_importer(
+                "import-all",
+                "--db",
+                str(db_path),
+                "--scryfall-json",
+                str(scryfall_path),
+                "--identifiers-json",
+                str(identifiers_path),
+                "--prices-json",
+                str(prices_path),
+            )
+
+            history_output = self.run_importer(
+                "list-sync-runs",
+                "--db",
+                str(db_path),
+            )
+
+            self.assertIn("kind", history_output)
+            self.assertIn("import_all", history_output)
+            self.assertIn("succeeded", history_output)
+            self.assertIn("import_scryfall:succeeded", history_output)
+
+    def test_show_sync_run_prints_steps_artifacts_and_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            scryfall_path = tmp / "scryfall.json"
+            identifiers_path = tmp / "identifiers.json"
+            prices_path = tmp / "prices.json"
+
+            scryfall_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "id": "show-card-1",
+                            "oracle_id": "show-oracle-1",
+                            "name": "Show Test Card",
+                            "set": "shw",
+                            "set_name": "Show Set",
+                            "collector_number": "1",
+                            "lang": "en",
+                            "rarity": "rare",
+                            "released_at": "2026-01-01",
+                            "colors": ["R"],
+                            "color_identity": ["R"],
+                            "finishes": ["nonfoil"],
+                            "legalities": {"commander": "legal"},
+                            "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            identifiers_path.write_text(
+                json.dumps(
+                    {
+                        "data": {
+                            "uuid-show-1": {
+                                "identifiers": {
+                                    "scryfallId": "show-card-1",
+                                    "tcgplayerProductId": "5201",
+                                }
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            prices_path.write_text(
+                json.dumps(
+                    {
+                        "data": {
+                            "uuid-show-1": {
+                                "paper": {
+                                    "tcgplayer": {
+                                        "currency": "USD",
+                                        "retail": {"normal": {"2026-03-27": 5.0}},
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.run_importer(
+                "import-all",
+                "--db",
+                str(db_path),
+                "--scryfall-json",
+                str(scryfall_path),
+                "--identifiers-json",
+                str(identifiers_path),
+                "--prices-json",
+                str(prices_path),
+            )
+
+            with connect(db_path) as connection:
+                run_id = connection.execute("SELECT id FROM sync_runs ORDER BY id DESC LIMIT 1").fetchone()[0]
+
+            report_output = self.run_importer(
+                "show-sync-run",
+                "--db",
+                str(db_path),
+                "--run-id",
+                str(run_id),
+            )
+
+            self.assertIn(f"sync run {run_id}", report_output)
+            self.assertIn("summary:", report_output)
+            self.assertIn("steps:", report_output)
+            self.assertIn("artifacts:", report_output)
+            self.assertIn("issues:", report_output)
+            self.assertIn("import_identifiers", report_output)
+            self.assertIn("mtgjson_identifiers", report_output)
+
     def test_import_all_records_failed_sync_run_when_late_step_errors(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp = Path(tmp_dir)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -659,12 +659,64 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(1, second_stats.rows_seen)
             self.assertEqual(0, second_stats.rows_written)
             self.assertEqual(0, second_stats.rows_skipped)
-            self.assertEqual(
-                {"matched_cards": 1, "staged_link_rows": 1, "changed_cards": 0, "no_op_cards": 1, "link_rows_written": 0},
-                second_stats.details,
-            )
+            self.assertEqual(1, second_stats.details["matched_cards"])
+            self.assertEqual(1, second_stats.details["staged_link_rows"])
+            self.assertEqual(0, second_stats.details["changed_cards"])
+            self.assertEqual(1, second_stats.details["no_op_cards"])
+            self.assertEqual(0, second_stats.details["link_rows_written"])
+            self.assertIn("phase_seconds", second_stats.details)
+            self.assertIn("import_total_seconds", second_stats.details)
             self.assertEqual(("uuid-noop", "7001", "2000-01-01 00:00:00"), tuple(row))
             self.assertEqual(1, link_count)
+
+    def test_import_mtgjson_identifiers_reports_phase_timings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            identifiers_path = Path(tmp_dir) / "identifiers.json"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('card-phases', 'oracle-phases', 'Phase Card', 'tst', 'Test Set', '70')
+                    """
+                )
+                connection.commit()
+
+            identifiers_payload = {
+                "data": {
+                    "uuid-phases": {
+                        "identifiers": {
+                            "scryfallId": "card-phases",
+                            "tcgplayerProductId": "7002",
+                        }
+                    }
+                }
+            }
+            identifiers_path.write_text(json.dumps(identifiers_payload), encoding="utf-8")
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_identifiers
+
+            stats = import_mtgjson_identifiers(db_path, identifiers_path)
+
+            self.assertEqual(1, stats.rows_written)
+            self.assertIsInstance(stats.details["import_total_seconds"], float)
+            self.assertGreaterEqual(stats.details["import_total_seconds"], 0.0)
+            self.assertEqual(
+                {"preload", "scan", "merge", "stage", "detect_changes", "write"},
+                set(stats.details["phase_seconds"]),
+            )
+            for value in stats.details["phase_seconds"].values():
+                self.assertIsInstance(value, float)
+                self.assertGreaterEqual(value, 0.0)
 
     def test_iter_json_object_items_reads_gzip_data_object(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1071,6 +1123,9 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(2, stats.rows_seen)
             self.assertEqual(1, stats.rows_written)
             self.assertEqual(0, stats.rows_skipped)
+            self.assertEqual(1, stats.details["conflict_rows"])
+            self.assertEqual(1, stats.details["merged_price_rows"])
+            self.assertEqual({"preload", "scan", "write"}, set(stats.details["phase_seconds"]))
             self.assertEqual(("tcgplayer", 2.25), (row["provider"], row["price_value"]))
 
     def test_import_all_records_sync_run_steps_and_artifacts(self) -> None:
@@ -1151,7 +1206,7 @@ class ImporterTest(RepoSmokeTestCase):
                 ).fetchone()
                 step_rows = connection.execute(
                     """
-                    SELECT step_name, status, rows_seen, rows_written, rows_skipped
+                    SELECT step_name, status, rows_seen, rows_written, rows_skipped, details_json
                     FROM sync_run_steps
                     ORDER BY id
                     """
@@ -1192,6 +1247,10 @@ class ImporterTest(RepoSmokeTestCase):
                     for row in step_rows
                 ],
             )
+            for row in step_rows:
+                details = json.loads(row["details_json"])
+                self.assertIn("elapsed_seconds", details)
+                self.assertGreaterEqual(details["elapsed_seconds"], 0.0)
             self.assertEqual(
                 ["mtgjson_identifiers", "mtgjson_prices", "scryfall_json"],
                 [row["artifact_role"] for row in artifact_rows],
@@ -1691,6 +1750,7 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertIn("sync-scryfall completed", sync_output)
             self.assertIn("run_id:", sync_output)
             self.assertIn("import-scryfall: seen=1 written=1 skipped=0", sync_output)
+            self.assertIn("elapsed:", sync_output)
             self.assertTrue((cache_dir / "scryfall_default_cards.json").exists())
 
             with connect(db_path) as connection:
@@ -1773,6 +1833,8 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertIn("sync-identifiers completed", sync_output)
             self.assertIn("run_id:", sync_output)
             self.assertIn("import-identifiers: seen=1 written=1 skipped=0", sync_output)
+            self.assertIn("phases:", sync_output)
+            self.assertIn("details: matched_cards=1 changed_cards=1", sync_output)
             self.assertTrue((cache_dir / "AllIdentifiers.json.gz").exists())
 
             with connect(db_path) as connection:
@@ -1872,6 +1934,7 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertIn("sync-prices completed", sync_output)
             self.assertIn("run_id:", sync_output)
             self.assertIn("import-prices: seen=1 written=1 skipped=0", sync_output)
+            self.assertIn("phases:", sync_output)
             self.assertTrue((cache_dir / "AllPricesToday.json.gz").exists())
 
             with connect(db_path) as connection:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -590,6 +590,82 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(0, stats.rows_skipped)
             self.assertEqual(("uuid-known", "999"), (row["mtgjson_uuid"], row["tcgplayer_product_id"]))
 
+    def test_import_mtgjson_identifiers_skips_no_op_card_updates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            identifiers_path = Path(tmp_dir) / "identifiers.json"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('card-noop', 'oracle-noop', 'No-Op Card', 'tst', 'Test Set', '7')
+                    """
+                )
+                connection.commit()
+
+            identifiers_payload = {
+                "data": {
+                    "uuid-noop": {
+                        "identifiers": {
+                            "scryfallId": "card-noop",
+                            "tcgplayerProductId": "7001",
+                        }
+                    }
+                }
+            }
+            identifiers_path.write_text(json.dumps(identifiers_payload), encoding="utf-8")
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_identifiers
+
+            first_stats = import_mtgjson_identifiers(db_path, identifiers_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    UPDATE mtg_cards
+                    SET updated_at = '2000-01-01 00:00:00'
+                    WHERE scryfall_id = 'card-noop'
+                    """
+                )
+                connection.commit()
+
+            second_stats = import_mtgjson_identifiers(db_path, identifiers_path)
+
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    """
+                    SELECT mtgjson_uuid, tcgplayer_product_id, updated_at
+                    FROM mtg_cards
+                    WHERE scryfall_id = 'card-noop'
+                    """
+                ).fetchone()
+                link_count = connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM mtgjson_card_links
+                    WHERE scryfall_id = 'card-noop'
+                    """
+                ).fetchone()[0]
+
+            self.assertEqual(1, first_stats.rows_written)
+            self.assertEqual(1, second_stats.rows_seen)
+            self.assertEqual(0, second_stats.rows_written)
+            self.assertEqual(0, second_stats.rows_skipped)
+            self.assertEqual(
+                {"matched_cards": 1, "staged_link_rows": 1, "changed_cards": 0, "no_op_cards": 1, "link_rows_written": 0},
+                second_stats.details,
+            )
+            self.assertEqual(("uuid-noop", "7001", "2000-01-01 00:00:00"), tuple(row))
+            self.assertEqual(1, link_count)
+
     def test_import_mtgjson_prices_skips_non_usd_provider_payloads(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "collection.db"
@@ -1080,6 +1156,201 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(
                 ("error", "ValueError", "Expected MTGJSON prices to contain an object at payload['data']."),
                 (issue_row["level"], issue_row["code"], issue_row["message"]),
+            )
+
+    def test_sync_bulk_records_partial_artifacts_when_download_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            metadata_path = tmp / "scryfall_bulk_metadata.json"
+            scryfall_bulk_path = tmp / "default_cards.json"
+            missing_identifiers_path = tmp / "missing-identifiers.json.gz"
+            prices_path = tmp / "AllPricesToday.json.gz"
+
+            scryfall_payload = [
+                {
+                    "id": "sync-download-fail-1",
+                    "oracle_id": "sync-download-fail-oracle-1",
+                    "name": "Sync Download Failure Card",
+                    "set": "syn",
+                    "set_name": "Sync Set",
+                    "collector_number": "90",
+                    "lang": "en",
+                    "rarity": "rare",
+                    "released_at": "2026-01-01",
+                    "colors": ["U"],
+                    "color_identity": ["U"],
+                    "finishes": ["nonfoil"],
+                    "legalities": {"commander": "legal"},
+                    "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                }
+            ]
+            metadata_payload = {
+                "data": [
+                    {
+                        "type": "default_cards",
+                        "download_uri": scryfall_bulk_path.as_uri(),
+                    }
+                ]
+            }
+            prices_payload = {"data": {}}
+
+            scryfall_bulk_path.write_text(json.dumps(scryfall_payload), encoding="utf-8")
+            metadata_path.write_text(json.dumps(metadata_payload), encoding="utf-8")
+            with gzip.open(prices_path, "wt", encoding="utf-8") as handle:
+                json.dump(prices_payload, handle)
+
+            result = self.run_failing_importer(
+                "sync-bulk",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--scryfall-metadata-url",
+                metadata_path.as_uri(),
+                "--mtgjson-identifiers-url",
+                missing_identifiers_path.as_uri(),
+                "--mtgjson-prices-url",
+                prices_path.as_uri(),
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertTrue(db_path.exists())
+
+            with connect(db_path) as connection:
+                run_row = connection.execute(
+                    """
+                    SELECT run_kind, status
+                    FROM sync_runs
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                step_count = connection.execute("SELECT COUNT(*) FROM sync_run_steps").fetchone()[0]
+                artifact_rows = connection.execute(
+                    """
+                    SELECT artifact_role, local_path
+                    FROM sync_run_artifacts
+                    ORDER BY artifact_role
+                    """
+                ).fetchall()
+
+            self.assertEqual(("sync_bulk", "failed"), (run_row["run_kind"], run_row["status"]))
+            self.assertEqual(0, step_count)
+            self.assertEqual(
+                [("scryfall_bulk", str((cache_dir / "scryfall_default_cards.json").resolve()))],
+                [(row["artifact_role"], row["local_path"]) for row in artifact_rows],
+            )
+
+    def test_sync_bulk_records_failed_import_step_when_late_stage_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            metadata_path = tmp / "scryfall_bulk_metadata.json"
+            scryfall_bulk_path = tmp / "default_cards.json"
+            identifiers_path = tmp / "AllIdentifiers.json.gz"
+            prices_path = tmp / "AllPricesToday.json.gz"
+
+            scryfall_payload = [
+                {
+                    "id": "sync-fail-1",
+                    "oracle_id": "sync-fail-oracle-1",
+                    "name": "Sync Failure Card",
+                    "set": "syn",
+                    "set_name": "Sync Set",
+                    "collector_number": "91",
+                    "lang": "en",
+                    "rarity": "rare",
+                    "released_at": "2026-01-01",
+                    "colors": ["U"],
+                    "color_identity": ["U"],
+                    "finishes": ["nonfoil"],
+                    "legalities": {"commander": "legal"},
+                    "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                }
+            ]
+            identifiers_payload = {
+                "data": {
+                    "uuid-sync-fail-1": {
+                        "identifiers": {
+                            "scryfallId": "sync-fail-1",
+                            "tcgplayerProductId": "901",
+                        }
+                    }
+                }
+            }
+            prices_payload = {"data": []}
+            metadata_payload = {
+                "data": [
+                    {
+                        "type": "default_cards",
+                        "download_uri": scryfall_bulk_path.as_uri(),
+                    }
+                ]
+            }
+
+            scryfall_bulk_path.write_text(json.dumps(scryfall_payload), encoding="utf-8")
+            metadata_path.write_text(json.dumps(metadata_payload), encoding="utf-8")
+            with gzip.open(identifiers_path, "wt", encoding="utf-8") as handle:
+                json.dump(identifiers_payload, handle)
+            with gzip.open(prices_path, "wt", encoding="utf-8") as handle:
+                json.dump(prices_payload, handle)
+
+            result = self.run_failing_importer(
+                "sync-bulk",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--scryfall-metadata-url",
+                metadata_path.as_uri(),
+                "--mtgjson-identifiers-url",
+                identifiers_path.as_uri(),
+                "--mtgjson-prices-url",
+                prices_path.as_uri(),
+            )
+
+            self.assertEqual(2, result.returncode)
+            self.assertIn("Expected MTGJSON prices to contain an object", result.stderr)
+
+            with connect(db_path) as connection:
+                run_row = connection.execute(
+                    """
+                    SELECT run_kind, status
+                    FROM sync_runs
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                step_rows = connection.execute(
+                    """
+                    SELECT step_name, status
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+                artifact_rows = connection.execute(
+                    """
+                    SELECT artifact_role
+                    FROM sync_run_artifacts
+                    ORDER BY artifact_role
+                    """
+                ).fetchall()
+
+            self.assertEqual(("sync_bulk", "failed"), (run_row["run_kind"], run_row["status"]))
+            self.assertEqual(
+                [
+                    ("import_scryfall", "succeeded"),
+                    ("import_identifiers", "succeeded"),
+                    ("import_prices", "failed"),
+                ],
+                [(row["step_name"], row["status"]) for row in step_rows],
+            )
+            self.assertEqual(
+                ["mtgjson_identifiers", "mtgjson_prices", "scryfall_bulk"],
+                [row["artifact_role"] for row in artifact_rows],
             )
 
     def test_sync_bulk_downloads_and_imports_from_override_urls(self) -> None:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -442,6 +442,154 @@ class ImporterTest(RepoSmokeTestCase):
                 self.assertEqual(layout, row["layout"])
                 self.assertEqual(1, row["is_default_add_searchable"])
 
+    def test_import_mtgjson_identifiers_merges_duplicate_scryfall_rows_and_links_all_uuids(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            identifiers_path = Path(tmp_dir) / "identifiers.json"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('card-1', 'oracle-1', 'Front // Back', 'tst', 'Test Set', '1')
+                    """
+                )
+                connection.commit()
+
+            identifiers_payload = {
+                "data": {
+                    "uuid-back": {
+                        "name": "Front // Back",
+                        "side": "b",
+                        "identifiers": {
+                            "scryfallId": "card-1",
+                            "cardKingdomId": "202",
+                            "mcmId": "303",
+                            "cardsphereId": "404",
+                        },
+                    },
+                    "uuid-front": {
+                        "name": "Front // Back",
+                        "side": "a",
+                        "identifiers": {
+                            "scryfallId": "card-1",
+                            "tcgplayerProductId": "101",
+                        },
+                    },
+                }
+            }
+            identifiers_path.write_text(json.dumps(identifiers_payload), encoding="utf-8")
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_identifiers
+
+            stats = import_mtgjson_identifiers(db_path, identifiers_path)
+
+            with connect(db_path) as connection:
+                card_row = connection.execute(
+                    """
+                    SELECT
+                        mtgjson_uuid,
+                        tcgplayer_product_id,
+                        cardkingdom_id,
+                        cardmarket_id,
+                        cardsphere_id
+                    FROM mtg_cards
+                    WHERE scryfall_id = 'card-1'
+                    """
+                ).fetchone()
+                link_rows = connection.execute(
+                    """
+                    SELECT mtgjson_uuid, scryfall_id
+                    FROM mtgjson_card_links
+                    ORDER BY mtgjson_uuid
+                    """
+                ).fetchall()
+
+            self.assertEqual(2, stats.rows_seen)
+            self.assertEqual(1, stats.rows_written)
+            self.assertEqual(0, stats.rows_skipped)
+            self.assertEqual(
+                ("uuid-back", "101", "202", "303", "404"),
+                (
+                    card_row["mtgjson_uuid"],
+                    card_row["tcgplayer_product_id"],
+                    card_row["cardkingdom_id"],
+                    card_row["cardmarket_id"],
+                    card_row["cardsphere_id"],
+                ),
+            )
+            self.assertEqual(
+                [("uuid-back", "card-1"), ("uuid-front", "card-1")],
+                [(row["mtgjson_uuid"], row["scryfall_id"]) for row in link_rows],
+            )
+
+    def test_import_mtgjson_identifiers_can_match_known_uuid_without_scryfall_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            identifiers_path = Path(tmp_dir) / "identifiers.json"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        mtgjson_uuid,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('card-2', 'oracle-2', 'uuid-known', 'Known UUID Card', 'tst', 'Test Set', '2')
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
+                    VALUES ('uuid-known', 'card-2')
+                    """
+                )
+                connection.commit()
+
+            identifiers_payload = {
+                "data": {
+                    "uuid-known": {
+                        "name": "Known UUID Card",
+                        "identifiers": {
+                            "tcgplayerProductId": "999",
+                        },
+                    }
+                }
+            }
+            identifiers_path.write_text(json.dumps(identifiers_payload), encoding="utf-8")
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_identifiers
+
+            stats = import_mtgjson_identifiers(db_path, identifiers_path)
+
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    """
+                    SELECT mtgjson_uuid, tcgplayer_product_id
+                    FROM mtg_cards
+                    WHERE scryfall_id = 'card-2'
+                    """
+                ).fetchone()
+
+            self.assertEqual(1, stats.rows_seen)
+            self.assertEqual(1, stats.rows_written)
+            self.assertEqual(0, stats.rows_skipped)
+            self.assertEqual(("uuid-known", "999"), (row["mtgjson_uuid"], row["tcgplayer_product_id"]))
+
     def test_import_mtgjson_prices_skips_non_usd_provider_payloads(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "collection.db"

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -692,6 +692,168 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual(0, stats.rows_skipped)
             self.assertEqual([("normal", 3.5)], [(row["finish"], row["price_value"]) for row in rows])
 
+    def test_import_mtgjson_prices_unions_linked_uuid_provider_coverage(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            prices_path = Path(tmp_dir) / "prices.json"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        mtgjson_uuid,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('card-3', 'oracle-3', 'uuid-primary', 'Union Price Test', 'tst', 'Test Set', '3')
+                    """
+                )
+                connection.executemany(
+                    """
+                    INSERT INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
+                    VALUES (?, 'card-3')
+                    """,
+                    [
+                        ("uuid-primary",),
+                        ("uuid-secondary",),
+                    ],
+                )
+                connection.commit()
+
+            prices_payload = {
+                "data": {
+                    "uuid-secondary": {
+                        "paper": {
+                            "tcgplayer": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 3.50}},
+                            }
+                        }
+                    },
+                    "uuid-primary": {
+                        "paper": {
+                            "cardkingdom": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 4.25}},
+                            },
+                            "tcgplayer": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 3.50}},
+                            },
+                        }
+                    },
+                }
+            }
+            prices_path.write_text(json.dumps(prices_payload), encoding="utf-8")
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_prices
+
+            stats = import_mtgjson_prices(db_path, prices_path)
+
+            with connect(db_path) as connection:
+                rows = connection.execute(
+                    """
+                    SELECT provider, price_value
+                    FROM price_snapshots
+                    WHERE scryfall_id = 'card-3'
+                    ORDER BY provider
+                    """
+                ).fetchall()
+
+            self.assertEqual(2, stats.rows_seen)
+            self.assertEqual(2, stats.rows_written)
+            self.assertEqual(0, stats.rows_skipped)
+            self.assertEqual(
+                [("cardkingdom", 4.25), ("tcgplayer", 3.5)],
+                [(row["provider"], row["price_value"]) for row in rows],
+            )
+
+    def test_import_mtgjson_prices_prefers_compatibility_uuid_on_conflicting_values(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            prices_path = Path(tmp_dir) / "prices.json"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        mtgjson_uuid,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES (
+                        'card-4',
+                        'oracle-4',
+                        'uuid-preferred',
+                        'Conflict Price Test',
+                        'tst',
+                        'Test Set',
+                        '4'
+                    )
+                    """
+                )
+                connection.executemany(
+                    """
+                    INSERT INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
+                    VALUES (?, 'card-4')
+                    """,
+                    [
+                        ("uuid-alt",),
+                        ("uuid-preferred",),
+                    ],
+                )
+                connection.commit()
+
+            prices_payload = {
+                "data": {
+                    "uuid-alt": {
+                        "paper": {
+                            "tcgplayer": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 1.50}},
+                            }
+                        }
+                    },
+                    "uuid-preferred": {
+                        "paper": {
+                            "tcgplayer": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 2.25}},
+                            }
+                        }
+                    },
+                }
+            }
+            prices_path.write_text(json.dumps(prices_payload), encoding="utf-8")
+
+            from mtg_source_stack.importer.mtgjson import import_mtgjson_prices
+
+            stats = import_mtgjson_prices(db_path, prices_path)
+
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    """
+                    SELECT provider, price_value
+                    FROM price_snapshots
+                    WHERE scryfall_id = 'card-4'
+                    """
+                ).fetchone()
+
+            self.assertEqual(2, stats.rows_seen)
+            self.assertEqual(1, stats.rows_written)
+            self.assertEqual(0, stats.rows_skipped)
+            self.assertEqual(("tcgplayer", 2.25), (row["provider"], row["price_value"]))
+
     def test_sync_bulk_downloads_and_imports_from_override_urls(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp = Path(tmp_dir)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1497,6 +1497,276 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertTrue(all(row[2] > 0 for row in artifacts))
             self.assertTrue(all(row[3] for row in artifacts))
 
+    def test_sync_scryfall_downloads_and_imports_from_override_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            metadata_path = tmp / "scryfall_bulk_metadata.json"
+            scryfall_bulk_path = tmp / "default_cards.json"
+
+            scryfall_payload = [
+                {
+                    "id": "sync-scryfall-1",
+                    "oracle_id": "sync-scryfall-oracle-1",
+                    "name": "Sync Scryfall Card",
+                    "set": "syn",
+                    "set_name": "Sync Set",
+                    "collector_number": "100",
+                    "lang": "en",
+                    "rarity": "rare",
+                    "released_at": "2026-01-01",
+                    "colors": ["U"],
+                    "color_identity": ["U"],
+                    "finishes": ["nonfoil"],
+                    "legalities": {"commander": "legal"},
+                    "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                }
+            ]
+            metadata_payload = {
+                "data": [
+                    {
+                        "type": "default_cards",
+                        "download_uri": scryfall_bulk_path.as_uri(),
+                    }
+                ]
+            }
+
+            scryfall_bulk_path.write_text(json.dumps(scryfall_payload), encoding="utf-8")
+            metadata_path.write_text(json.dumps(metadata_payload), encoding="utf-8")
+
+            sync_output = self.run_importer(
+                "sync-scryfall",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--scryfall-metadata-url",
+                metadata_path.as_uri(),
+            )
+
+            self.assertIn("sync-scryfall completed", sync_output)
+            self.assertIn("run_id:", sync_output)
+            self.assertIn("import-scryfall: seen=1 written=1 skipped=0", sync_output)
+            self.assertTrue((cache_dir / "scryfall_default_cards.json").exists())
+
+            with connect(db_path) as connection:
+                mtg_cards = connection.execute("SELECT COUNT(*) FROM mtg_cards").fetchone()[0]
+                sync_run = connection.execute(
+                    """
+                    SELECT run_kind, status
+                    FROM sync_runs
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                sync_steps = connection.execute(
+                    """
+                    SELECT step_name, status
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+                artifacts = connection.execute(
+                    """
+                    SELECT artifact_role
+                    FROM sync_run_artifacts
+                    ORDER BY artifact_role
+                    """
+                ).fetchall()
+
+            self.assertEqual(1, mtg_cards)
+            self.assertEqual(("sync_scryfall", "succeeded"), (sync_run["run_kind"], sync_run["status"]))
+            self.assertEqual([("import_scryfall", "succeeded")], [(row["step_name"], row["status"]) for row in sync_steps])
+            self.assertEqual(["scryfall_bulk"], [row["artifact_role"] for row in artifacts])
+
+    def test_sync_identifiers_downloads_and_imports_from_override_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            identifiers_path = tmp / "AllIdentifiers.json.gz"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('sync-identifiers-1', 'oracle-sync-identifiers-1', 'Sync Identifiers Card', 'syn', 'Sync Set', '101')
+                    """
+                )
+                connection.commit()
+
+            identifiers_payload = {
+                "data": {
+                    "uuid-sync-identifiers-1": {
+                        "identifiers": {
+                            "scryfallId": "sync-identifiers-1",
+                            "tcgplayerProductId": "10101",
+                        }
+                    }
+                }
+            }
+            with gzip.open(identifiers_path, "wt", encoding="utf-8") as handle:
+                json.dump(identifiers_payload, handle)
+
+            sync_output = self.run_importer(
+                "sync-identifiers",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--mtgjson-identifiers-url",
+                identifiers_path.as_uri(),
+            )
+
+            self.assertIn("sync-identifiers completed", sync_output)
+            self.assertIn("run_id:", sync_output)
+            self.assertIn("import-identifiers: seen=1 written=1 skipped=0", sync_output)
+            self.assertTrue((cache_dir / "AllIdentifiers.json.gz").exists())
+
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    """
+                    SELECT mtgjson_uuid, tcgplayer_product_id
+                    FROM mtg_cards
+                    WHERE scryfall_id = 'sync-identifiers-1'
+                    """
+                ).fetchone()
+                sync_run = connection.execute(
+                    """
+                    SELECT run_kind, status
+                    FROM sync_runs
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                sync_steps = connection.execute(
+                    """
+                    SELECT step_name, status
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+                artifacts = connection.execute(
+                    """
+                    SELECT artifact_role
+                    FROM sync_run_artifacts
+                    ORDER BY artifact_role
+                    """
+                ).fetchall()
+
+            self.assertEqual(("uuid-sync-identifiers-1", "10101"), (row["mtgjson_uuid"], row["tcgplayer_product_id"]))
+            self.assertEqual(("sync_identifiers", "succeeded"), (sync_run["run_kind"], sync_run["status"]))
+            self.assertEqual([("import_identifiers", "succeeded")], [(row["step_name"], row["status"]) for row in sync_steps])
+            self.assertEqual(["mtgjson_identifiers"], [row["artifact_role"] for row in artifacts])
+
+    def test_sync_prices_downloads_and_imports_from_override_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            prices_path = tmp / "AllPricesToday.json.gz"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        mtgjson_uuid,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('sync-prices-1', 'oracle-sync-prices-1', 'uuid-sync-prices-1', 'Sync Prices Card', 'syn', 'Sync Set', '102')
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
+                    VALUES ('uuid-sync-prices-1', 'sync-prices-1')
+                    """
+                )
+                connection.commit()
+
+            prices_payload = {
+                "data": {
+                    "uuid-sync-prices-1": {
+                        "paper": {
+                            "tcgplayer": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 11.25}},
+                            }
+                        }
+                    }
+                }
+            }
+            with gzip.open(prices_path, "wt", encoding="utf-8") as handle:
+                json.dump(prices_payload, handle)
+
+            sync_output = self.run_importer(
+                "sync-prices",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--source-name",
+                "custom_sync_prices",
+                "--mtgjson-prices-url",
+                prices_path.as_uri(),
+            )
+
+            self.assertIn("sync-prices completed", sync_output)
+            self.assertIn("run_id:", sync_output)
+            self.assertIn("import-prices: seen=1 written=1 skipped=0", sync_output)
+            self.assertTrue((cache_dir / "AllPricesToday.json.gz").exists())
+
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    """
+                    SELECT provider, price_value, source_name
+                    FROM price_snapshots
+                    WHERE scryfall_id = 'sync-prices-1'
+                    """
+                ).fetchone()
+                sync_run = connection.execute(
+                    """
+                    SELECT run_kind, status
+                    FROM sync_runs
+                    ORDER BY id DESC
+                    LIMIT 1
+                    """
+                ).fetchone()
+                sync_steps = connection.execute(
+                    """
+                    SELECT step_name, status
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+                artifacts = connection.execute(
+                    """
+                    SELECT artifact_role
+                    FROM sync_run_artifacts
+                    ORDER BY artifact_role
+                    """
+                ).fetchall()
+
+            self.assertEqual(("tcgplayer", 11.25, "custom_sync_prices"), (row["provider"], row["price_value"], row["source_name"]))
+            self.assertEqual(("sync_prices", "succeeded"), (sync_run["run_kind"], sync_run["status"]))
+            self.assertEqual([("import_prices", "succeeded")], [(row["step_name"], row["status"]) for row in sync_steps])
+            self.assertEqual(["mtgjson_prices"], [row["artifact_role"] for row in artifacts])
+
     def test_remove_card_creates_snapshot_and_restore_snapshot_recovers_inventory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp = Path(tmp_dir)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -7,6 +7,7 @@ import json
 import sqlite3
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from mtg_source_stack.db.connection import SQLITE_BUSY_TIMEOUT_MS, connect
 from tests.common import RepoSmokeTestCase
@@ -1790,6 +1791,74 @@ class ImporterTest(RepoSmokeTestCase):
                 ["scryfall_bulk", "scryfall_bulk_metadata"],
                 [row["artifact_role"] for row in artifacts],
             )
+
+    def test_sync_scryfall_ignores_stale_bulk_validators_when_resolved_url_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            cache_dir = tmp / "cache"
+            metadata_path = cache_dir / "scryfall_bulk_metadata.json"
+            bulk_path = cache_dir / "scryfall_default_cards.json"
+            metadata_path.parent.mkdir(parents=True, exist_ok=True)
+            metadata_path.write_text("{}", encoding="utf-8")
+            bulk_path.write_text("[]", encoding="utf-8")
+
+            from mtg_source_stack.importer.service import DownloadResult, ImportStats, sync_scryfall
+
+            metadata_download = DownloadResult(
+                label="scryfall_bulk_metadata.json",
+                url="https://metadata.example.test/bulk-data",
+                path=metadata_path,
+                bytes_written=2,
+                sha256="meta",
+                etag="meta-etag",
+                last_modified="meta-last",
+                downloaded=True,
+            )
+            bulk_download = DownloadResult(
+                label="scryfall_default_cards.json",
+                url="https://data.example.test/default-cards-new.json",
+                path=bulk_path,
+                bytes_written=2,
+                sha256="bulk",
+                etag="bulk-etag",
+                last_modified="bulk-last",
+                downloaded=True,
+            )
+            bulk_download_kwargs: dict[str, str | None] = {}
+
+            def fake_download(
+                url: str,
+                destination: str | Path,
+                *,
+                on_download=None,
+                if_none_match: str | None = None,
+                if_modified_since: str | None = None,
+            ):
+                self.assertEqual("https://data.example.test/default-cards-new.json", url)
+                bulk_download_kwargs["if_none_match"] = if_none_match
+                bulk_download_kwargs["if_modified_since"] = if_modified_since
+                return bulk_download
+
+            with patch(
+                "mtg_source_stack.importer.service._download_scryfall_metadata",
+                return_value=(metadata_download, "https://data.example.test/default-cards-new.json"),
+            ), patch(
+                "mtg_source_stack.importer.service._download_sync_artifact",
+                side_effect=fake_download,
+            ), patch(
+                "mtg_source_stack.importer.scryfall.import_scryfall_cards",
+                return_value=ImportStats(rows_seen=1, rows_written=1),
+            ):
+                result = sync_scryfall(
+                    tmp / "collection.db",
+                    cache_dir=cache_dir,
+                    bulk_hint_url="https://data.example.test/default-cards-old.json",
+                    bulk_if_none_match="old-etag",
+                    bulk_if_modified_since="old-last",
+                )
+
+            self.assertEqual({"if_none_match": None, "if_modified_since": None}, bulk_download_kwargs)
+            self.assertEqual(1, result["scryfall_stats"].rows_written)
 
     def test_sync_identifiers_downloads_and_imports_from_override_url(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -1767,6 +1767,356 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual([("import_prices", "succeeded")], [(row["step_name"], row["status"]) for row in sync_steps])
             self.assertEqual(["mtgjson_prices"], [row["artifact_role"] for row in artifacts])
 
+    def test_sync_scryfall_skips_unchanged_artifact_on_repeat_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            metadata_path = tmp / "scryfall_bulk_metadata.json"
+            scryfall_bulk_path = tmp / "default_cards.json"
+
+            scryfall_payload = [
+                {
+                    "id": "sync-scryfall-repeat-1",
+                    "oracle_id": "sync-scryfall-repeat-oracle-1",
+                    "name": "Repeat Sync Scryfall Card",
+                    "set": "syn",
+                    "set_name": "Sync Set",
+                    "collector_number": "110",
+                    "lang": "en",
+                    "rarity": "rare",
+                    "released_at": "2026-01-01",
+                    "colors": ["U"],
+                    "color_identity": ["U"],
+                    "finishes": ["nonfoil"],
+                    "legalities": {"commander": "legal"},
+                    "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                }
+            ]
+            metadata_payload = {
+                "data": [
+                    {
+                        "type": "default_cards",
+                        "download_uri": scryfall_bulk_path.as_uri(),
+                    }
+                ]
+            }
+
+            scryfall_bulk_path.write_text(json.dumps(scryfall_payload), encoding="utf-8")
+            metadata_path.write_text(json.dumps(metadata_payload), encoding="utf-8")
+
+            self.run_importer(
+                "sync-scryfall",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--scryfall-metadata-url",
+                metadata_path.as_uri(),
+            )
+            second_output = self.run_importer(
+                "sync-scryfall",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--scryfall-metadata-url",
+                metadata_path.as_uri(),
+            )
+
+            self.assertIn("artifact unchanged since run 1", second_output)
+            with connect(db_path) as connection:
+                step_rows = connection.execute(
+                    """
+                    SELECT step_name, status
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+
+            self.assertEqual(
+                [("import_scryfall", "succeeded"), ("import_scryfall", "skipped")],
+                [(row["step_name"], row["status"]) for row in step_rows],
+            )
+
+    def test_sync_identifiers_skips_unchanged_artifact_on_repeat_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            identifiers_path = tmp / "AllIdentifiers.json.gz"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('sync-identifiers-repeat-1', 'oracle-sync-identifiers-repeat-1', 'Repeat Sync Identifiers Card', 'syn', 'Sync Set', '111')
+                    """
+                )
+                connection.commit()
+
+            identifiers_payload = {
+                "data": {
+                    "uuid-sync-identifiers-repeat-1": {
+                        "identifiers": {
+                            "scryfallId": "sync-identifiers-repeat-1",
+                            "tcgplayerProductId": "11101",
+                        }
+                    }
+                }
+            }
+            with gzip.open(identifiers_path, "wt", encoding="utf-8") as handle:
+                json.dump(identifiers_payload, handle)
+
+            self.run_importer(
+                "sync-identifiers",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--mtgjson-identifiers-url",
+                identifiers_path.as_uri(),
+            )
+            second_output = self.run_importer(
+                "sync-identifiers",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--mtgjson-identifiers-url",
+                identifiers_path.as_uri(),
+            )
+
+            self.assertIn("artifact unchanged since run 1", second_output)
+            with connect(db_path) as connection:
+                step_rows = connection.execute(
+                    """
+                    SELECT step_name, status
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+
+            self.assertEqual(
+                [("import_identifiers", "succeeded"), ("import_identifiers", "skipped")],
+                [(row["step_name"], row["status"]) for row in step_rows],
+            )
+
+    def test_sync_prices_skips_unchanged_artifact_on_repeat_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            prices_path = tmp / "AllPricesToday.json.gz"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        mtgjson_uuid,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES ('sync-prices-repeat-1', 'oracle-sync-prices-repeat-1', 'uuid-sync-prices-repeat-1', 'Repeat Sync Prices Card', 'syn', 'Sync Set', '112')
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO mtgjson_card_links (mtgjson_uuid, scryfall_id)
+                    VALUES ('uuid-sync-prices-repeat-1', 'sync-prices-repeat-1')
+                    """
+                )
+                connection.commit()
+
+            prices_payload = {
+                "data": {
+                    "uuid-sync-prices-repeat-1": {
+                        "paper": {
+                            "tcgplayer": {
+                                "currency": "USD",
+                                "retail": {"normal": {"2026-03-27": 12.25}},
+                            }
+                        }
+                    }
+                }
+            }
+            with gzip.open(prices_path, "wt", encoding="utf-8") as handle:
+                json.dump(prices_payload, handle)
+
+            self.run_importer(
+                "sync-prices",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--mtgjson-prices-url",
+                prices_path.as_uri(),
+            )
+            second_output = self.run_importer(
+                "sync-prices",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--mtgjson-prices-url",
+                prices_path.as_uri(),
+            )
+
+            self.assertIn("artifact unchanged since run 1", second_output)
+            with connect(db_path) as connection:
+                step_rows = connection.execute(
+                    """
+                    SELECT step_name, status
+                    FROM sync_run_steps
+                    ORDER BY id
+                    """
+                ).fetchall()
+
+            self.assertEqual(
+                [("import_prices", "succeeded"), ("import_prices", "skipped")],
+                [(row["step_name"], row["status"]) for row in step_rows],
+            )
+
+    def test_sync_identifiers_reimports_after_later_scryfall_sync_changes_catalog(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            db_path = tmp / "collection.db"
+            cache_dir = tmp / "cache"
+            metadata_path = tmp / "scryfall_bulk_metadata.json"
+            scryfall_bulk_path = tmp / "default_cards.json"
+            identifiers_path = tmp / "AllIdentifiers.json.gz"
+
+            initial_scryfall_payload = [
+                {
+                    "id": "sync-identifiers-dependency-1",
+                    "oracle_id": "oracle-sync-identifiers-dependency-1",
+                    "name": "Dependency Card One",
+                    "set": "syn",
+                    "set_name": "Sync Set",
+                    "collector_number": "113",
+                    "lang": "en",
+                    "rarity": "rare",
+                    "released_at": "2026-01-01",
+                    "colors": ["U"],
+                    "color_identity": ["U"],
+                    "finishes": ["nonfoil"],
+                    "legalities": {"commander": "legal"},
+                    "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                }
+            ]
+            expanded_scryfall_payload = initial_scryfall_payload + [
+                {
+                    "id": "sync-identifiers-dependency-2",
+                    "oracle_id": "oracle-sync-identifiers-dependency-2",
+                    "name": "Dependency Card Two",
+                    "set": "syn",
+                    "set_name": "Sync Set",
+                    "collector_number": "114",
+                    "lang": "en",
+                    "rarity": "rare",
+                    "released_at": "2026-01-01",
+                    "colors": ["U"],
+                    "color_identity": ["U"],
+                    "finishes": ["nonfoil"],
+                    "legalities": {"commander": "legal"},
+                    "purchase_uris": {"tcgplayer": "https://example.test/tcg"},
+                }
+            ]
+            metadata_payload = {
+                "data": [
+                    {
+                        "type": "default_cards",
+                        "download_uri": scryfall_bulk_path.as_uri(),
+                    }
+                ]
+            }
+            identifiers_payload = {
+                "data": {
+                    "uuid-sync-identifiers-dependency-1": {
+                        "identifiers": {
+                            "scryfallId": "sync-identifiers-dependency-1",
+                            "tcgplayerProductId": "11301",
+                        }
+                    },
+                    "uuid-sync-identifiers-dependency-2": {
+                        "identifiers": {
+                            "scryfallId": "sync-identifiers-dependency-2",
+                            "tcgplayerProductId": "11401",
+                        }
+                    },
+                }
+            }
+
+            scryfall_bulk_path.write_text(json.dumps(initial_scryfall_payload), encoding="utf-8")
+            metadata_path.write_text(json.dumps(metadata_payload), encoding="utf-8")
+            with gzip.open(identifiers_path, "wt", encoding="utf-8") as handle:
+                json.dump(identifiers_payload, handle)
+
+            self.run_importer(
+                "sync-scryfall",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--scryfall-metadata-url",
+                metadata_path.as_uri(),
+            )
+            self.run_importer(
+                "sync-identifiers",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--mtgjson-identifiers-url",
+                identifiers_path.as_uri(),
+            )
+
+            scryfall_bulk_path.write_text(json.dumps(expanded_scryfall_payload), encoding="utf-8")
+            self.run_importer(
+                "sync-scryfall",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--scryfall-metadata-url",
+                metadata_path.as_uri(),
+            )
+            final_output = self.run_importer(
+                "sync-identifiers",
+                "--db",
+                str(db_path),
+                "--cache-dir",
+                str(cache_dir),
+                "--mtgjson-identifiers-url",
+                identifiers_path.as_uri(),
+            )
+
+            self.assertNotIn("artifact unchanged since run 2", final_output)
+            self.assertIn("import-identifiers: seen=2 written=1 skipped=0", final_output)
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    """
+                    SELECT mtgjson_uuid, tcgplayer_product_id
+                    FROM mtg_cards
+                    WHERE scryfall_id = 'sync-identifiers-dependency-2'
+                    """
+                ).fetchone()
+
+            self.assertEqual(("uuid-sync-identifiers-dependency-2", "11401"), (row["mtgjson_uuid"], row["tcgplayer_product_id"]))
+
     def test_remove_card_creates_snapshot_and_restore_snapshot_recovers_inventory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp = Path(tmp_dir)

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -82,6 +82,18 @@ class SchemaMigrationTest(unittest.TestCase):
                 mtgjson_card_links_exists = connection.execute(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'mtgjson_card_links'"
                 ).fetchone()[0]
+                sync_runs_exists = connection.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_runs'"
+                ).fetchone()[0]
+                sync_run_steps_exists = connection.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_steps'"
+                ).fetchone()[0]
+                sync_run_artifacts_exists = connection.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_artifacts'"
+                ).fetchone()[0]
+                sync_run_issues_exists = connection.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_issues'"
+                ).fetchone()[0]
                 mtg_card_columns = {
                     row["name"]
                     for row in connection.execute("PRAGMA table_info(mtg_cards)").fetchall()
@@ -91,13 +103,17 @@ class SchemaMigrationTest(unittest.TestCase):
                     for row in connection.execute("PRAGMA table_info(inventories)").fetchall()
                 }
 
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], versions)
-            self.assertEqual(12, latest_version)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], versions)
+            self.assertEqual(13, latest_version)
             self.assertEqual(1, audit_log_exists)
             self.assertEqual(1, card_search_fts_exists)
             self.assertEqual(1, inventory_memberships_exists)
             self.assertEqual(1, actor_default_inventories_exists)
             self.assertEqual(1, mtgjson_card_links_exists)
+            self.assertEqual(1, sync_runs_exists)
+            self.assertEqual(1, sync_run_steps_exists)
+            self.assertEqual(1, sync_run_artifacts_exists)
+            self.assertEqual(1, sync_run_issues_exists)
             self.assertTrue(
                 {
                     "layout",
@@ -133,7 +149,7 @@ class SchemaMigrationTest(unittest.TestCase):
                     "SELECT version, name FROM schema_migrations ORDER BY version"
                 ).fetchall()
 
-            self.assertEqual(12, len(rows))
+            self.assertEqual(13, len(rows))
             self.assertEqual(
                 [
                     (1, "mvp base"),
@@ -148,6 +164,7 @@ class SchemaMigrationTest(unittest.TestCase):
                     (10, "add inventory printing selection mode"),
                     (11, "add inventory metadata defaults"),
                     (12, "add mtgjson card links"),
+                    (13, "add sync run tracking"),
                 ],
                 [(row["version"], row["name"]) for row in rows],
             )
@@ -214,13 +231,25 @@ class SchemaMigrationTest(unittest.TestCase):
                 mtgjson_card_links_exists = migrated.execute(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'mtgjson_card_links'"
                 ).fetchone()[0]
+                sync_runs_exists = migrated.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_runs'"
+                ).fetchone()[0]
+                sync_run_steps_exists = migrated.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_steps'"
+                ).fetchone()[0]
+                sync_run_artifacts_exists = migrated.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_artifacts'"
+                ).fetchone()[0]
+                sync_run_issues_exists = migrated.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_issues'"
+                ).fetchone()[0]
                 inventory_columns = {row["name"] for row in migrated.execute("PRAGMA table_info(inventories)")}
 
             self.assertIn("tags_json", columns)
             self.assertIn("printing_selection_mode", columns)
             self.assertEqual("[]", tags_value)
             self.assertEqual("explicit", printing_selection_mode)
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], versions)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], versions)
             self.assertIn("before_json", audit_columns)
             self.assertIn("after_json", audit_columns)
             self.assertIn("metadata_json", audit_columns)
@@ -228,6 +257,10 @@ class SchemaMigrationTest(unittest.TestCase):
             self.assertEqual(1, memberships_exists)
             self.assertEqual(1, actor_default_inventories_exists)
             self.assertEqual(1, mtgjson_card_links_exists)
+            self.assertEqual(1, sync_runs_exists)
+            self.assertEqual(1, sync_run_steps_exists)
+            self.assertEqual(1, sync_run_artifacts_exists)
+            self.assertEqual(1, sync_run_issues_exists)
             self.assertTrue(
                 {
                     "default_location",
@@ -312,7 +345,7 @@ class SchemaMigrationTest(unittest.TestCase):
                 ]
 
             self.assertEqual([("normal", 1.5)], [(row["finish"], row["price_value"]) for row in rows])
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], versions)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], versions)
 
     def test_initialize_database_backfills_default_add_search_scope_for_legacy_rows(self) -> None:
         for type_line, expected in (
@@ -414,4 +447,4 @@ class SchemaMigrationTest(unittest.TestCase):
                 ]
 
             self.assertEqual([("uuid-1", "card-with-uuid")], [(row["mtgjson_uuid"], row["scryfall_id"]) for row in rows])
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], versions)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], versions)

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -94,6 +94,13 @@ class SchemaMigrationTest(unittest.TestCase):
                 sync_run_issues_exists = connection.execute(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_issues'"
                 ).fetchone()[0]
+                update_trigger_sql = connection.execute(
+                    """
+                    SELECT sql
+                    FROM sqlite_master
+                    WHERE type = 'trigger' AND name = 'trg_mtg_cards_au_fts'
+                    """
+                ).fetchone()[0]
                 mtg_card_columns = {
                     row["name"]
                     for row in connection.execute("PRAGMA table_info(mtg_cards)").fetchall()
@@ -103,8 +110,8 @@ class SchemaMigrationTest(unittest.TestCase):
                     for row in connection.execute("PRAGMA table_info(inventories)").fetchall()
                 }
 
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], versions)
-            self.assertEqual(13, latest_version)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], versions)
+            self.assertEqual(14, latest_version)
             self.assertEqual(1, audit_log_exists)
             self.assertEqual(1, card_search_fts_exists)
             self.assertEqual(1, inventory_memberships_exists)
@@ -114,6 +121,11 @@ class SchemaMigrationTest(unittest.TestCase):
             self.assertEqual(1, sync_run_steps_exists)
             self.assertEqual(1, sync_run_artifacts_exists)
             self.assertEqual(1, sync_run_issues_exists)
+            self.assertIn(
+                "AFTER UPDATE OF scryfall_id, name, set_code, set_name, collector_number, lang ON mtg_cards",
+                update_trigger_sql,
+            )
+            self.assertIn("WHEN", update_trigger_sql)
             self.assertTrue(
                 {
                     "layout",
@@ -149,7 +161,7 @@ class SchemaMigrationTest(unittest.TestCase):
                     "SELECT version, name FROM schema_migrations ORDER BY version"
                 ).fetchall()
 
-            self.assertEqual(13, len(rows))
+            self.assertEqual(14, len(rows))
             self.assertEqual(
                 [
                     (1, "mvp base"),
@@ -165,6 +177,7 @@ class SchemaMigrationTest(unittest.TestCase):
                     (11, "add inventory metadata defaults"),
                     (12, "add mtgjson card links"),
                     (13, "add sync run tracking"),
+                    (14, "narrow card search fts updates"),
                 ],
                 [(row["version"], row["name"]) for row in rows],
             )
@@ -249,7 +262,7 @@ class SchemaMigrationTest(unittest.TestCase):
             self.assertIn("printing_selection_mode", columns)
             self.assertEqual("[]", tags_value)
             self.assertEqual("explicit", printing_selection_mode)
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], versions)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], versions)
             self.assertIn("before_json", audit_columns)
             self.assertIn("after_json", audit_columns)
             self.assertIn("metadata_json", audit_columns)
@@ -345,7 +358,7 @@ class SchemaMigrationTest(unittest.TestCase):
                 ]
 
             self.assertEqual([("normal", 1.5)], [(row["finish"], row["price_value"]) for row in rows])
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], versions)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], versions)
 
     def test_initialize_database_backfills_default_add_search_scope_for_legacy_rows(self) -> None:
         for type_line, expected in (
@@ -447,4 +460,4 @@ class SchemaMigrationTest(unittest.TestCase):
                 ]
 
             self.assertEqual([("uuid-1", "card-with-uuid")], [(row["mtgjson_uuid"], row["scryfall_id"]) for row in rows])
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], versions)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], versions)

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -79,6 +79,9 @@ class SchemaMigrationTest(unittest.TestCase):
                 actor_default_inventories_exists = connection.execute(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'actor_default_inventories'"
                 ).fetchone()[0]
+                mtgjson_card_links_exists = connection.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'mtgjson_card_links'"
+                ).fetchone()[0]
                 mtg_card_columns = {
                     row["name"]
                     for row in connection.execute("PRAGMA table_info(mtg_cards)").fetchall()
@@ -88,12 +91,13 @@ class SchemaMigrationTest(unittest.TestCase):
                     for row in connection.execute("PRAGMA table_info(inventories)").fetchall()
                 }
 
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], versions)
-            self.assertEqual(11, latest_version)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], versions)
+            self.assertEqual(12, latest_version)
             self.assertEqual(1, audit_log_exists)
             self.assertEqual(1, card_search_fts_exists)
             self.assertEqual(1, inventory_memberships_exists)
             self.assertEqual(1, actor_default_inventories_exists)
+            self.assertEqual(1, mtgjson_card_links_exists)
             self.assertTrue(
                 {
                     "layout",
@@ -129,7 +133,7 @@ class SchemaMigrationTest(unittest.TestCase):
                     "SELECT version, name FROM schema_migrations ORDER BY version"
                 ).fetchall()
 
-            self.assertEqual(11, len(rows))
+            self.assertEqual(12, len(rows))
             self.assertEqual(
                 [
                     (1, "mvp base"),
@@ -143,6 +147,7 @@ class SchemaMigrationTest(unittest.TestCase):
                     (9, "add catalog relevance rank"),
                     (10, "add inventory printing selection mode"),
                     (11, "add inventory metadata defaults"),
+                    (12, "add mtgjson card links"),
                 ],
                 [(row["version"], row["name"]) for row in rows],
             )
@@ -206,19 +211,23 @@ class SchemaMigrationTest(unittest.TestCase):
                 actor_default_inventories_exists = migrated.execute(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'actor_default_inventories'"
                 ).fetchone()[0]
+                mtgjson_card_links_exists = migrated.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'mtgjson_card_links'"
+                ).fetchone()[0]
                 inventory_columns = {row["name"] for row in migrated.execute("PRAGMA table_info(inventories)")}
 
             self.assertIn("tags_json", columns)
             self.assertIn("printing_selection_mode", columns)
             self.assertEqual("[]", tags_value)
             self.assertEqual("explicit", printing_selection_mode)
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], versions)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], versions)
             self.assertIn("before_json", audit_columns)
             self.assertIn("after_json", audit_columns)
             self.assertIn("metadata_json", audit_columns)
             self.assertEqual(1, fts_exists)
             self.assertEqual(1, memberships_exists)
             self.assertEqual(1, actor_default_inventories_exists)
+            self.assertEqual(1, mtgjson_card_links_exists)
             self.assertTrue(
                 {
                     "default_location",
@@ -303,7 +312,7 @@ class SchemaMigrationTest(unittest.TestCase):
                 ]
 
             self.assertEqual([("normal", 1.5)], [(row["finish"], row["price_value"]) for row in rows])
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], versions)
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], versions)
 
     def test_initialize_database_backfills_default_add_search_scope_for_legacy_rows(self) -> None:
         for type_line, expected in (
@@ -347,3 +356,62 @@ class SchemaMigrationTest(unittest.TestCase):
                 self.assertEqual("[]", row["promo_types_json"])
                 self.assertIsNone(row["edhrec_rank"])
                 self.assertEqual(expected, row["is_default_add_searchable"])
+
+    def test_initialize_database_backfills_mtgjson_card_links_from_existing_card_uuid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "legacy-mtgjson-links.db"
+
+            connection = sqlite3.connect(db_path)
+            connection.executescript(
+                """
+                CREATE TABLE mtg_cards (
+                    scryfall_id TEXT PRIMARY KEY,
+                    mtgjson_uuid TEXT UNIQUE
+                );
+
+                CREATE TABLE schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+
+                INSERT INTO mtg_cards (scryfall_id, mtgjson_uuid)
+                VALUES
+                    ('card-with-uuid', 'uuid-1'),
+                    ('card-without-uuid', NULL);
+
+                INSERT INTO schema_migrations (version, name)
+                VALUES
+                    (1, 'mvp base'),
+                    (2, 'add tags json'),
+                    (3, 'add inventory audit log'),
+                    (4, 'add card search fts'),
+                    (5, 'normalize price snapshot finishes'),
+                    (6, 'add inventory memberships'),
+                    (7, 'add actor default inventories'),
+                    (8, 'add catalog classification fields'),
+                    (9, 'add catalog relevance rank'),
+                    (10, 'add inventory printing selection mode'),
+                    (11, 'add inventory metadata defaults');
+                """
+            )
+            connection.commit()
+            connection.close()
+
+            initialize_database(db_path)
+
+            with connect(db_path) as migrated:
+                rows = migrated.execute(
+                    """
+                    SELECT mtgjson_uuid, scryfall_id
+                    FROM mtgjson_card_links
+                    ORDER BY mtgjson_uuid
+                    """
+                ).fetchall()
+                versions = [
+                    row["version"]
+                    for row in migrated.execute("SELECT version FROM schema_migrations ORDER BY version").fetchall()
+                ]
+
+            self.assertEqual([("uuid-1", "card-with-uuid")], [(row["mtgjson_uuid"], row["scryfall_id"]) for row in rows])
+            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], versions)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -562,6 +562,7 @@ class WebApiSchemaTest(unittest.TestCase):
             add_request_schema = components["AddInventoryItemRequest"]
             self.assertIn("oracle_id", add_request_schema["properties"])
             self.assertNotIn("default", add_request_schema["properties"]["language_code"])
+            self.assertIsNone(add_request_schema["properties"]["location"].get("default"))
             self.assertIn(
                 "inherits the resolved printing language",
                 add_request_schema["properties"]["language_code"]["description"],
@@ -1201,7 +1202,7 @@ class WebApiTest(unittest.TestCase):
                         "display_name": "Personal Collection",
                         "description": "Main demo inventory",
                         "default_location": "Trade Binder",
-                        "default_tags": "staples, trade",
+                        "default_tags": "trade, staples",
                         "notes": "Main inventory notes",
                         "acquisition_price": "25.00",
                         "acquisition_currency": "USD",
@@ -1218,9 +1219,9 @@ class WebApiTest(unittest.TestCase):
                             "display_name": "Personal Collection",
                             "description": "Main demo inventory",
                             "default_location": "Trade Binder",
-                            "default_tags": "staples, trade",
+                            "default_tags": "trade, staples",
                             "notes": "Main inventory notes",
-                            "acquisition_price": "25.00",
+                            "acquisition_price": "25",
                             "acquisition_currency": "USD",
                             "item_rows": 0,
                             "total_cards": 0,
@@ -1240,7 +1241,7 @@ class WebApiTest(unittest.TestCase):
                 )
                 self.assertEqual(201, added.status_code)
                 self.assertEqual("Trade Binder", added.json()["location"])
-                self.assertEqual(["staples", "trade"], added.json()["tags"])
+                self.assertEqual(["trade", "staples"], added.json()["tags"])
 
                 with connect(db_path) as connection:
                     item_row = connection.execute(
@@ -1249,7 +1250,7 @@ class WebApiTest(unittest.TestCase):
                     ).fetchone()
 
                 self.assertEqual("Trade Binder", item_row["location"])
-                self.assertEqual('["staples", "trade"]', item_row["tags_json"])
+                self.assertEqual(["trade", "staples"], json.loads(item_row["tags_json"]))
 
     def test_demo_api_csv_import_supports_preview_and_commit_but_not_implicit_inventory_creation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- improve sync/import operations with split commands, artifact tracking, unchanged-skip logic, timing visibility, and search-index maintenance tooling
- speed up MTGJSON identifier refreshes by narrowing FTS updates and adding benchmark coverage
- smooth the frontend demo setup with repo-local launchers, clearer docs, and full-catalog demo support for imported MTGJSON prices

## Validation
- PYTHONPATH=src ./.venv/bin/python -m unittest discover -s tests -q
- PATH="/home/boydm9/mtg_inventory_tool/var/tools/node/current/bin:$PATH"; cd frontend && npm run test
- PATH="/home/boydm9/mtg_inventory_tool/var/tools/node/current/bin:$PATH"; cd frontend && npm run build
- PATH="/home/boydm9/mtg_inventory_tool/var/tools/node/current/bin:$PATH"; cd frontend && npm run demo:bootstrap -- --db /tmp/frontend_demo_full_prices_npm.db --force --full-catalog --scryfall-json ../tests/fixtures/frontend_demo_full_catalog/scryfall.json --identifiers-json ../tests/fixtures/frontend_demo_full_catalog/identifiers.json --prices-json ../tests/fixtures/frontend_demo_full_catalog/prices.json