### PR TITLE
Fail closed shared-service roles while preserving self-service ownership

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -43,7 +43,7 @@ Shared-service auth expects verified upstream headers:
 Current authz model:
 
 - `/health` is open
-- authenticated users with no roles header default to `editor`
+- authenticated users with no roles header have no global roles
 - `admin` implies `editor`
 - global proxy-backed app roles are `editor` and `admin`
 - local inventory membership roles are `viewer`, `editor`, and `owner`
@@ -53,8 +53,8 @@ Current authz model:
 - inventory reads require inventory membership or global `admin`
 - inventory writes require inventory `editor` / `owner` membership or global
   `admin`
-- `POST /inventories` still requires global `editor` / `admin`, and the creator
-  becomes `owner`
+- `POST /inventories` lets any authenticated user create an inventory and
+  become `owner`
 - `POST /inventories/{inventory_slug}/items/bulk` now supports grouped:
   - `add_tags`
   - `remove_tags`
@@ -70,10 +70,11 @@ Current authz model:
   selected-row and whole-inventory `copy` / `move` operations, `dry_run`
   previews, `on_conflict=fail|merge`, and `keep_acquisition`
 - `POST /inventories/{source_inventory_slug}/duplicate` creates a new inventory
-  atomically, copies all source rows into it, and grants the caller `owner`
+  atomically, copies all source rows into it, requires write access to the
+  source inventory, and grants the caller `owner`
 - `POST /me/bootstrap` creates one personal `Collection` inventory per
-  authenticated global `editor` / `admin`, grants `owner`, and returns that
-  same inventory on repeated calls
+  authenticated user, grants `owner`, and returns that same inventory on
+  repeated calls
 
 Important limitation:
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Deck URL preview/commit flows also use a short-lived signed snapshot token.
 `shared_service` also supports a normalized roles header,
 `X-Authenticated-Roles` by default, with `editor` and `admin` as the current
 recognized global app roles. If the verified user header is present and no
-roles header is supplied, the app defaults that user to `editor`. `admin`
-implies `editor`.
+roles header is supplied, the caller is authenticated with no global roles.
+`admin` implies `editor`.
 
 Inventory access is now controlled by local inventory memberships:
 
@@ -127,11 +127,10 @@ The current shared-service behavior is:
 - card search routes require a user who can read at least one inventory
 - inventory item/audit reads require membership on that inventory
 - inventory writes require `editor` or `owner` membership on that inventory
-- `POST /inventories` still requires a global `editor` or `admin` user, and the
-  creator is automatically granted `owner`
+- `POST /inventories` lets any authenticated user create an owned inventory
 - `POST /me/bootstrap` creates one personal default inventory named
-  `Collection` for a first-time global `editor` or `admin`, grants `owner`,
-  and returns the same inventory on repeated calls
+  `Collection` for an authenticated user, grants `owner`, and returns the same
+  inventory on repeated calls
 
 For the first live cohort, the recommended deployment shape is:
 
@@ -435,6 +434,8 @@ Operational expectations:
   as `X-Authenticated-User`
 - if you forward app roles, normalize them to global app roles `editor` and
   `admin` in a header such as `X-Authenticated-Roles`
+- if no roles header is forwarded, the user is authenticated with no global
+  roles but can still create and own their own inventories
 - publish the API to browsers through a same-origin reverse proxy, not by
   exposing the backend directly
 - validate snapshot backup and restore before live use
@@ -544,10 +545,11 @@ checkout in multi-repo environments.
   stamps writes as `local-demo` unless trusted-header mode is explicitly
   enabled.
 - In `shared_service`, non-health routes require an authenticated app user.
-  Inventory reads and writes are scoped by local memberships, while inventory
-  creation still requires a global `editor` or `admin` role. The default
-  verified identity header is `X-Authenticated-User`, and the default roles
-  header is `X-Authenticated-Roles`.
+  Inventory reads and writes are scoped by local memberships. Authenticated
+  users can create inventories they own; global roles are only for elevated app
+  permissions such as admin bypass. The default verified identity header is
+  `X-Authenticated-User`, and the default roles header is
+  `X-Authenticated-Roles`.
 - The recommended first-live deployment is same-origin and proxy-based. The
   backend is not yet intended to be exposed directly to browsers on a separate
   origin.

