### PR TITLE
Stop API imports from migrating schema on request

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -194,6 +194,15 @@ Why this matters:
   actual write-access rule and only keep route-specific wrappers if they are
   buying real policy separation or clearer intent.
 
+Current schema-policy shape:
+
+- API import routes pass `schema_policy="require_current"` into the service
+  layer, so request handling never auto-migrates the database.
+- CLI import entrypoints keep the local-first default
+  `schema_policy="initialize_if_needed"`.
+- The public import entrypoints prepare the schema once, then resolution/write
+  helpers operate on the prepared DB path.
+
 Multipart caveat:
 
 - `POST /imports/csv` uses FastAPI `UploadFile` + `File(...)` + `Form(...)`.
@@ -227,11 +236,20 @@ Multipart caveat:
 
 ## Useful Commands
 
+Python command note:
+
+- prefer the repo-local `.venv/bin/python` for backend commands and tests, or
+  activate `.venv` first
+- using system `python3` can miss optional web/test deps that are installed only
+  in the repo virtualenv
+- if a unittest import fails for modules like `pydantic`, `fastapi`, or
+  `uvicorn`, confirm you are using `.venv/bin/python`
+
 Backend:
 
 ```bash
 ./scripts/test_backend.sh
-python3 -m unittest discover -s tests -q
+PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -q
 ```
 
 Frontend:
@@ -244,13 +262,13 @@ cd frontend && npm run build
 Localhost API test layer:
 
 ```bash
-python3 -m unittest tests.test_web_api tests.test_api_app -q
+PYTHONPATH=src .venv/bin/python -m unittest tests.test_web_api tests.test_api_app -q
 ```
 
 Importer benchmark:
 
 ```bash
-python3 scripts/benchmark_import_pipeline.py \
+PYTHONPATH=src .venv/bin/python scripts/benchmark_import_pipeline.py \
   --db /tmp/mtg_benchmark.db \
   --scryfall-json /path/to/default-cards.json \
   --identifiers-json /path/to/AllIdentifiers.json.gz \
@@ -260,15 +278,15 @@ python3 scripts/benchmark_import_pipeline.py \
 Search index maintenance:
 
 ```bash
-python3 -m mtg_source_stack.mvp_importer check-search-index --db var/db/mtg_mvp.db
-python3 -m mtg_source_stack.mvp_importer rebuild-search-index --db var/db/mtg_mvp.db
+PYTHONPATH=src .venv/bin/python -m mtg_source_stack.mvp_importer check-search-index --db var/db/mtg_mvp.db
+PYTHONPATH=src .venv/bin/python -m mtg_source_stack.mvp_importer rebuild-search-index --db var/db/mtg_mvp.db
 ```
 
 Sync run history:
 
 ```bash
-python3 -m mtg_source_stack.mvp_importer list-sync-runs --db var/db/mtg_mvp.db
-python3 -m mtg_source_stack.mvp_importer show-sync-run --db var/db/mtg_mvp.db --run-id 1
+PYTHONPATH=src .venv/bin/python -m mtg_source_stack.mvp_importer list-sync-runs --db var/db/mtg_mvp.db
+PYTHONPATH=src .venv/bin/python -m mtg_source_stack.mvp_importer show-sync-run --db var/db/mtg_mvp.db --run-id 1
 ```
 
 Suggested local/shared-service cadence:
@@ -302,8 +320,8 @@ Backend default:
 Useful targeted commands:
 
 ```bash
-python3 -m unittest discover -s tests -q
-python3 -m unittest tests.test_web_api tests.test_api_app -q
+PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -q
+PYTHONPATH=src .venv/bin/python -m unittest tests.test_web_api tests.test_api_app -q
 cd frontend && npm test
 cd frontend && npm run build
 ```
@@ -317,7 +335,7 @@ After intentional API contract changes, refresh `contracts/openapi.json` from
 the repo root with:
 
 ```bash
-python3 - <<'PY'
+PYTHONPATH=src .venv/bin/python - <<'PY'
 import json
 from pathlib import Path
 from mtg_source_stack.api.app import create_app
@@ -360,7 +378,7 @@ PY
   fail for sandbox reasons, rerun them with elevated permissions instead of
   assuming the repo is broken.
 - This most often applies to:
-  - `python3 -m unittest tests.test_web_api tests.test_api_app -q`
+  - `PYTHONPATH=src .venv/bin/python -m unittest tests.test_web_api tests.test_api_app -q`
   - `gh auth status`
   - `gh issue ...`
   - `gh pr ...`

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ mtg-web-api --db "var/db/mtg_mvp.db" --runtime-mode shared_service
 If you need to override startup migration behavior explicitly, use
 `--auto-migrate` or `--no-auto-migrate`, or set `MTG_API_AUTO_MIGRATE`.
 