--- a/docs/api_v1_contract.md
+++ b/docs/api_v1_contract.md
@@ -284,8 +284,8 @@ preserve for the first API-backed version of the project.
       previews can stay bounded without losing summary accuracy
 - `POST /inventories/{source_inventory_slug}/duplicate`
   - creates a brand-new target inventory and copies every source row into it
-  - requires the same inventory-creation permission as `POST /inventories`
-  - also requires write access to the source inventory in shared-service mode
+  - requires write access to the source inventory in shared-service mode
+  - grants the caller `owner` membership on the new inventory
   - `target_description` is optional; when omitted, the source inventory
     description is copied to the new inventory
   - source inventory memberships are not copied to the new inventory
@@ -538,8 +538,8 @@ before the generic 500 envelope is returned.
   default header name is `X-Authenticated-Roles`, and it can be overridden with
   `MTG_API_AUTHENTICATED_ROLES_HEADER`.
 - The current recognized global app roles are `editor` and `admin`.
-- If the verified user header is present and the roles header is missing, the
-  API defaults that caller to `editor`.
+- If the verified user header is present and the roles header is missing or
+  blank, the API authenticates that caller with no global roles.
 - `admin` implies `editor`.
 - Shared-service inventory access is also scoped by local inventory
   memberships:
@@ -563,22 +563,21 @@ before the generic 500 envelope is returned.
 - `POST /inventories/{source_inventory_slug}/transfer` requires write access to
   both the source inventory in the path and the target inventory in the
   request body; global `admin` bypasses both checks.
-- `POST /inventories/{source_inventory_slug}/duplicate` requires the same
-  global `editor` or `admin` permission as `POST /inventories`, plus write
-  access to the source inventory; global `admin` bypasses the inventory
-  membership check.
+- `POST /inventories/{source_inventory_slug}/duplicate` requires write access
+  to the source inventory; global `admin` bypasses the inventory membership
+  check. The caller becomes `owner` of the duplicated inventory.
 - In `shared_service`, `POST /imports/csv`, `POST /imports/decklist`, and
   `POST /imports/deck-url` validate write access against every referenced
   inventory before committing any rows. For `POST /imports/deck-url`, the
   target inventory is validated before the backend fetches the remote deck.
-- `POST /inventories` still requires a global `editor` or `admin`, and the
-  creator is automatically granted `owner` membership on the new inventory.
+- `POST /inventories` lets any authenticated caller create an inventory, and
+  the creator is automatically granted `owner` membership on the new inventory.
   Inventory slugs are trimmed before create-time uniqueness checks and
   storage, and inventory path/body slugs are resolved using that same trimmed
   canonical value.
-- `POST /me/bootstrap` requires a global `editor` or `admin`, creates one
-  personal default inventory named `Collection` for that actor, grants
-  `owner`, and returns the same inventory on repeated calls.
+- `POST /me/bootstrap` creates one personal default inventory named
+  `Collection` for an authenticated actor, grants `owner`, and returns the same
+  inventory on repeated calls.
 - `GET /me/access-summary` returns a small onboarding-state summary for the
   authenticated actor:
   - `can_bootstrap`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,11 +133,10 @@ shared service.
   - local inventory membership roles: `viewer`, `editor`, `owner`
 - Inventory listing, inventory reads, and inventory writes are now scoped by
   local memberships, with global `admin` as the bypass.
-- Inventory creation still requires a global `editor` or `admin`, and the
-  creator becomes `owner` on the new inventory.
+- Inventory creation is available to authenticated users, and the creator
+  becomes `owner` on the new inventory.
 - First-run shared-service onboarding can now use `POST /me/bootstrap` to
-  create one owned personal `Collection` inventory for an authenticated global
-  `editor` or `admin`.
+  create one owned personal `Collection` inventory for an authenticated user.
 - The recommended first-live deployment is same-origin through a reverse proxy
   that publishes `/api`, strips that prefix before forwarding, and injects
   verified identity headers.

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -293,7 +293,9 @@ export default {
   deliberately enabled.
 - `shared_service` uses verified upstream identity headers such as
   `X-Authenticated-User` and optionally `X-Authenticated-Roles`; frontend code
-  should not treat `X-Actor-Id` as the shared-service auth model.
+  should not treat `X-Actor-Id` as the shared-service auth model. A missing
+  roles header means the user has no global roles, not that they are a global
+  `editor`.
 - Shared-service inventory access is now membership-scoped. Frontend code
   should assume:
   - inventory lists are filtered to the current user
@@ -302,6 +304,7 @@ export default {
   - catalog search should not be treated as globally available to every
     authenticated user; it currently requires a user who can read at least one
     inventory, or a global `admin`
+  - authenticated users can create inventories they own
   - first-run shared-service users can call `POST /me/bootstrap` to create a
     personal `Collection` inventory and unlock search/add flows
 

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -35,7 +35,8 @@ Recommended normalized roles:
 
 The app currently treats:
 
-- authenticated users with no roles header as `editor`
+- authenticated users with no roles header as authenticated users with no
+  global roles
 - `admin` as implying `editor`
 
 These are global app roles from the proxy, not per-inventory roles.
@@ -64,11 +65,10 @@ Effective behavior:
   inventory, or a global `admin`
 - inventory writes require `editor` or `owner` membership on that inventory,
   or a global `admin`
-- `POST /inventories` still requires a global `editor` or `admin`, and the
-  creator automatically becomes `owner`
-- `POST /me/bootstrap` lets a first-time global `editor` or `admin` create one
-  owned personal `Collection` inventory and returns that same inventory on
-  repeated calls
+- `POST /inventories` lets any authenticated user create an inventory and
+  automatically become `owner`
+- `POST /me/bootstrap` lets any authenticated user create one owned personal
+  `Collection` inventory and returns that same inventory on repeated calls
 
 Important rollout note:
 

--- a/src/mtg_source_stack/api/dependencies.py
+++ b/src/mtg_source_stack/api/dependencies.py
@@ -204,7 +204,7 @@ def _resolve_shared_service_roles(request: "Request", settings: ApiSettings, act
         return frozenset()
     raw_roles = request.headers.get(settings.authenticated_roles_header, "").strip()
     if not raw_roles:
-        return frozenset({"editor"})
+        return frozenset()
     return _normalize_roles(raw_roles)
 
 

--- a/src/mtg_source_stack/api/routes.py
+++ b/src/mtg_source_stack/api/routes.py
@@ -54,7 +54,6 @@ from ..inventory.service import (
 from .dependencies import (
     ApiSettings,
     RequestContext,
-    get_editor_request_context,
     get_inventory_read_request_context,
     get_inventory_write_request_context,
     get_inventory_scoped_read_request_context,
@@ -340,7 +339,7 @@ def inventories_list(
 def inventories_create(
     payload: InventoryCreateRequest,
     settings: Annotated[ApiSettings, Depends(get_settings)],
-    context: Annotated[RequestContext, Depends(get_editor_request_context)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
 ) -> Any:
     return _serialize(
         create_inventory(
@@ -365,7 +364,7 @@ def inventories_create(
 )
 def bootstrap_default_inventory(
     settings: Annotated[ApiSettings, Depends(get_settings)],
-    context: Annotated[RequestContext, Depends(get_editor_request_context)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
 ) -> Any:
     return _serialize(
         ensure_default_inventory(
@@ -404,7 +403,7 @@ def inventories_duplicate(
     source_inventory_slug: str,
     payload: InventoryDuplicateRequest,
     settings: Annotated[ApiSettings, Depends(get_settings)],
-    context: Annotated[RequestContext, Depends(get_editor_request_context)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
 ) -> Any:
     require_inventory_write_access(settings, context, inventory_slug=source_inventory_slug)
     return _serialize(

--- a/src/mtg_source_stack/inventory/inventories.py
+++ b/src/mtg_source_stack/inventory/inventories.py
@@ -8,7 +8,7 @@ from typing import Iterable
 
 from ..db.connection import connect
 from ..db.schema import require_current_schema
-from ..errors import AuthorizationError, ConflictError, ValidationError
+from ..errors import ConflictError, ValidationError
 from .access import grant_inventory_membership_with_connection, is_global_admin
 from .money import coerce_decimal
 from .normalize import normalize_currency_code, normalize_inventory_slug, normalize_tag_text, slugify_inventory_name, text_or_none
@@ -87,15 +87,8 @@ def _normalize_inventory_metadata(
     )
 
 
-def _require_global_editor_or_admin(actor_roles: Iterable[str]) -> None:
-    roles = set(actor_roles)
-    if "editor" not in roles and "admin" not in roles:
-        raise AuthorizationError("Role 'editor' is required to bootstrap a default inventory.")
-
-
-def _can_bootstrap_default_inventory(actor_roles: Iterable[str]) -> bool:
-    roles = set(actor_roles)
-    return "editor" in roles or "admin" in roles
+def _can_bootstrap_default_inventory(actor_id: str | None) -> bool:
+    return _normalized_visible_actor_id(actor_id) is not None
 
 
 def _default_inventory_slug_root(actor_id: str) -> str:
@@ -258,7 +251,6 @@ def ensure_default_inventory(
     normalized_actor_id = _normalized_visible_actor_id(actor_id)
     if normalized_actor_id is None:
         raise ValidationError("actor_id is required.")
-    _require_global_editor_or_admin(actor_roles)
 
     db_file = require_current_schema(db_path)
     with connect(db_file) as connection:
@@ -438,7 +430,7 @@ def summarize_actor_access(
             actor_id=normalized_actor_id,
         )
     return AccessSummaryResult(
-        can_bootstrap=_can_bootstrap_default_inventory(actor_roles),
+        can_bootstrap=_can_bootstrap_default_inventory(normalized_actor_id),
         has_readable_inventory=bool(visible_inventories),
         visible_inventory_count=len(visible_inventories),
         default_inventory_slug=(default_inventory.slug if default_inventory is not None else None),

--- a/tests/test_api_dependencies.py
+++ b/tests/test_api_dependencies.py
@@ -165,7 +165,7 @@ class ApiDependenciesTest(unittest.TestCase):
         self.assertEqual("dev-user", context.actor_id)
         self.assertEqual(frozenset({"editor", "admin"}), context.roles)
 
-    def test_shared_service_authenticated_context_uses_authenticated_actor_header(self) -> None:
+    def test_shared_service_authenticated_context_uses_authenticated_actor_header_without_default_roles(self) -> None:
         settings = ApiSettings(
             db_path="test.db",
             runtime_mode="shared_service",
@@ -182,6 +182,50 @@ class ApiDependenciesTest(unittest.TestCase):
         context = get_authenticated_request_context(request)
 
         self.assertEqual("shared-user", context.actor_id)
+        self.assertEqual(frozenset(), context.roles)
+
+    def test_shared_service_authenticated_context_treats_blank_roles_header_as_no_global_roles(self) -> None:
+        settings = ApiSettings(
+            db_path="test.db",
+            runtime_mode="shared_service",
+            auto_migrate=False,
+            host="127.0.0.1",
+            port=8000,
+        )
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(settings=settings)),
+            state=SimpleNamespace(),
+            headers={
+                "X-Authenticated-User": "shared-user",
+                "X-Authenticated-Roles": "  ",
+            },
+        )
+
+        context = get_authenticated_request_context(request)
+
+        self.assertEqual("shared-user", context.actor_id)
+        self.assertEqual(frozenset(), context.roles)
+
+    def test_shared_service_authenticated_context_can_parse_editor_role_header(self) -> None:
+        settings = ApiSettings(
+            db_path="test.db",
+            runtime_mode="shared_service",
+            auto_migrate=False,
+            host="127.0.0.1",
+            port=8000,
+        )
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(settings=settings)),
+            state=SimpleNamespace(),
+            headers={
+                "X-Authenticated-User": "shared-editor",
+                "X-Authenticated-Roles": "editor",
+            },
+        )
+
+        context = get_authenticated_request_context(request)
+
+        self.assertEqual("shared-editor", context.actor_id)
         self.assertEqual(frozenset({"editor"}), context.roles)
 
     def test_shared_service_authenticated_context_can_parse_admin_role_header(self) -> None:
@@ -244,7 +288,7 @@ class ApiDependenciesTest(unittest.TestCase):
         with self.assertRaises(AuthenticationError):
             get_mutating_request_context(request)
 
-    def test_shared_service_editor_context_allows_default_editor_role(self) -> None:
+    def test_shared_service_editor_context_rejects_missing_roles_header(self) -> None:
         settings = ApiSettings(
             db_path="test.db",
             runtime_mode="shared_service",
@@ -258,9 +302,29 @@ class ApiDependenciesTest(unittest.TestCase):
             headers={"X-Authenticated-User": "shared-user"},
         )
 
+        with self.assertRaises(AuthorizationError):
+            get_editor_request_context(request)
+
+    def test_shared_service_editor_context_allows_explicit_editor_role(self) -> None:
+        settings = ApiSettings(
+            db_path="test.db",
+            runtime_mode="shared_service",
+            auto_migrate=False,
+            host="127.0.0.1",
+            port=8000,
+        )
+        request = SimpleNamespace(
+            app=SimpleNamespace(state=SimpleNamespace(settings=settings)),
+            state=SimpleNamespace(),
+            headers={
+                "X-Authenticated-User": "shared-editor",
+                "X-Authenticated-Roles": "editor",
+            },
+        )
+
         context = get_editor_request_context(request)
 
-        self.assertEqual("shared-user", context.actor_id)
+        self.assertEqual("shared-editor", context.actor_id)
         self.assertEqual(frozenset({"editor"}), context.roles)
 
     def test_shared_service_editor_context_allows_admin_role(self) -> None:
@@ -295,7 +359,10 @@ class ApiDependenciesTest(unittest.TestCase):
         request = SimpleNamespace(
             app=SimpleNamespace(state=SimpleNamespace(settings=settings)),
             state=SimpleNamespace(),
-            headers={"X-Authenticated-User": "shared-user"},
+            headers={
+                "X-Authenticated-User": "shared-user",
+                "X-Authenticated-Roles": "editor",
+            },
         )
 
         with self.assertRaises(AuthorizationError):

--- a/tests/test_inventory_access.py
+++ b/tests/test_inventory_access.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from mtg_source_stack.db.connection import connect
 from mtg_source_stack.db.schema import initialize_database
-from mtg_source_stack.errors import AuthorizationError, NotFoundError, ValidationError
+from mtg_source_stack.errors import NotFoundError, ValidationError
 from mtg_source_stack.inventory.service import (
     actor_can_read_any_inventory,
     actor_can_read_inventory,
@@ -128,7 +128,7 @@ class InventoryAccessTest(unittest.TestCase):
             created = ensure_default_inventory(
                 db_path,
                 actor_id="alice@example.com",
-                actor_roles={"editor"},
+                actor_roles=frozenset(),
             )
             self.assertTrue(created.created)
             self.assertEqual("Collection", created.inventory.display_name)
@@ -142,7 +142,7 @@ class InventoryAccessTest(unittest.TestCase):
             repeated = ensure_default_inventory(
                 db_path,
                 actor_id="alice@example.com",
-                actor_roles={"editor"},
+                actor_roles=frozenset(),
             )
             self.assertFalse(repeated.created)
             self.assertEqual(created.inventory.inventory_id, repeated.inventory.inventory_id)
@@ -184,7 +184,7 @@ class InventoryAccessTest(unittest.TestCase):
             created = ensure_default_inventory(
                 db_path,
                 actor_id="alice@example.com",
-                actor_roles={"editor"},
+                actor_roles=frozenset(),
             )
 
             self.assertTrue(created.created)
@@ -232,7 +232,7 @@ class InventoryAccessTest(unittest.TestCase):
             created = ensure_default_inventory(
                 db_path,
                 actor_id="alice@example.com",
-                actor_roles={"editor"},
+                actor_roles=frozenset(),
             )
 
             self.assertTrue(created.created)
@@ -244,22 +244,32 @@ class InventoryAccessTest(unittest.TestCase):
                     for row in list_visible_inventories(
                         db_path,
                         actor_id="alice@example.com",
-                        actor_roles={"editor"},
+                        actor_roles=frozenset(),
                     )
                 ],
             )
 
-    def test_ensure_default_inventory_requires_global_editor_or_admin(self) -> None:
+    def test_ensure_default_inventory_allows_authenticated_actor_without_global_roles(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "collection.db"
             initialize_database(db_path)
 
-            with self.assertRaisesRegex(AuthorizationError, "Role 'editor' is required"):
-                ensure_default_inventory(
+            created = ensure_default_inventory(
+                db_path,
+                actor_id="viewer@example.com",
+                actor_roles=frozenset(),
+            )
+
+            self.assertTrue(created.created)
+            self.assertEqual("viewer-collection", created.inventory.slug)
+            self.assertEqual(
+                "owner",
+                actor_inventory_role(
                     db_path,
+                    inventory_slug="viewer-collection",
                     actor_id="viewer@example.com",
-                    actor_roles={"viewer"},
-                )
+                ),
+            )
 
     def test_list_visible_inventories_filters_memberships_with_admin_bypass(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -17,7 +17,12 @@ from unittest.mock import patch
 
 from mtg_source_stack.db.connection import connect
 from mtg_source_stack.db.schema import initialize_database
-from mtg_source_stack.inventory.service import create_inventory, grant_inventory_membership, import_deck_url
+from mtg_source_stack.inventory.service import (
+    actor_inventory_role,
+    create_inventory,
+    grant_inventory_membership,
+    import_deck_url,
+)
 
 
 FASTAPI_TESTING_AVAILABLE = (
@@ -4792,15 +4797,15 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual(401, create_with_wrong_header.status_code)
                 self.assertEqual("authentication_required", create_with_wrong_header.json()["error"]["code"])
 
-                bootstrap_with_viewer_role = client.post(
+                bootstrap_with_non_global_role = client.post(
                     "/me/bootstrap",
                     headers={
                         "X-Authenticated-User": "shared-viewer",
                         "X-Authenticated-Roles": "viewer",
                     },
                 )
-                self.assertEqual(403, bootstrap_with_viewer_role.status_code)
-                self.assertEqual("forbidden", bootstrap_with_viewer_role.json()["error"]["code"])
+                self.assertEqual(200, bootstrap_with_non_global_role.status_code)
+                self.assertEqual("shared-viewer-collection", bootstrap_with_non_global_role.json()["inventory"]["slug"])
 
                 created_inventory = client.post(
                     "/inventories",
@@ -4808,6 +4813,14 @@ class WebApiTest(unittest.TestCase):
                     json={"slug": "personal", "display_name": "Personal Collection"},
                 )
                 self.assertEqual(201, created_inventory.status_code)
+                self.assertEqual(
+                    "owner",
+                    actor_inventory_role(
+                        db_path,
+                        inventory_slug="personal",
+                        actor_id="shared-user",
+                    ),
+                )
 
                 import_without_auth = client.post(
                     "/imports/csv",
@@ -4916,7 +4929,7 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual(200, viewer_summary.status_code)
                 self.assertEqual(
                     {
-                        "can_bootstrap": False,
+                        "can_bootstrap": True,
                         "has_readable_inventory": True,
                         "visible_inventory_count": 1,
                         "default_inventory_slug": None,
@@ -4932,7 +4945,7 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual(200, outsider_summary.status_code)
                 self.assertEqual(
                     {
-                        "can_bootstrap": False,
+                        "can_bootstrap": True,
                         "has_readable_inventory": False,
                         "visible_inventory_count": 0,
                         "default_inventory_slug": None,
@@ -5062,10 +5075,7 @@ class WebApiTest(unittest.TestCase):
                 "X-Authenticated-User": "editor-user",
                 "X-Authenticated-Roles": "viewer",
             }
-            outsider_headers = {
-                "X-Authenticated-User": "outsider-user",
-                "X-Authenticated-Roles": "viewer",
-            }
+            outsider_headers = {"X-Authenticated-User": "outsider-user"}
             admin_headers = {
                 "X-Authenticated-User": "admin-user",
                 "X-Authenticated-Roles": "admin",
@@ -5416,15 +5426,15 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual("moved", allowed.json()["results"][0]["status"])
                 self.assertEqual("target", allowed.json()["target_inventory"])
 
-    def test_shared_service_duplicate_requires_editor_role_and_source_write_access(self) -> None:
+    def test_shared_service_duplicate_requires_source_write_access_and_grants_owner(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "api.db"
             initialize_database(db_path)
-            viewer_headers = {
-                "X-Authenticated-User": "viewer-user",
+            read_only_headers = {
+                "X-Authenticated-User": "read-only-user",
                 "X-Authenticated-Roles": "viewer",
             }
-            editor_headers = {"X-Authenticated-User": "editor-user"}
+            writer_headers = {"X-Authenticated-User": "writer-user"}
 
             create_inventory(
                 db_path,
@@ -5436,13 +5446,13 @@ class WebApiTest(unittest.TestCase):
             grant_inventory_membership(
                 db_path,
                 inventory_slug="source",
-                actor_id="viewer-user",
-                role="editor",
+                actor_id="read-only-user",
+                role="viewer",
             )
             grant_inventory_membership(
                 db_path,
                 inventory_slug="source",
-                actor_id="editor-user",
+                actor_id="writer-user",
                 role="editor",
             )
 
@@ -5457,7 +5467,7 @@ class WebApiTest(unittest.TestCase):
 
                 denied = client.post(
                     "/inventories/source/duplicate",
-                    headers=viewer_headers,
+                    headers=read_only_headers,
                     json={
                         "target_slug": "source-copy",
                         "target_display_name": "Source Copy",
@@ -5465,11 +5475,11 @@ class WebApiTest(unittest.TestCase):
                 )
                 self.assertEqual(403, denied.status_code)
                 self.assertEqual("forbidden", denied.json()["error"]["code"])
-                self.assertIn("Role 'editor' is required", denied.json()["error"]["message"])
+                self.assertIn("Write access to inventory 'source' is required", denied.json()["error"]["message"])
 
                 allowed = client.post(
                     "/inventories/source/duplicate",
-                    headers=editor_headers,
+                    headers=writer_headers,
                     json={
                         "target_slug": " source-copy ",
                         "target_display_name": "Source Copy",
@@ -5479,6 +5489,14 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual("source-copy", allowed.json()["inventory"]["slug"])
                 self.assertEqual("source-copy", allowed.json()["transfer"]["target_inventory"])
                 self.assertEqual(1, allowed.json()["transfer"]["copied_count"])
+                self.assertEqual(
+                    "owner",
+                    actor_inventory_role(
+                        db_path,
+                        inventory_slug="source-copy",
+                        actor_id="writer-user",
+                    ),
+                )
 
     def test_shared_service_uses_authenticated_actor_header_for_audit_attribution(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- stop treating a missing or blank `X-Authenticated-Roles` header as implicit global `editor`
- allow authenticated users without global roles to bootstrap and create inventories they own
- make inventory duplication require write access to the source inventory, then grant `owner` on the duplicated inventory
- update shared-service docs and contract notes for the self-service ownership model

## Testing
- PYTHONPATH=src .venv/bin/python -m unittest tests.test_api_dependencies tests.test_inventory_access tests.test_web_api tests.test_api_app tests.test_api_contract -q
- PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -q

Full suite result: Ran 408 tests in 25.113s, OK (skipped=81).

Closes #48