+API import routes follow that startup schema posture. `POST /imports/csv`,
+`POST /imports/decklist`, and `POST /imports/deck-url` require a current
+database and do not auto-migrate during request handling. If the schema is
+stale, migrate it intentionally first with `mtg-mvp-importer migrate-db` or
+start the API with auto-migrate enabled.
+
 `shared_service` also supports:
 
 - `--proxy-headers` / `--no-proxy-headers`

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -117,6 +117,8 @@ Notes:
 
 - `shared_service` enables proxy-header handling by default.
 - `shared_service` disables auto-migrate by default.
+- API import routes obey that startup schema posture and return
+  `schema_not_ready` instead of migrating during request handling.
 - `shared_service` rejects `MTG_API_TRUST_ACTOR_HEADERS=true`.
 - `shared_service` now also requires `MTG_API_SNAPSHOT_SIGNING_SECRET` so
   deck URL preview tokens stay tamper-evident across the preview/commit flow.

--- a/src/mtg_source_stack/api/routes.py
+++ b/src/mtg_source_stack/api/routes.py
@@ -446,6 +446,7 @@ async def imports_csv(
                 actor_type=context.actor_type,
                 actor_id=context.actor_id,
                 request_id=context.request_id,
+                schema_policy="require_current",
             )
         except MtgStackError:
             raise
@@ -486,6 +487,7 @@ async def imports_decklist(
         actor_type=context.actor_type,
         actor_id=context.actor_id,
         request_id=context.request_id,
+        schema_policy="require_current",
     )
     return _serialize(result)
 
@@ -518,6 +520,7 @@ async def imports_deck_url(
         actor_type=context.actor_type,
         actor_id=context.actor_id,
         request_id=context.request_id,
+        schema_policy="require_current",
     )
     return _serialize(result)
 

--- a/src/mtg_source_stack/cli/inventory.py
+++ b/src/mtg_source_stack/cli/inventory.py
@@ -624,6 +624,7 @@ def main() -> None:
                 dry_run=args.dry_run,
                 resolutions=resolutions,
                 before_write=before_write,
+                schema_policy="initialize_if_needed",
             )
             if not args.dry_run:
                 snapshot = get_snapshot()

--- a/src/mtg_source_stack/db/schema.py
+++ b/src/mtg_source_stack/db/schema.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import sqlite3
 from importlib.resources import files
 from pathlib import Path
+from typing import Literal
 
 from .connection import connect, require_database_file
 from .migrator import migrate_database, pending_migrations
 from ..errors import SchemaNotReadyError
+
+
+SchemaPreparationPolicy = Literal["initialize_if_needed", "require_current"]
 
 
 def load_schema_sql() -> str:
@@ -39,6 +43,19 @@ def initialize_database(db_path: str | Path) -> None:
     migrate_database(db_path)
 
 
+def prepare_database(
+    db_path: str | Path,
+    *,
+    schema_policy: SchemaPreparationPolicy = "initialize_if_needed",
+) -> Path:
+    if schema_policy == "initialize_if_needed":
+        initialize_database(db_path)
+        return require_database_file(db_path)
+    if schema_policy == "require_current":
+        return require_current_schema(db_path)
+    raise ValueError(f"Unsupported schema_policy: {schema_policy}")
+
+
 def require_current_schema(db_path: str | Path) -> Path:
     path = require_database_file(db_path)
     with connect(path) as connection:
@@ -47,7 +64,7 @@ def require_current_schema(db_path: str | Path) -> Path:
     if pending:
         raise SchemaNotReadyError(
             f"Database file '{path}' is not at the current schema version. "
-            f"Run mtg-mvp-importer migrate-db --db '{path}' before using read-only commands."
+            f"Run mtg-mvp-importer migrate-db --db '{path}' before using this database."
         )
 
     return path

--- a/src/mtg_source_stack/inventory/csv_import.py
+++ b/src/mtg_source_stack/inventory/csv_import.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Callable, Mapping, TextIO
 
 from ..db.connection import connect
-from ..db.schema import initialize_database
+from ..db.schema import SchemaPreparationPolicy, prepare_database
 from ..errors import MtgStackError, ValidationError
 from .catalog import (
     determine_printing_selection_mode,
@@ -579,28 +579,22 @@ def _build_pending_csv_row_from_selection(
     )
 
 
-def _plan_csv_import(
-    db_path: str | Path,
+def _resolve_csv_import_plan(
+    prepared_db_path: str | Path,
     *,
-    csv_handle: TextIO,
-    csv_filename: str,
-    default_inventory: str | None,
-    resolutions: list[Mapping[str, Any]] | None = None,
+    detected_format: str,
+    rows_seen: int,
+    loaded_rows: list[PendingImportRow],
+    resolutions: list[Mapping[str, Any]] | None,
     allow_inventory_auto_create: bool = True,
     inventory_validator: InventoryValidator | None = None,
 ) -> PlannedCsvImport:
-    detected_format, rows_seen, loaded_rows = _load_pending_csv_rows(
-        csv_handle,
-        source_name=csv_filename,
-        default_inventory=default_inventory,
-    )
     requested_card_quantity = sum(int(pending_row.add_kwargs.get("quantity") or 0) for pending_row in loaded_rows)
     selection_map = _normalize_csv_resolution_selections(resolutions)
     pending_rows: list[PendingImportRow] = []
     resolution_issues: list[CsvResolutionIssue] = []
 
-    initialize_database(db_path)
-    with connect(db_path) as connection:
+    with connect(prepared_db_path) as connection:
         validated_inventories: set[str] = set()
         for loaded_row in loaded_rows:
             inventory_slug = str(loaded_row.add_kwargs["inventory_slug"])
@@ -649,7 +643,7 @@ def _plan_csv_import(
 
 
 def _import_pending_rows(
-    db_path: str | Path,
+    prepared_db_path: str | Path,
     *,
     pending_rows: list[PendingImportRow],
     dry_run: bool = False,
@@ -663,8 +657,7 @@ def _import_pending_rows(
     imported_rows: list[dict[str, Any]] = []
     inventory_cache: dict[str, sqlite3.Row] = {}
 
-    initialize_database(db_path)
-    with connect(db_path) as connection:
+    with connect(prepared_db_path) as connection:
         validated_inventories: set[str] = set()
         for pending_row in pending_rows:
             inventory_slug = str(pending_row.add_kwargs["inventory_slug"])
@@ -730,12 +723,22 @@ def import_csv_stream(
     actor_type: str = "cli",
     actor_id: str | None = None,
     request_id: str | None = None,
+    schema_policy: SchemaPreparationPolicy = "initialize_if_needed",
 ) -> dict[str, Any]:
-    plan = _plan_csv_import(
-        db_path,
-        csv_handle=csv_handle,
-        csv_filename=csv_filename,
+    detected_format, rows_seen, loaded_rows = _load_pending_csv_rows(
+        csv_handle,
+        source_name=csv_filename,
         default_inventory=default_inventory,
+    )
+    prepared_db_path = prepare_database(
+        db_path,
+        schema_policy=schema_policy,
+    )
+    plan = _resolve_csv_import_plan(
+        prepared_db_path,
+        detected_format=detected_format,
+        rows_seen=rows_seen,
+        loaded_rows=loaded_rows,
         resolutions=resolutions,
         allow_inventory_auto_create=allow_inventory_auto_create,
         inventory_validator=inventory_validator,
@@ -746,7 +749,7 @@ def import_csv_stream(
             details={"resolution_issues": serialize_response(plan.resolution_issues)},
         )
     imported_rows = _import_pending_csv_rows(
-        db_path,
+        prepared_db_path,
         pending_rows=plan.pending_rows,
         dry_run=dry_run,
         before_write=before_write,
@@ -774,7 +777,7 @@ def import_csv_stream(
 
 
 def _import_pending_csv_rows(
-    db_path: str | Path,
+    prepared_db_path: str | Path,
     *,
     pending_rows: list[PendingImportRow],
     dry_run: bool = False,
@@ -786,7 +789,7 @@ def _import_pending_csv_rows(
     request_id: str | None = None,
 ) -> list[dict[str, Any]]:
     return _import_pending_rows(
-        db_path,
+        prepared_db_path,
         pending_rows=pending_rows,
         dry_run=dry_run,
         before_write=before_write,
@@ -806,25 +809,35 @@ def import_csv(
     dry_run: bool = False,
     resolutions: list[Mapping[str, Any]] | None = None,
     before_write: Callable[[], Any] | None = None,
+    schema_policy: SchemaPreparationPolicy = "initialize_if_needed",
 ) -> dict[str, Any]:
     try:
         with Path(csv_path).open(mode="r", encoding="utf-8-sig", newline="") as handle:
-            plan = _plan_csv_import(
-                db_path,
-                csv_handle=handle,
-                csv_filename=str(csv_path),
+            detected_format, rows_seen, loaded_rows = _load_pending_csv_rows(
+                handle,
+                source_name=str(csv_path),
                 default_inventory=default_inventory,
-                resolutions=resolutions,
             )
     except OSError as exc:
         raise ValueError(f"Could not read CSV file '{csv_path}'.") from exc
+    prepared_db_path = prepare_database(
+        db_path,
+        schema_policy=schema_policy,
+    )
+    plan = _resolve_csv_import_plan(
+        prepared_db_path,
+        detected_format=detected_format,
+        rows_seen=rows_seen,
+        loaded_rows=loaded_rows,
+        resolutions=resolutions,
+    )
     if plan.resolution_issues and not dry_run:
         raise ValidationError(
             "Unresolved CSV import ambiguities remain.",
             details={"resolution_issues": serialize_response(plan.resolution_issues)},
         )
     imported_rows = _import_pending_csv_rows(
-        db_path,
+        prepared_db_path,
         pending_rows=plan.pending_rows,
         dry_run=dry_run,
         before_write=before_write,

--- a/src/mtg_source_stack/inventory/deck_url_import.py
+++ b/src/mtg_source_stack/inventory/deck_url_import.py
@@ -21,7 +21,7 @@ import re
 
 from ..errors import MtgStackError, NotFoundError, ValidationError
 from ..db.connection import connect
-from ..db.schema import initialize_database
+from ..db.schema import SchemaPreparationPolicy, prepare_database
 from .catalog import (
     determine_printing_selection_mode,
     list_default_card_name_candidate_rows,
@@ -1759,24 +1759,19 @@ def _build_pending_remote_row_from_selection(
 
 
 def _plan_remote_deck_import(
-    db_path: str | Path,
+    prepared_db_path: str | Path,
     *,
     source_url: str,
     source_snapshot_token: str | None,
     snapshot_signing_secret: str | None,
     resolutions: list[Mapping[str, Any]] | None,
     inventory_validator: InventoryValidator | None,
-    default_inventory: str | None,
+    default_inventory: str,
 ) -> PlannedRemoteDeckImport:
-    inventory_slug = text_or_none(default_inventory)
-    if inventory_slug is None:
-        raise ValidationError("default_inventory is required for deck URL imports.")
-
-    initialize_database(db_path)
-    with connect(db_path) as connection:
+    with connect(prepared_db_path) as connection:
         if inventory_validator is not None:
-            inventory_validator(connection, inventory_slug)
-        get_inventory_row(connection, inventory_slug)
+            inventory_validator(connection, default_inventory)
+        get_inventory_row(connection, default_inventory)
 
     source, snapshot_token = _load_remote_source_for_import(
         source_url,
@@ -1788,7 +1783,7 @@ def _plan_remote_deck_import(
     pending_rows: list[PendingImportRow] = []
     resolution_issues: list[RemoteDeckResolutionIssue] = []
 
-    with connect(db_path) as connection:
+    with connect(prepared_db_path) as connection:
         for card in source.cards:
             selection = selection_map.pop(card.source_position, None)
             if selection is not None:
@@ -1842,6 +1837,7 @@ def import_deck_url(
     actor_type: str = "cli",
     actor_id: str | None = None,
     request_id: str | None = None,
+    schema_policy: SchemaPreparationPolicy = "initialize_if_needed",
 ) -> dict[str, Any]:
     logger.info(
         "remote_deck_import_start source_url=%s default_inventory=%s dry_run=%s",
@@ -1849,14 +1845,21 @@ def import_deck_url(
         default_inventory,
         dry_run,
     )
-    plan = _plan_remote_deck_import(
+    inventory_slug = text_or_none(default_inventory)
+    if inventory_slug is None:
+        raise ValidationError("default_inventory is required for deck URL imports.")
+    prepared_db_path = prepare_database(
         db_path,
+        schema_policy=schema_policy,
+    )
+    plan = _plan_remote_deck_import(
+        prepared_db_path,
         source_url=source_url,
         source_snapshot_token=source_snapshot_token,
         snapshot_signing_secret=snapshot_signing_secret,
         resolutions=resolutions,
         inventory_validator=inventory_validator,
-        default_inventory=default_inventory,
+        default_inventory=inventory_slug,
     )
     if plan.resolution_issues and not dry_run:
         raise ValidationError(
@@ -1867,7 +1870,7 @@ def import_deck_url(
             },
         )
     imported_rows = _import_pending_rows(
-        db_path,
+        prepared_db_path,
         pending_rows=plan.pending_rows,
         dry_run=dry_run,
         before_write=before_write,

--- a/src/mtg_source_stack/inventory/decklist_import.py
+++ b/src/mtg_source_stack/inventory/decklist_import.py
@@ -17,7 +17,7 @@ from .catalog import (
     resolve_default_card_row_for_name,
 )
 from ..db.connection import connect
-from ..db.schema import initialize_database
+from ..db.schema import SchemaPreparationPolicy, prepare_database
 from .csv_import import InventoryValidator, PendingImportRow, _import_pending_rows
 from .import_summary import build_resolvable_deck_import_summary
 from .import_resolution import (
@@ -494,25 +494,20 @@ def _build_pending_decklist_row_from_selection(
     )
 
 
-def _plan_decklist_import(
-    db_path: str | Path,
+def _resolve_decklist_import_plan(
+    prepared_db_path: str | Path,
     *,
-    deck_text: str,
-    default_inventory: str | None,
-    resolutions: list[Mapping[str, Any]] | None = None,
+    parsed_decklist: ParsedDecklistText,
+    inventory_slug: str,
+    resolutions: list[Mapping[str, Any]] | None,
     inventory_validator: InventoryValidator | None = None,
 ) -> PlannedDecklistImport:
-    parsed_decklist = parse_decklist_text_with_metadata(deck_text)
     entries = parsed_decklist.entries
     requested_card_quantity = sum(entry.quantity for entry in entries)
     selection_map = _normalize_decklist_resolution_selections(resolutions)
-    initialize_database(db_path)
     pending_rows: list[PendingImportRow] = []
     resolution_issues: list[DecklistResolutionIssue] = []
-    with connect(db_path) as connection:
-        inventory_slug = text_or_none(default_inventory)
-        if inventory_slug is None:
-            raise ValidationError("default_inventory is required for decklist imports.")
+    with connect(prepared_db_path) as connection:
         if inventory_validator is not None:
             inventory_validator(connection, inventory_slug)
         get_inventory_row(connection, inventory_slug)
@@ -523,7 +518,7 @@ def _plan_decklist_import(
                     _build_pending_decklist_row_from_selection(
                         connection,
                         entry=entry,
-                        default_inventory=default_inventory,
+                        default_inventory=inventory_slug,
                         selection=selection,
                     )
                 )
@@ -532,7 +527,7 @@ def _plan_decklist_import(
             pending_row, resolution_issue = _probe_decklist_resolution(
                 connection,
                 entry=entry,
-                default_inventory=default_inventory,
+                default_inventory=inventory_slug,
             )
             if resolution_issue is not None:
                 resolution_issues.append(resolution_issue)
@@ -566,11 +561,20 @@ def import_decklist_text(
     actor_type: str = "cli",
     actor_id: str | None = None,
     request_id: str | None = None,
+    schema_policy: SchemaPreparationPolicy = "initialize_if_needed",
 ) -> dict[str, Any]:
-    plan = _plan_decklist_import(
+    parsed_decklist = parse_decklist_text_with_metadata(deck_text)
+    inventory_slug = text_or_none(default_inventory)
+    if inventory_slug is None:
+        raise ValidationError("default_inventory is required for decklist imports.")
+    prepared_db_path = prepare_database(
         db_path,
-        deck_text=deck_text,
-        default_inventory=default_inventory,
+        schema_policy=schema_policy,
+    )
+    plan = _resolve_decklist_import_plan(
+        prepared_db_path,
+        parsed_decklist=parsed_decklist,
+        inventory_slug=inventory_slug,
         resolutions=resolutions,
         inventory_validator=inventory_validator,
     )
@@ -580,7 +584,7 @@ def import_decklist_text(
             details={"resolution_issues": serialize_response(plan.resolution_issues)},
         )
     imported_rows = _import_pending_rows(
-        db_path,
+        prepared_db_path,
         pending_rows=plan.pending_rows,
         dry_run=dry_run,
         before_write=before_write,

--- a/tests/test_csv_import.py
+++ b/tests/test_csv_import.py
@@ -7,11 +7,13 @@ from io import StringIO
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from mtg_source_stack.db.connection import connect
 from mtg_source_stack.db.schema import initialize_database
 from mtg_source_stack.errors import NotFoundError, ValidationError
 from mtg_source_stack.inventory.csv_import import (
+    PlannedCsvImport,
     build_add_card_kwargs_from_csv_row,
     import_csv,
     import_csv_stream,
@@ -22,6 +24,91 @@ from tests.common import RepoSmokeTestCase, materialize_fixture_bundle
 
 
 class InventoryCsvImportTest(RepoSmokeTestCase):
+    def test_import_csv_stream_defaults_to_initialize_if_needed_schema_policy(self) -> None:
+        plan = PlannedCsvImport(
+            detected_format="generic_csv",
+            rows_seen=0,
+            requested_card_quantity=0,
+            pending_rows=[],
+            resolution_issues=[],
+        )
+        prepared_db_path = Path("/tmp/prepared_csv_import.db")
+
+        with (
+            patch(
+                "mtg_source_stack.inventory.csv_import._load_pending_csv_rows",
+                return_value=("generic_csv", 0, []),
+            ),
+            patch(
+                "mtg_source_stack.inventory.csv_import.prepare_database",
+                return_value=prepared_db_path,
+            ) as prepare_database,
+            patch(
+                "mtg_source_stack.inventory.csv_import._resolve_csv_import_plan",
+                return_value=plan,
+            ) as resolve_csv_import_plan,
+            patch(
+                "mtg_source_stack.inventory.csv_import._import_pending_csv_rows",
+                return_value=[],
+            ) as import_pending_rows,
+        ):
+            result = import_csv_stream(
+                "collection.db",
+                csv_handle=StringIO("Inventory,Scryfall ID,Qty\n"),
+                csv_filename="inventory_import.csv",
+                default_inventory=None,
+            )
+
+        prepare_database.assert_called_once_with(
+            "collection.db",
+            schema_policy="initialize_if_needed",
+        )
+        self.assertEqual(prepared_db_path, resolve_csv_import_plan.call_args.args[0])
+        self.assertEqual(prepared_db_path, import_pending_rows.call_args.args[0])
+        self.assertEqual("inventory_import.csv", result["csv_filename"])
+        self.assertEqual("generic_csv", result["detected_format"])
+
+    def test_import_csv_stream_accepts_require_current_schema_policy(self) -> None:
+        plan = PlannedCsvImport(
+            detected_format="generic_csv",
+            rows_seen=0,
+            requested_card_quantity=0,
+            pending_rows=[],
+            resolution_issues=[],
+        )
+        prepared_db_path = Path("/tmp/prepared_csv_import.db")
+
+        with (
+            patch(
+                "mtg_source_stack.inventory.csv_import._load_pending_csv_rows",
+                return_value=("generic_csv", 0, []),
+            ),
+            patch(
+                "mtg_source_stack.inventory.csv_import.prepare_database",
+                return_value=prepared_db_path,
+            ) as prepare_database,
+            patch(
+                "mtg_source_stack.inventory.csv_import._resolve_csv_import_plan",
+                return_value=plan,
+            ),
+            patch(
+                "mtg_source_stack.inventory.csv_import._import_pending_csv_rows",
+                return_value=[],
+            ),
+        ):
+            import_csv_stream(
+                "collection.db",
+                csv_handle=StringIO("Inventory,Scryfall ID,Qty\n"),
+                csv_filename="inventory_import.csv",
+                default_inventory=None,
+                schema_policy="require_current",
+            )
+
+        prepare_database.assert_called_once_with(
+            "collection.db",
+            schema_policy="require_current",
+        )
+
     def test_flatten_import_csv_rows_accepts_stream_result_shape(self) -> None:
         flattened = flatten_import_csv_rows(
             {

--- a/tests/test_deck_url_import.py
+++ b/tests/test_deck_url_import.py
@@ -16,6 +16,7 @@ from mtg_source_stack.db.connection import connect
 from mtg_source_stack.db.schema import initialize_database
 from mtg_source_stack.errors import ValidationError
 from mtg_source_stack.inventory.deck_url_import import (
+    PlannedRemoteDeckImport,
     RemoteDeckCard,
     RemoteDeckSource,
     _RemoteDeckSourceError,
@@ -58,6 +59,92 @@ class DeckUrlImportTest(unittest.TestCase):
 
         def geturl(self) -> str:
             return self._final_url
+
+    def test_import_deck_url_defaults_to_initialize_if_needed_schema_policy(self) -> None:
+        plan = PlannedRemoteDeckImport(
+            source=RemoteDeckSource(
+                provider="archidekt",
+                source_url="https://archidekt.com/decks/123/test",
+                deck_name="Test Deck",
+                cards=[],
+            ),
+            rows_seen=0,
+            requested_card_quantity=0,
+            source_snapshot_token="snapshot-token",
+            pending_rows=[],
+            resolution_issues=[],
+        )
+        prepared_db_path = Path("/tmp/prepared_deck_url_import.db")
+
+        with (
+            patch(
+                "mtg_source_stack.inventory.deck_url_import.prepare_database",
+                return_value=prepared_db_path,
+            ) as prepare_database,
+            patch(
+                "mtg_source_stack.inventory.deck_url_import._plan_remote_deck_import",
+                return_value=plan,
+            ) as plan_remote_deck_import,
+            patch(
+                "mtg_source_stack.inventory.deck_url_import._import_pending_rows",
+                return_value=[],
+            ) as import_pending_rows,
+        ):
+            result = import_deck_url(
+                "collection.db",
+                source_url="https://archidekt.com/decks/123/test",
+                default_inventory="personal",
+            )
+
+        prepare_database.assert_called_once_with(
+            "collection.db",
+            schema_policy="initialize_if_needed",
+        )
+        self.assertEqual(prepared_db_path, plan_remote_deck_import.call_args.args[0])
+        self.assertEqual(prepared_db_path, import_pending_rows.call_args.args[0])
+        self.assertEqual("archidekt", result["provider"])
+
+    def test_import_deck_url_accepts_require_current_schema_policy(self) -> None:
+        plan = PlannedRemoteDeckImport(
+            source=RemoteDeckSource(
+                provider="archidekt",
+                source_url="https://archidekt.com/decks/123/test",
+                deck_name="Test Deck",
+                cards=[],
+            ),
+            rows_seen=0,
+            requested_card_quantity=0,
+            source_snapshot_token="snapshot-token",
+            pending_rows=[],
+            resolution_issues=[],
+        )
+        prepared_db_path = Path("/tmp/prepared_deck_url_import.db")
+
+        with (
+            patch(
+                "mtg_source_stack.inventory.deck_url_import.prepare_database",
+                return_value=prepared_db_path,
+            ) as prepare_database,
+            patch(
+                "mtg_source_stack.inventory.deck_url_import._plan_remote_deck_import",
+                return_value=plan,
+            ),
+            patch(
+                "mtg_source_stack.inventory.deck_url_import._import_pending_rows",
+                return_value=[],
+            ),
+        ):
+            import_deck_url(
+                "collection.db",
+                source_url="https://archidekt.com/decks/123/test",
+                default_inventory="personal",
+                schema_policy="require_current",
+            )
+
+        prepare_database.assert_called_once_with(
+            "collection.db",
+            schema_policy="require_current",
+        )
 
     def _manabox_page_html(self, deck_payload: dict[str, object]) -> str:
         props = json.dumps({"deck": [0, deck_payload]}, separators=(",", ":"))

--- a/tests/test_decklist_import.py
+++ b/tests/test_decklist_import.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
 from mtg_source_stack.db.connection import connect
 from mtg_source_stack.db.schema import initialize_database
 from mtg_source_stack.errors import NotFoundError, ValidationError
 from mtg_source_stack.inventory.catalog import resolve_default_card_row_for_name
 from mtg_source_stack.inventory.decklist_import import (
+    ParsedDecklistEntry,
+    ParsedDecklistText,
+    PlannedDecklistImport,
     import_decklist_text,
     parse_decklist_text,
     parse_decklist_text_with_metadata,
@@ -20,6 +24,96 @@ from mtg_source_stack.inventory.service import create_inventory
 
 
 class DecklistImportTest(unittest.TestCase):
+    def test_import_decklist_text_defaults_to_initialize_if_needed_schema_policy(self) -> None:
+        parsed_decklist = ParsedDecklistText(
+            deck_name=None,
+            entries=[ParsedDecklistEntry(line_number=1, quantity=1, name="Test Card")],
+        )
+        plan = PlannedDecklistImport(
+            deck_name=None,
+            rows_seen=1,
+            requested_card_quantity=1,
+            pending_rows=[],
+            resolution_issues=[],
+        )
+        prepared_db_path = Path("/tmp/prepared_decklist_import.db")
+
+        with (
+            patch(
+                "mtg_source_stack.inventory.decklist_import.parse_decklist_text_with_metadata",
+                return_value=parsed_decklist,
+            ),
+            patch(
+                "mtg_source_stack.inventory.decklist_import.prepare_database",
+                return_value=prepared_db_path,
+            ) as prepare_database,
+            patch(
+                "mtg_source_stack.inventory.decklist_import._resolve_decklist_import_plan",
+                return_value=plan,
+            ) as resolve_decklist_import_plan,
+            patch(
+                "mtg_source_stack.inventory.decklist_import._import_pending_rows",
+                return_value=[],
+            ) as import_pending_rows,
+        ):
+            result = import_decklist_text(
+                "collection.db",
+                deck_text="1 Test Card",
+                default_inventory="personal",
+            )
+
+        prepare_database.assert_called_once_with(
+            "collection.db",
+            schema_policy="initialize_if_needed",
+        )
+        self.assertEqual(prepared_db_path, resolve_decklist_import_plan.call_args.args[0])
+        self.assertEqual(prepared_db_path, import_pending_rows.call_args.args[0])
+        self.assertEqual(1, result["rows_seen"])
+
+    def test_import_decklist_text_accepts_require_current_schema_policy(self) -> None:
+        parsed_decklist = ParsedDecklistText(
+            deck_name=None,
+            entries=[ParsedDecklistEntry(line_number=1, quantity=1, name="Test Card")],
+        )
+        plan = PlannedDecklistImport(
+            deck_name=None,
+            rows_seen=1,
+            requested_card_quantity=1,
+            pending_rows=[],
+            resolution_issues=[],
+        )
+        prepared_db_path = Path("/tmp/prepared_decklist_import.db")
+
+        with (
+            patch(
+                "mtg_source_stack.inventory.decklist_import.parse_decklist_text_with_metadata",
+                return_value=parsed_decklist,
+            ),
+            patch(
+                "mtg_source_stack.inventory.decklist_import.prepare_database",
+                return_value=prepared_db_path,
+            ) as prepare_database,
+            patch(
+                "mtg_source_stack.inventory.decklist_import._resolve_decklist_import_plan",
+                return_value=plan,
+            ),
+            patch(
+                "mtg_source_stack.inventory.decklist_import._import_pending_rows",
+                return_value=[],
+            ),
+        ):
+            import_decklist_text(
+                "collection.db",
+                deck_text="1 Test Card",
+                default_inventory="personal",
+                schema_policy="require_current",
+            )
+
+        prepare_database.assert_called_once_with(
+            "collection.db",
+            schema_policy="require_current",
+        )
+
     def _insert_card(
         self,
         db_path: Path,

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1252,6 +1252,46 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual("Trade Binder", item_row["location"])
                 self.assertEqual(["trade", "staples"], json.loads(item_row["tags_json"]))
 
+    def test_demo_api_csv_import_uses_strict_schema_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            with self._client(db_path) as client:
+                with patch(
+                    "mtg_source_stack.api.routes.import_csv_stream",
+                    return_value={
+                        "csv_filename": "inventory_import.csv",
+                        "detected_format": "generic_csv",
+                        "default_inventory": None,
+                        "rows_seen": 0,
+                        "rows_written": 0,
+                        "ready_to_commit": True,
+                        "summary": {
+                            "total_card_quantity": 0,
+                            "distinct_card_names": 0,
+                            "distinct_printings": 0,
+                            "requested_card_quantity": 0,
+                            "unresolved_card_quantity": 0,
+                        },
+                        "resolution_issues": [],
+                        "dry_run": True,
+                        "imported_rows": [],
+                    },
+                ) as import_csv_stream:
+                    response = client.post(
+                        "/imports/csv",
+                        files={
+                            "file": (
+                                "inventory_import.csv",
+                                b"Inventory,Scryfall ID,Qty\npersonal,api-card-1,1\n",
+                                "text/csv",
+                            )
+                        },
+                        data={"dry_run": "true"},
+                    )
+
+                self.assertEqual(200, response.status_code)
+                self.assertEqual("require_current", import_csv_stream.call_args.kwargs["schema_policy"])
+
     def test_demo_api_csv_import_supports_preview_and_commit_but_not_implicit_inventory_creation(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "api.db"
@@ -1977,6 +2017,43 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual(1, item_row["quantity"])
                 self.assertEqual(("api", "local-demo", "req-decklist-commit"), tuple(audit_row))
 
+    def test_demo_api_decklist_import_uses_strict_schema_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            with self._client(db_path) as client:
+                with patch(
+                    "mtg_source_stack.api.routes.import_decklist_text",
+                    return_value={
+                        "deck_name": None,
+                        "default_inventory": "personal",
+                        "rows_seen": 0,
+                        "rows_written": 0,
+                        "ready_to_commit": True,
+                        "summary": {
+                            "total_card_quantity": 0,
+                            "distinct_card_names": 0,
+                            "distinct_printings": 0,
+                            "section_card_quantities": {},
+                            "requested_card_quantity": 0,
+                            "unresolved_card_quantity": 0,
+                        },
+                        "resolution_issues": [],
+                        "dry_run": True,
+                        "imported_rows": [],
+                    },
+                ) as import_decklist_text:
+                    response = client.post(
+                        "/imports/decklist",
+                        json={
+                            "deck_text": "1 API Test Card",
+                            "default_inventory": "personal",
+                            "dry_run": True,
+                        },
+                    )
+
+                self.assertEqual(200, response.status_code)
+                self.assertEqual("require_current", import_decklist_text.call_args.kwargs["schema_policy"])
+
     def test_demo_api_decklist_import_returns_resolution_issues_and_accepts_resolutions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "api.db"
@@ -2156,6 +2233,46 @@ class WebApiTest(unittest.TestCase):
 
                 self.assertEqual(4, item_row["quantity"])
                 self.assertEqual(("api", "local-demo", "req-deck-url-commit"), tuple(audit_row))
+
+    def test_demo_api_deck_url_import_uses_strict_schema_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            with self._client(db_path) as client:
+                with patch(
+                    "mtg_source_stack.api.routes.import_deck_url",
+                    return_value={
+                        "source_url": "https://archidekt.com/decks/123/test",
+                        "provider": "archidekt",
+                        "deck_name": None,
+                        "default_inventory": "personal",
+                        "rows_seen": 0,
+                        "rows_written": 0,
+                        "ready_to_commit": True,
+                        "source_snapshot_token": "snapshot-token",
+                        "summary": {
+                            "total_card_quantity": 0,
+                            "distinct_card_names": 0,
+                            "distinct_printings": 0,
+                            "section_card_quantities": {},
+                            "requested_card_quantity": 0,
+                            "unresolved_card_quantity": 0,
+                        },
+                        "resolution_issues": [],
+                        "dry_run": True,
+                        "imported_rows": [],
+                    },
+                ) as import_deck_url:
+                    response = client.post(
+                        "/imports/deck-url",
+                        json={
+                            "source_url": "https://archidekt.com/decks/123/test",
+                            "default_inventory": "personal",
+                            "dry_run": True,
+                        },
+                    )
+
+                self.assertEqual(200, response.status_code)
+                self.assertEqual("require_current", import_deck_url.call_args.kwargs["schema_policy"])
 
     def test_demo_api_deck_url_import_returns_resolution_issues_and_uses_snapshot_token(self) -> None:
         from mtg_source_stack.inventory.deck_url_import import RemoteDeckCard, RemoteDeckSource


### PR DESCRIPTION
## Summary
- add an explicit schema-preparation seam so API import routes require a current schema while CLI import entrypoints keep intentional local-first initialization behavior
- refactor CSV, decklist, and deck URL import entrypoints to prepare the database once and run planning/write helpers against the prepared DB path
- document that startup owns schema policy and API import requests do not auto-migrate during request handling

## Testing
- PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -q

Closes #49