### PR TITLE
Resolve issue 39 quick-add printing summary

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -103,11 +103,12 @@ Important limitation:
 
 ## Search Model Notes
 
-There are now three closely related app-facing search surfaces:
+There are now four closely related app-facing search surfaces:
 
 - `GET /cards/search`
 - `GET /cards/search/names`
 - `GET /cards/oracle/{oracle_id}/printings`
+- `GET /cards/oracle/{oracle_id}/printings/summary`
 
 Current behavior:
 
@@ -121,6 +122,9 @@ Current behavior:
   broaden automatically
 - when `lang` is omitted for quick-add, the resolver prefers English, then
   mainstream paper printings, then newer printings with stable ties
+- the quick-add printing summary route exposes the backend default add choice,
+  available languages, scoped printing count, and primary/preferred printings;
+  full all-language browsing remains an explicit `lang=all` printings lookup
 
 Migration `0008` note:
 

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -874,6 +874,58 @@
         "title": "CatalogPrintingLookupRowResponse",
         "type": "object"
       },
+      "CatalogPrintingSummaryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "available_languages": {
+            "description": "Catalog language codes available for the matched card. Common values include: en, ja, de, fr, it, es, pt, ru, ko, zhs, zht, ph.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Available Languages",
+            "type": "array"
+          },
+          "default_printing": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CatalogPrintingLookupRowResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "has_more_printings": {
+            "title": "Has More Printings",
+            "type": "boolean"
+          },
+          "oracle_id": {
+            "title": "Oracle Id",
+            "type": "string"
+          },
+          "printings": {
+            "items": {
+              "$ref": "#/components/schemas/CatalogPrintingLookupRowResponse"
+            },
+            "title": "Printings",
+            "type": "array"
+          },
+          "printings_count": {
+            "title": "Printings Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "oracle_id",
+          "default_printing",
+          "available_languages",
+          "printings_count",
+          "has_more_printings",
+          "printings"
+        ],
+        "title": "CatalogPrintingSummaryResponse",
+        "type": "object"
+      },
       "CatalogSearchRowResponse": {
         "additionalProperties": false,
         "properties": {
@@ -5143,6 +5195,117 @@
           }
         },
         "summary": "Card Printings Lookup"
+      }
+    },
+    "/cards/oracle/{oracle_id}/printings/summary": {
+      "get": {
+        "operationId": "card_printings_summary_cards_oracle__oracle_id__printings_summary_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "oracle_id",
+            "required": true,
+            "schema": {
+              "title": "Oracle Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Catalog scope to search. Omit this parameter or use `default` for the mainline card-add flow. Use `all` to include auxiliary catalog objects such as tokens, emblems, and art-series rows.",
+            "in": "query",
+            "name": "scope",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Catalog scope to search. Omit this parameter or use `default` for the mainline card-add flow. Use `all` to include auxiliary catalog objects such as tokens, emblems, and art-series rows.",
+              "enum": [
+                "default",
+                "all"
+              ],
+              "title": "Scope"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogPrintingSummaryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Card Printings Summary"
       }
     },
     "/cards/search": {

--- a/docs/api_v1_contract.md
+++ b/docs/api_v1_contract.md
@@ -196,6 +196,17 @@ preserve for the first API-backed version of the project.
     printing the backend would choose for omitted-finish quick-add
   - marks exactly one row when omitted-finish quick-add resolves successfully;
     foil-only or otherwise incompatible quick-add cases leave every row unmarked
+- `GET /cards/oracle/{oracle_id}/printings/summary`
+  - returns the quick-add printing summary for one `oracle_id`
+  - uses the same default mainline add-flow scope as the app-facing search
+    routes
+  - query `scope` accepts `default` or `all`
+  - returns `default_printing` when omitted-finish quick-add can resolve one
+  - returns `available_languages` across all scoped printings
+  - returns `printings_count`, `has_more_printings`, and the primary/preferred
+    `printings` subset suitable for the initial quick-add picker
+  - full all-language browsing remains on
+    `GET /cards/oracle/{oracle_id}/printings?lang=all`
 - `PATCH /inventories/{inventory_slug}/items/{item_id}/printing`
   - requires a target `scryfall_id` for another printing of the same `oracle_id`
   - clients may resubmit the current `scryfall_id` only to confirm a

--- a/docs/frontend_backend_requests/local_first_bootstrap_and_printing_lookup_support.md
+++ b/docs/frontend_backend_requests/local_first_bootstrap_and_printing_lookup_support.md
@@ -7,66 +7,51 @@ Feature / screen:
 - local-app first-run onboarding
 - card search quick-add printing resolution
 
-Current blocker:
+Current status after rescope:
 
-- The repo is drifting toward a local-app setup, but the backend-supported
-  first-run path is still framed mainly as a shared-service bootstrap flow.
-  The frontend can create inventories manually today, but there is no clearly
-  supported, idempotent local-first way to say "ensure this local install has a
-  primary collection and open it".
-- In quick-add search, the frontend wants to keep the printing picker
-  unselected while still using the backend's default add choice if the user
-  clicks Add immediately. To preserve that behavior and still know whether to
-  expose other-language choices, the current UI ends up loading the full
-  all-language printing list eagerly for the active card. That will get
-  noticeably heavier as the app moves from demo data to real local catalogs.
+- The local/shared first-run path is now covered by `GET /me/access-summary`
+  plus idempotent `POST /me/bootstrap`. That part of the original request is
+  treated as satisfied and should not gain another competing bootstrap route.
+- The remaining backend contract need is a lightweight quick-add printing
+  summary so the frontend can get the default add choice, language availability,
+  and primary/preferred printings without using the full all-language printing
+  lookup.
 
 Endpoint involved:
 
-- `POST /me/bootstrap`
+- `GET /me/access-summary`
 - `GET /cards/oracle/{oracle_id}/printings`
+- `GET /cards/oracle/{oracle_id}/printings/summary`
 
 Current behavior:
 
-- `POST /me/bootstrap` is documented as the intended first-run escape hatch for
-  authenticated shared-service users. In local-demo mode, the app still
-  supports ordinary `POST /inventories`, but the local-first semantics of
-  `/me/bootstrap` are not the main documented story.
+- `GET /me/access-summary` is the startup probe for onboarding-state decisions,
+  and `POST /me/bootstrap` creates or returns one default `Collection` for an
+  eligible caller.
 - `GET /cards/oracle/{oracle_id}/printings` returns printing rows and supports
-  `lang` and `scope`. The frontend can request `lang=all`, but that is a
-  detail-heavy response shape when the UI only needs:
-  - the default add choice
-  - whether English is available
-  - whether other languages exist
-  - the smaller initial printing set for the default quick-add path
+  `lang` and `scope`. Omitting `lang` already returns the default primary
+  language subset, and `lang=all` remains the explicit full-browse expansion.
 
 Requested change:
 
-- Clarify and support a deterministic local-first bootstrap contract. Any of
-  these additive options would work:
-  - make `POST /me/bootstrap` explicitly supported and documented for local app
-    startup as an idempotent "ensure my default collection exists" flow
-  - add a dedicated local-safe bootstrap / ensure-default-inventory route
-  - publish stronger contract guidance that local installs should use a
-    different supported bootstrap path instead of inheriting shared-service
-    wording
-- Add a lighter-weight printing lookup mode for quick-add, while preserving the
-  existing full lookup route for explicit printing browsing. Any of these
-  additive shapes would work:
-  - a dedicated default-printing route for an `oracle_id`
-  - additive query params on `/cards/oracle/{oracle_id}/printings` that return
-    only the default / preferred subset first
-  - a summary response that exposes the default add choice plus language
-    availability before the frontend asks for every printing
+- Add a backend/API quick-add printing summary endpoint while preserving the
+  existing full lookup route for explicit printing browsing:
+  - `GET /cards/oracle/{oracle_id}/printings/summary`
+  - return the backend default add choice when one exists
+  - return `available_languages` across all scoped printings
+  - return `printings_count` and `has_more_printings`
+  - return the primary/preferred `printings` subset that is suitable for the
+    quick-add picker
+  - keep full all-language browsing on `GET /cards/oracle/{oracle_id}/printings?lang=all`
 
 Example request JSON:
 
 ```json
-POST /me/bootstrap
+GET /me/access-summary
 ```
 
 ```json
-GET /cards/oracle/{oracle_id}/printings?lang=en
+GET /cards/oracle/{oracle_id}/printings/summary
 ```
 
 Example response JSON:
@@ -92,6 +77,7 @@ Example response JSON:
     "is_default_add_choice": true
   },
   "available_languages": ["en", "ja"],
+  "printings_count": 27,
   "has_more_printings": true,
   "printings": [
     {
@@ -114,13 +100,10 @@ Example response JSON:
 
 Expected error cases:
 
-- `400` validation if a new printing-lookup mode or query-parameter
-  combination is invalid
+- `400` validation if `scope` is invalid
 - `401` / `403` should keep the current shared-service auth behavior where
   applicable
 - `404` when the requested `oracle_id` does not exist
-- local-first bootstrap should be idempotent rather than returning a conflict
-  for an already-initialized install
 
 Compatibility note:
 

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -81,7 +81,11 @@ Use this as the first-pass UI-to-endpoint map:
   grouped matches are absent.
   - if the frontend opts into `scope=all`, keep that same scope choice when
     moving from card-name search to printing lookup
-- Printing lookup for a selected card -> `GET /cards/oracle/{oracle_id}/printings`
+- Quick-add printing summary for a selected card ->
+  `GET /cards/oracle/{oracle_id}/printings/summary`
+  Returns the backend default add choice, available languages, scoped printing
+  count, and the primary/preferred printings for the initial picker.
+- Full printing lookup for a selected card -> `GET /cards/oracle/{oracle_id}/printings`
   Defaults to English printings when available; use `lang=all` or a specific
   language code to expand the list.
   - also accepts `scope=all` when the frontend intentionally wants the broader

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -8,6 +8,7 @@ import type {
   CatalogNameSearchResult,
   CatalogNameSearchRow,
   CatalogPrintingLookupRow,
+  CatalogPrintingSummaryResponse,
   InventoryAuditEvent,
   InventoryCreateResponse,
   InventorySummary,
@@ -23,6 +24,7 @@ vi.mock("./api", async () => {
     listInventoryAudit: vi.fn(),
     searchCardNames: vi.fn(),
     listCardPrintings: vi.fn(),
+    getCardPrintingSummary: vi.fn(),
     addInventoryItem: vi.fn(),
     bulkMutateInventoryItems: vi.fn(),
     createInventory: vi.fn(),
@@ -42,6 +44,7 @@ import {
   importCsv,
   importDeckUrl,
   importDecklist,
+  getCardPrintingSummary,
   listCardPrintings,
   listInventories,
   listInventoryItems,
@@ -103,6 +106,27 @@ describe("App", () => {
       image_uri_small: null,
       image_uri_normal: null,
       is_default_add_choice: false,
+      ...overrides,
+    };
+  }
+
+  function buildPrintingSummary(
+    printings: CatalogPrintingLookupRow[] = [],
+    overrides: Partial<CatalogPrintingSummaryResponse> = {},
+  ): CatalogPrintingSummaryResponse {
+    const defaultPrinting =
+      printings.find((printing) => printing.is_default_add_choice) || null;
+    const availableLanguages = Array.from(
+      new Set(printings.map((printing) => printing.lang)),
+    );
+
+    return {
+      oracle_id: "bolt-oracle",
+      default_printing: defaultPrinting,
+      available_languages: availableLanguages.length ? availableLanguages : ["en"],
+      printings_count: printings.length,
+      has_more_printings: false,
+      printings,
       ...overrides,
     };
   }
@@ -257,6 +281,7 @@ describe("App", () => {
     vi.mocked(listInventoryAudit).mockResolvedValue(auditEvents);
     vi.mocked(searchCardNames).mockResolvedValue(buildNameSearchResult());
     vi.mocked(listCardPrintings).mockResolvedValue([]);
+    vi.mocked(getCardPrintingSummary).mockResolvedValue(buildPrintingSummary());
     vi.mocked(importCsv).mockResolvedValue(buildCsvImportResponse());
     vi.mocked(importDeckUrl).mockResolvedValue(buildDeckUrlImportResponse());
     vi.mocked(importDecklist).mockResolvedValue(buildDecklistImportResponse());
@@ -293,6 +318,7 @@ describe("App", () => {
     vi.mocked(listInventoryAudit).mockResolvedValue([]);
     vi.mocked(searchCardNames).mockResolvedValue(buildNameSearchResult());
     vi.mocked(listCardPrintings).mockResolvedValue([]);
+    vi.mocked(getCardPrintingSummary).mockResolvedValue(buildPrintingSummary());
     vi.mocked(importCsv).mockResolvedValue(buildCsvImportResponse());
     vi.mocked(importDeckUrl).mockResolvedValue(buildDeckUrlImportResponse());
     vi.mocked(importDecklist).mockResolvedValue(buildDecklistImportResponse());
@@ -1046,25 +1072,27 @@ describe("App", () => {
       }
       return buildNameSearchResult();
     });
-    vi.mocked(listCardPrintings).mockResolvedValue([
-      buildSearchRow({
-        scryfall_id: "bolt-alpha",
-        name: "Lightning Bolt",
-        set_code: "lea",
-        set_name: "Limited Edition Alpha",
-        collector_number: "161",
-        finishes: ["normal"],
-      }),
-      buildSearchRow({
-        scryfall_id: "bolt-m11",
-        name: "Lightning Bolt",
-        set_code: "m11",
-        set_name: "Magic 2011",
-        collector_number: "146",
-        finishes: ["normal", "foil"],
-        is_default_add_choice: true,
-      }),
-    ]);
+    vi.mocked(getCardPrintingSummary).mockResolvedValue(
+      buildPrintingSummary([
+        buildSearchRow({
+          scryfall_id: "bolt-alpha",
+          name: "Lightning Bolt",
+          set_code: "lea",
+          set_name: "Limited Edition Alpha",
+          collector_number: "161",
+          finishes: ["normal"],
+        }),
+        buildSearchRow({
+          scryfall_id: "bolt-m11",
+          name: "Lightning Bolt",
+          set_code: "m11",
+          set_name: "Magic 2011",
+          collector_number: "146",
+          finishes: ["normal", "foil"],
+          is_default_add_choice: true,
+        }),
+      ]),
+    );
     vi.mocked(addInventoryItem).mockResolvedValue({ card_name: "Lightning Bolt" } as any);
 
     render(<App />);
@@ -1082,7 +1110,7 @@ describe("App", () => {
     const finishSelect = within(boltCard!).getByRole("combobox", { name: "Finish" });
 
     await waitFor(() => {
-      expect(listCardPrintings).toHaveBeenCalledWith("bolt-oracle");
+      expect(getCardPrintingSummary).toHaveBeenCalledWith("bolt-oracle");
     });
     await waitFor(() => {
       expect(printingSelect).toHaveValue("");
@@ -1138,25 +1166,27 @@ describe("App", () => {
       }
       return buildNameSearchResult();
     });
-    vi.mocked(listCardPrintings).mockResolvedValue([
-      buildSearchRow({
-        scryfall_id: "bolt-alpha",
-        name: "Lightning Bolt",
-        set_code: "lea",
-        set_name: "Limited Edition Alpha",
-        collector_number: "161",
-        finishes: ["normal"],
-      }),
-      buildSearchRow({
-        scryfall_id: "bolt-m11",
-        name: "Lightning Bolt",
-        set_code: "m11",
-        set_name: "Magic 2011",
-        collector_number: "146",
-        finishes: ["normal", "foil"],
-        is_default_add_choice: true,
-      }),
-    ]);
+    vi.mocked(getCardPrintingSummary).mockResolvedValue(
+      buildPrintingSummary([
+        buildSearchRow({
+          scryfall_id: "bolt-alpha",
+          name: "Lightning Bolt",
+          set_code: "lea",
+          set_name: "Limited Edition Alpha",
+          collector_number: "161",
+          finishes: ["normal"],
+        }),
+        buildSearchRow({
+          scryfall_id: "bolt-m11",
+          name: "Lightning Bolt",
+          set_code: "m11",
+          set_name: "Magic 2011",
+          collector_number: "146",
+          finishes: ["normal", "foil"],
+          is_default_add_choice: true,
+        }),
+      ]),
+    );
     vi.mocked(addInventoryItem).mockResolvedValue({ card_name: "Lightning Bolt" } as any);
 
     render(<App />);
@@ -1208,37 +1238,31 @@ describe("App", () => {
       }
       return buildNameSearchResult();
     });
-    vi.mocked(listCardPrintings).mockImplementation(async (oracleId, params) => {
+    vi.mocked(getCardPrintingSummary).mockImplementation(async (oracleId) => {
       if (oracleId === "bolt-oracle") {
-        if (params?.lang === "all") {
-          return [
-            buildSearchRow({
-              scryfall_id: "bolt-alpha",
-              name: "Lightning Bolt",
-              set_code: "lea",
-              set_name: "Limited Edition Alpha",
-              collector_number: "161",
-              finishes: ["normal"],
-            }),
-            buildSearchRow({
-              scryfall_id: "bolt-m11",
-              name: "Lightning Bolt",
-              set_code: "m11",
-              set_name: "Magic 2011",
-              collector_number: "146",
-              finishes: ["normal", "foil"],
-            }),
-            buildSearchRow({
-              scryfall_id: "bolt-sta-ja",
-              name: "Lightning Bolt",
-              set_code: "sta",
-              set_name: "Strixhaven Mystical Archive",
-              collector_number: "39",
-              lang: "ja",
-              finishes: ["normal"],
-            }),
-          ];
-        }
+        return buildPrintingSummary([
+          buildSearchRow({
+            scryfall_id: "bolt-alpha",
+            name: "Lightning Bolt",
+            set_code: "lea",
+            set_name: "Limited Edition Alpha",
+            collector_number: "161",
+            finishes: ["normal"],
+          }),
+          buildSearchRow({
+            scryfall_id: "bolt-m11",
+            name: "Lightning Bolt",
+            set_code: "m11",
+            set_name: "Magic 2011",
+            collector_number: "146",
+            finishes: ["normal", "foil"],
+          }),
+        ]);
+      }
+      return buildPrintingSummary([], { oracle_id: oracleId });
+    });
+    vi.mocked(listCardPrintings).mockImplementation(async (oracleId, params) => {
+      if (oracleId === "bolt-oracle" && params?.lang === "all") {
         return [
           buildSearchRow({
             scryfall_id: "bolt-alpha",
@@ -1255,6 +1279,15 @@ describe("App", () => {
             set_name: "Magic 2011",
             collector_number: "146",
             finishes: ["normal", "foil"],
+          }),
+          buildSearchRow({
+            scryfall_id: "bolt-sta-ja",
+            name: "Lightning Bolt",
+            set_code: "sta",
+            set_name: "Strixhaven Mystical Archive",
+            collector_number: "39",
+            lang: "ja",
+            finishes: ["normal"],
           }),
         ];
       }
@@ -1279,7 +1312,7 @@ describe("App", () => {
     expect(finishSelect).toBeDisabled();
 
     await waitFor(() => {
-      expect(listCardPrintings).toHaveBeenCalledWith("bolt-oracle");
+      expect(getCardPrintingSummary).toHaveBeenCalledWith("bolt-oracle");
     });
     expect(listCardPrintings).not.toHaveBeenCalledWith("bolt-oracle", { lang: "all" });
 

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -5,6 +5,7 @@ import {
   createInventory,
   duplicateInventory,
   exportInventoryCsv,
+  getCardPrintingSummary,
   importCsv,
   importDeckUrl,
   importDecklist,
@@ -441,5 +442,38 @@ describe("api transport", () => {
     expect(requestUrl.searchParams.get("exact")).toBe("false");
     expect(requestUrl.searchParams.get("limit")).toBe("25");
     expect(requestUrl.searchParams.has("set_code")).toBe(false);
+  });
+
+  it("loads card printing summaries with optional scope filtering", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          oracle_id: "bolt-oracle",
+          default_printing: null,
+          available_languages: ["en"],
+          printings_count: 0,
+          has_more_printings: false,
+          printings: [],
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        },
+      ),
+    );
+
+    const response = await getCardPrintingSummary("bolt-oracle", { scope: "all" });
+
+    expect(response.printings_count).toBe(0);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url] = vi.mocked(fetch).mock.calls[0];
+    const requestUrl = new URL(String(url));
+
+    expect(requestUrl.pathname).toBe(
+      "/api/cards/oracle/bolt-oracle/printings/summary",
+    );
+    expect(requestUrl.searchParams.get("scope")).toBe("all");
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,8 +3,10 @@ import type {
   ApiErrorEnvelope,
   BulkInventoryItemMutationRequest,
   BulkInventoryItemMutationResponse,
+  CardPrintingSummaryParams,
   CatalogNameSearchResult,
   CatalogPrintingLookupRow,
+  CatalogPrintingSummaryResponse,
   CatalogSearchRow,
   CsvImportRequest,
   CsvImportResponse,
@@ -367,6 +369,18 @@ export async function listCardPrintings(
     `/cards/oracle/${encodeURIComponent(oracleId)}/printings`,
     {
       query: { lang: params.lang, scope: params.scope },
+    },
+  );
+}
+
+export async function getCardPrintingSummary(
+  oracleId: string,
+  params: CardPrintingSummaryParams = {},
+) {
+  return requestJson<CatalogPrintingSummaryResponse>(
+    `/cards/oracle/${encodeURIComponent(oracleId)}/printings/summary`,
+    {
+      query: { scope: params.scope },
     },
   );
 }

--- a/frontend/src/hooks/useCardSearch.ts
+++ b/frontend/src/hooks/useCardSearch.ts
@@ -4,7 +4,11 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 
-import { listCardPrintings, searchCardNames } from "../api";
+import {
+  getCardPrintingSummary,
+  listCardPrintings,
+  searchCardNames,
+} from "../api";
 import {
   createSearchCardGroups,
   type SearchCardGroup,
@@ -513,14 +517,18 @@ export function useCardSearch(options: UseCardSearchOptions = {}) {
       return inFlightRequest;
     }
 
-    const params = {
-      lang: mode === "all" ? ("all" as const) : undefined,
-      scope: getScopeQueryValue(scope),
-    };
+    const scopeQuery = getScopeQueryValue(scope);
     const request =
-      mode === "all" || scope === "all"
-        ? listCardPrintings(group.oracleId, params)
-        : listCardPrintings(group.oracleId);
+      mode === "all"
+        ? listCardPrintings(
+            group.oracleId,
+            scopeQuery ? { lang: "all", scope: scopeQuery } : { lang: "all" },
+          )
+        : (
+            scopeQuery
+              ? getCardPrintingSummary(group.oracleId, { scope: scopeQuery })
+              : getCardPrintingSummary(group.oracleId)
+          ).then((summary) => summary.printings);
 
     const trackedRequest = request
       .then((nextPrintings) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -122,6 +122,15 @@ export interface CatalogPrintingLookupRow extends CatalogSearchRow {
   is_default_add_choice: boolean;
 }
 
+export interface CatalogPrintingSummaryResponse {
+  oracle_id: string;
+  default_printing: CatalogPrintingLookupRow | null;
+  available_languages: LanguageCode[];
+  printings_count: number;
+  has_more_printings: boolean;
+  printings: CatalogPrintingLookupRow[];
+}
+
 export interface CatalogNameSearchRow {
   oracle_id: string;
   name: string;
@@ -441,6 +450,10 @@ export interface SearchCardNamesParams {
 
 export interface ListCardPrintingsParams {
   lang?: LanguageCode | "all";
+  scope?: CatalogScope;
+}
+
+export interface CardPrintingSummaryParams {
   scope?: CatalogScope;
 }
 

--- a/src/mtg_source_stack/api/response_models.py
+++ b/src/mtg_source_stack/api/response_models.py
@@ -164,6 +164,15 @@ class CatalogPrintingLookupRowResponse(CatalogSearchRowResponse):
     is_default_add_choice: bool = Field(description=DEFAULT_ADD_CHOICE_RESPONSE_DESCRIPTION)
 
 
+class CatalogPrintingSummaryResponse(ApiBaseModel):
+    oracle_id: str
+    default_printing: CatalogPrintingLookupRowResponse | None
+    available_languages: list[str] = Field(description=AVAILABLE_LANGUAGES_RESPONSE_DESCRIPTION)
+    printings_count: int
+    has_more_printings: bool
+    printings: list[CatalogPrintingLookupRowResponse]
+
+
 class CatalogNameSearchRowResponse(ApiBaseModel):
     oracle_id: str
     name: str

--- a/src/mtg_source_stack/api/routes.py
+++ b/src/mtg_source_stack/api/routes.py
@@ -48,6 +48,7 @@ from ..inventory.service import (
     set_printing,
     set_quantity,
     set_tags,
+    summarize_card_printings_for_oracle,
     summarize_actor_access,
     transfer_inventory_items,
 )
@@ -86,6 +87,7 @@ from .response_models import (
     CatalogNameSearchResponse,
     CatalogNameSearchRowResponse,
     CatalogPrintingLookupRowResponse,
+    CatalogPrintingSummaryResponse,
     CatalogSearchRowResponse,
     CsvImportResponse,
     DecklistImportResponse,
@@ -629,6 +631,29 @@ def card_printings_lookup(
         scope=scope,
     )
     return _serialize(rows)
+
+
+@router.get(
+    "/cards/oracle/{oracle_id}/printings/summary",
+    response_model=CatalogPrintingSummaryResponse,
+    responses=_error_responses(401, 403, 400, 404, 503, 500),
+)
+def card_printings_summary(
+    oracle_id: str,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    _context: Annotated[RequestContext, Depends(get_inventory_scoped_read_request_context)],
+    scope: Annotated[
+        str | None,
+        Query(description=SEARCH_SCOPE_DESCRIPTION, json_schema_extra={"enum": ["default", "all"]}),
+    ] = None,
+) -> Any:
+    return _serialize(
+        summarize_card_printings_for_oracle(
+            settings.db_path,
+            oracle_id=oracle_id,
+            scope=scope,
+        )
+    )
 
 
 @router.get(

--- a/src/mtg_source_stack/inventory/catalog.py
+++ b/src/mtg_source_stack/inventory/catalog.py
@@ -31,7 +31,13 @@ from .query_catalog import (
     catalog_scope_filter_sql,
     catalog_search_tokens,
 )
-from .response_models import CatalogNameSearchResult, CatalogNameSearchRow, CatalogPrintingLookupRow, CatalogSearchRow
+from .response_models import (
+    CatalogNameSearchResult,
+    CatalogNameSearchRow,
+    CatalogPrintingLookupRow,
+    CatalogPrintingSummaryResult,
+    CatalogSearchRow,
+)
 
 
 _LANGUAGE_ORDER = {code: index for index, code in enumerate(CANONICAL_LANGUAGE_CODES)}
@@ -73,6 +79,22 @@ def _catalog_printing_lookup_row_from_payload(payload: Mapping[str, Any]) -> Cat
         **_catalog_search_row_kwargs_from_payload(payload),
         is_default_add_choice=bool(dict(payload).get("is_default_add_choice", False)),
     )
+
+
+def _catalog_printing_lookup_rows_from_ranked_payloads(
+    rows: list[sqlite3.Row],
+    *,
+    default_choice_id: str | None,
+) -> list[CatalogPrintingLookupRow]:
+    return [
+        _catalog_printing_lookup_row_from_payload(
+            {
+                **dict(row),
+                "is_default_add_choice": str(row["scryfall_id"]) == default_choice_id,
+            }
+        )
+        for row in rows
+    ]
 
 
 def _language_sort_key(code: str) -> tuple[int, int, str]:
@@ -221,6 +243,43 @@ def _default_add_choice_row_for_printings(
     if not normal_rows:
         return None
     return _rank_oracle_default_printing_rows(normal_rows, prefer_english=prefer_english)[0]
+
+
+def _load_oracle_printing_rows(
+    connection: sqlite3.Connection,
+    *,
+    oracle_id_text: str,
+    scope_filter_sql: str,
+) -> list[sqlite3.Row]:
+    return connection.execute(
+        f"""
+        SELECT
+            scryfall_id,
+            name,
+            set_code,
+            set_name,
+            collector_number,
+            lang,
+            rarity,
+            finishes_json,
+            tcgplayer_product_id,
+            image_uris_json,
+            released_at,
+            set_type,
+            booster,
+            promo_types_json
+        FROM mtg_cards
+        WHERE oracle_id = ?
+          AND {scope_filter_sql}
+        ORDER BY
+            COALESCE(released_at, '') DESC,
+            CASE WHEN LOWER(lang) = 'en' THEN 0 ELSE 1 END,
+            set_code,
+            collector_number,
+            scryfall_id
+        """,
+        (oracle_id_text,),
+    ).fetchall()
 
 
 def search_cards(
@@ -580,35 +639,11 @@ def list_card_printings_for_oracle(
     scope_filter_sql = catalog_scope_filter_sql(normalized_scope)
     require_current_schema(db_path)
     with connect(db_path) as connection:
-        rows = connection.execute(
-            f"""
-            SELECT
-                scryfall_id,
-                name,
-                set_code,
-                set_name,
-                collector_number,
-                lang,
-                rarity,
-                finishes_json,
-                tcgplayer_product_id,
-                image_uris_json,
-                released_at,
-                set_type,
-                booster,
-                promo_types_json
-            FROM mtg_cards
-            WHERE oracle_id = ?
-              AND {scope_filter_sql}
-            ORDER BY
-                COALESCE(released_at, '') DESC,
-                CASE WHEN LOWER(lang) = 'en' THEN 0 ELSE 1 END,
-                set_code,
-                collector_number,
-                scryfall_id
-            """,
-            (oracle_id_text,),
-        ).fetchall()
+        rows = _load_oracle_printing_rows(
+            connection,
+            oracle_id_text=oracle_id_text,
+            scope_filter_sql=scope_filter_sql,
+        )
     if not rows:
         raise NotFoundError(f"No printings found for oracle_id '{oracle_id_text}'.")
 
@@ -631,15 +666,58 @@ def list_card_printings_for_oracle(
     )
     default_choice_id = str(default_choice["scryfall_id"]) if default_choice is not None else None
 
-    return [
-        _catalog_printing_lookup_row_from_payload(
-            {
-                **dict(row),
-                "is_default_add_choice": str(row["scryfall_id"]) == default_choice_id,
-            }
+    return _catalog_printing_lookup_rows_from_ranked_payloads(
+        ranked_rows,
+        default_choice_id=default_choice_id,
+    )
+
+
+def summarize_card_printings_for_oracle(
+    db_path: str | Path,
+    oracle_id: str,
+    *,
+    scope: str | None = None,
+) -> CatalogPrintingSummaryResult:
+    oracle_id_text = text_or_none(oracle_id)
+    if oracle_id_text is None:
+        raise ValidationError("oracle_id is required.")
+    normalized_scope = normalize_catalog_search_scope(scope)
+    scope_filter_sql = catalog_scope_filter_sql(normalized_scope)
+    require_current_schema(db_path)
+    with connect(db_path) as connection:
+        rows = _load_oracle_printing_rows(
+            connection,
+            oracle_id_text=oracle_id_text,
+            scope_filter_sql=scope_filter_sql,
         )
-        for row in ranked_rows
-    ]
+    if not rows:
+        raise NotFoundError(f"No printings found for oracle_id '{oracle_id_text}'.")
+
+    english_rows = [row for row in rows if normalize_language_code(row["lang"]) == "en"]
+    primary_rows = english_rows or rows
+    ranked_primary_rows = _rank_oracle_default_printing_rows(
+        primary_rows,
+        prefer_english=True,
+    )
+    default_choice = _default_add_choice_row_for_printings(
+        primary_rows,
+        prefer_english=True,
+    )
+    default_choice_id = str(default_choice["scryfall_id"]) if default_choice is not None else None
+    printings = _catalog_printing_lookup_rows_from_ranked_payloads(
+        ranked_primary_rows,
+        default_choice_id=default_choice_id,
+    )
+    default_printing = next((row for row in printings if row.is_default_add_choice), None)
+
+    return CatalogPrintingSummaryResult(
+        oracle_id=oracle_id_text,
+        default_printing=default_printing,
+        available_languages=_sorted_available_languages([row["lang"] for row in rows]),
+        printings_count=len(rows),
+        has_more_printings=len(rows) > len(primary_rows),
+        printings=printings,
+    )
 
 
 def list_default_card_name_candidate_rows(

--- a/src/mtg_source_stack/inventory/response_models.py
+++ b/src/mtg_source_stack/inventory/response_models.py
@@ -85,6 +85,16 @@ class CatalogPrintingLookupRow(CatalogSearchRow):
 
 
 @dataclass(frozen=True, slots=True)
+class CatalogPrintingSummaryResult(ResponseModel):
+    oracle_id: str
+    default_printing: CatalogPrintingLookupRow | None
+    available_languages: list[str]
+    printings_count: int
+    has_more_printings: bool
+    printings: list[CatalogPrintingLookupRow]
+
+
+@dataclass(frozen=True, slots=True)
 class CatalogNameSearchRow(ResponseModel):
     oracle_id: str
     name: str

--- a/src/mtg_source_stack/inventory/service.py
+++ b/src/mtg_source_stack/inventory/service.py
@@ -29,7 +29,13 @@ from .analysis import (
     valuation,
     valuation_filtered,
 )
-from .catalog import list_card_printings_for_oracle, resolve_card_row, search_card_names, search_cards
+from .catalog import (
+    list_card_printings_for_oracle,
+    resolve_card_row,
+    search_card_names,
+    search_cards,
+    summarize_card_printings_for_oracle,
+)
 from .csv_import import import_csv, import_csv_stream
 from .decklist_import import import_decklist_text
 from .deck_url_import import import_deck_url

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -31,6 +31,7 @@ from mtg_source_stack.api.response_models import (
     CatalogNameSearchResponse,
     CatalogNameSearchRowResponse,
     CatalogPrintingLookupRowResponse,
+    CatalogPrintingSummaryResponse,
     CatalogSearchRowResponse,
     CsvImportResponse,
     DecklistImportResponse,
@@ -62,6 +63,7 @@ from mtg_source_stack.inventory.service import (
     reconcile_prices,
     search_card_names,
     search_cards,
+    summarize_card_printings_for_oracle,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -232,6 +234,14 @@ class ApiContractTest(RepoSmokeTestCase):
         printing_lookup_payload = {
             **catalog_payload,
             "is_default_add_choice": True,
+        }
+        printing_summary_payload = {
+            "oracle_id": "oracle-lightning-bolt",
+            "default_printing": printing_lookup_payload,
+            "available_languages": ["en", "ja"],
+            "printings_count": 2,
+            "has_more_printings": True,
+            "printings": [printing_lookup_payload],
         }
         catalog_name_payload = {
             "oracle_id": "oracle-lightning-bolt",
@@ -410,6 +420,7 @@ class ApiContractTest(RepoSmokeTestCase):
         owned = OwnedInventoryRowResponse.model_validate(owned_payload)
         catalog = CatalogSearchRowResponse.model_validate(catalog_payload)
         printing_lookup = CatalogPrintingLookupRowResponse.model_validate(printing_lookup_payload)
+        printing_summary = CatalogPrintingSummaryResponse.model_validate(printing_summary_payload)
         catalog_name = CatalogNameSearchRowResponse.model_validate(catalog_name_payload)
         catalog_name_result = CatalogNameSearchResponse.model_validate(
             {
@@ -436,6 +447,11 @@ class ApiContractTest(RepoSmokeTestCase):
         self.assertEqual(["normal", "foil"], catalog.finishes)
         self.assertEqual("https://example.test/cards/card-1-normal.jpg", catalog.image_uri_normal)
         self.assertTrue(printing_lookup.is_default_add_choice)
+        self.assertEqual("oracle-lightning-bolt", printing_summary.oracle_id)
+        self.assertIsNotNone(printing_summary.default_printing)
+        self.assertEqual("card-1", printing_summary.default_printing.scryfall_id)
+        self.assertEqual(2, printing_summary.printings_count)
+        self.assertTrue(printing_summary.has_more_printings)
         self.assertEqual(["en", "ja", "de"], catalog_name.available_languages)
         self.assertEqual(1, catalog_name_result.total_count)
         self.assertFalse(catalog_name_result.has_more)
@@ -633,6 +649,12 @@ class ApiContractTest(RepoSmokeTestCase):
             "default quick-add choice",
             printing_lookup_schema["properties"]["is_default_add_choice"]["description"],
         )
+        printing_summary_schema = CatalogPrintingSummaryResponse.model_json_schema()
+        printing_summary_properties = printing_summary_schema["properties"]
+        self.assertEqual("integer", printing_summary_properties["printings_count"]["type"])
+        self.assertEqual("boolean", printing_summary_properties["has_more_printings"]["type"])
+        self.assertEqual("array", printing_summary_properties["printings"]["type"])
+        self.assertEqual("array", printing_summary_properties["available_languages"]["type"])
 
         catalog_name_schema = CatalogNameSearchRowResponse.model_json_schema()
         catalog_name_properties = catalog_name_schema["properties"]
@@ -948,6 +970,7 @@ class ApiContractTest(RepoSmokeTestCase):
             lambda: search_card_names(Path("var/db/not-used.db"), query="", limit=10),
             lambda: search_card_names(Path("var/db/not-used.db"), query="bolt", scope="weird", limit=10),
             lambda: list_card_printings_for_oracle(Path("var/db/not-used.db"), "oracle-1", scope="weird"),
+            lambda: summarize_card_printings_for_oracle(Path("var/db/not-used.db"), "oracle-1", scope="weird"),
             lambda: list_owned_filtered(
                 Path("var/db/not-used.db"),
                 inventory_slug="personal",

--- a/tests/test_inventory_service.py
+++ b/tests/test_inventory_service.py
@@ -61,6 +61,7 @@ from mtg_source_stack.inventory.service import (
     set_quantity,
     set_tags,
     split_row,
+    summarize_card_printings_for_oracle,
     transfer_inventory_items,
     valuation_filtered,
 )
@@ -1666,6 +1667,166 @@ class InventoryServiceTest(RepoSmokeTestCase):
 
             with self.assertRaisesRegex(NotFoundError, "No printings found for oracle_id 'missing-oracle'"):
                 list_card_printings_for_oracle(db_path, "missing-oracle")
+
+    def test_summarize_card_printings_for_oracle_returns_quick_add_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+
+            with connect(db_path) as connection:
+                connection.executemany(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number,
+                        lang,
+                        released_at,
+                        finishes_json,
+                        image_uris_json
+                    )
+                    VALUES (?, 'summary-oracle', ?, ?, ?, ?, ?, ?, '["nonfoil","foil"]', ?)
+                    """,
+                    [
+                        (
+                            "summary-en-new",
+                            "Summary Card",
+                            "mkm",
+                            "Murders at Karlov Manor",
+                            "41",
+                            "en",
+                            "2024-02-09",
+                            '{"small":"https://example.test/cards/summary-en-new-small.jpg","normal":"https://example.test/cards/summary-en-new-normal.jpg"}',
+                        ),
+                        (
+                            "summary-ja",
+                            "Summary Card",
+                            "mkm",
+                            "Murders at Karlov Manor",
+                            "42",
+                            "ja",
+                            "2024-03-01",
+                            '{"small":"https://example.test/cards/summary-ja-small.jpg","normal":"https://example.test/cards/summary-ja-normal.jpg"}',
+                        ),
+                        (
+                            "summary-en-old",
+                            "Summary Card",
+                            "woe",
+                            "Wilds of Eldraine",
+                            "12",
+                            "en",
+                            "2023-09-01",
+                            '{"small":"https://example.test/cards/summary-en-old-small.jpg","normal":"https://example.test/cards/summary-en-old-normal.jpg"}',
+                        ),
+                    ],
+                )
+                connection.commit()
+
+            summary = summarize_card_printings_for_oracle(db_path, "summary-oracle")
+
+            self.assertEqual("summary-oracle", summary.oracle_id)
+            self.assertIsNotNone(summary.default_printing)
+            self.assertEqual("summary-en-new", summary.default_printing.scryfall_id)
+            self.assertEqual(["en", "ja"], summary.available_languages)
+            self.assertEqual(3, summary.printings_count)
+            self.assertTrue(summary.has_more_printings)
+            self.assertEqual(["summary-en-new", "summary-en-old"], [row.scryfall_id for row in summary.printings])
+            self.assertEqual([True, False], [row.is_default_add_choice for row in summary.printings])
+
+            with self.assertRaisesRegex(NotFoundError, "No printings found for oracle_id 'missing-oracle'"):
+                summarize_card_printings_for_oracle(db_path, "missing-oracle")
+
+    def test_summarize_card_printings_for_oracle_handles_foreign_only_and_missing_default_choice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="summary-foreign-ja",
+                oracle_id="summary-foreign-oracle",
+                name="Foreign Summary Card",
+                collector_number="77",
+                lang="ja",
+                released_at="2024-01-01",
+                is_default_add_searchable=1,
+            )
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="summary-foreign-de",
+                oracle_id="summary-foreign-oracle",
+                name="Foreign Summary Card",
+                collector_number="78",
+                lang="de",
+                released_at="2023-12-01",
+                is_default_add_searchable=1,
+            )
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="summary-foil-only-en",
+                oracle_id="summary-foil-only-oracle",
+                name="Foil Only Summary Card",
+                collector_number="79",
+                lang="en",
+                finishes_json='["foil"]',
+                is_default_add_searchable=1,
+            )
+
+            foreign_summary = summarize_card_printings_for_oracle(db_path, "summary-foreign-oracle")
+            self.assertEqual(["ja", "de"], [row.lang for row in foreign_summary.printings])
+            self.assertEqual(["ja", "de"], foreign_summary.available_languages)
+            self.assertFalse(foreign_summary.has_more_printings)
+            self.assertIsNotNone(foreign_summary.default_printing)
+            self.assertEqual("summary-foreign-ja", foreign_summary.default_printing.scryfall_id)
+
+            foil_only_summary = summarize_card_printings_for_oracle(db_path, "summary-foil-only-oracle")
+            self.assertIsNone(foil_only_summary.default_printing)
+            self.assertEqual(["summary-foil-only-en"], [row.scryfall_id for row in foil_only_summary.printings])
+            self.assertEqual([False], [row.is_default_add_choice for row in foil_only_summary.printings])
+
+    def test_summarize_card_printings_for_oracle_respects_catalog_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="summary-scope-ja",
+                oracle_id="summary-scope-oracle",
+                name="Scoped Summary Card",
+                collector_number="31",
+                lang="ja",
+                released_at="2026-04-01",
+                is_default_add_searchable=1,
+            )
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="summary-scope-en-excluded",
+                oracle_id="summary-scope-oracle",
+                name="Scoped Summary Card",
+                collector_number="32",
+                lang="en",
+                released_at="2026-05-01",
+                is_default_add_searchable=0,
+            )
+
+            default_summary = summarize_card_printings_for_oracle(db_path, "summary-scope-oracle")
+            self.assertEqual(["summary-scope-ja"], [row.scryfall_id for row in default_summary.printings])
+            self.assertEqual(["ja"], default_summary.available_languages)
+            self.assertEqual(1, default_summary.printings_count)
+
+            all_summary = summarize_card_printings_for_oracle(
+                db_path,
+                "summary-scope-oracle",
+                scope="all",
+            )
+            self.assertEqual(["summary-scope-en-excluded"], [row.scryfall_id for row in all_summary.printings])
+            self.assertEqual(["en", "ja"], all_summary.available_languages)
+            self.assertEqual(2, all_summary.printings_count)
+            self.assertTrue(all_summary.has_more_printings)
 
     def test_list_card_printings_for_oracle_matches_default_add_policy_and_marks_one_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -115,6 +115,7 @@ class WebApiSchemaTest(unittest.TestCase):
                 ("/cards/search", "get"),
                 ("/cards/search/names", "get"),
                 ("/cards/oracle/{oracle_id}/printings", "get"),
+                ("/cards/oracle/{oracle_id}/printings/summary", "get"),
                 ("/inventories", "post"),
                 ("/inventories/{source_inventory_slug}/duplicate", "post"),
                 ("/inventories/{inventory_slug}/export.csv", "get"),
@@ -252,6 +253,26 @@ class WebApiSchemaTest(unittest.TestCase):
             self.assertEqual(
                 ["default", "all"],
                 printings_parameters["scope"]["schema"]["enum"],
+            )
+            summary_schema = spec["paths"]["/cards/oracle/{oracle_id}/printings/summary"]["get"]["responses"]["200"][
+                "content"
+            ]["application/json"]["schema"]
+            summary_schema_name = self._schema_name_from_ref(summary_schema["$ref"])
+            self.assertEqual("CatalogPrintingSummaryResponse", summary_schema_name)
+            summary_properties = components[summary_schema_name]["properties"]
+            self.assertEqual(
+                "CatalogPrintingLookupRowResponse",
+                self._schema_name_from_ref(summary_properties["default_printing"]["anyOf"][0]["$ref"]),
+            )
+            self.assertEqual("boolean", summary_properties["has_more_printings"]["type"])
+            self.assertEqual("integer", summary_properties["printings_count"]["type"])
+            self.assertEqual("array", summary_properties["available_languages"]["type"])
+            self.assertEqual(
+                ["default", "all"],
+                {
+                    parameter["name"]: parameter
+                    for parameter in spec["paths"]["/cards/oracle/{oracle_id}/printings/summary"]["get"]["parameters"]
+                }["scope"]["schema"]["enum"],
             )
 
             owned_schema = spec["paths"]["/inventories/{inventory_slug}/items"]["get"]["responses"]["200"][
@@ -2589,6 +2610,29 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual([True], [row["is_default_add_choice"] for row in japanese_printings.json()])
 
                 missing = client.get("/cards/oracle/missing-oracle/printings")
+                self.assertEqual(404, missing.status_code)
+                self.assertEqual("not_found", missing.json()["error"]["code"])
+
+    def test_demo_api_exposes_oracle_printings_summary_for_quick_add(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            with self._client(db_path) as client:
+                self._seed_oracle_printings(db_path)
+
+                summary = client.get("/cards/oracle/api-oracle-lookup/printings/summary")
+                self.assertEqual(200, summary.status_code)
+                self.assertEqual("api-oracle-lookup", summary.json()["oracle_id"])
+                self.assertEqual("api-printing-en-new", summary.json()["default_printing"]["scryfall_id"])
+                self.assertEqual(["en", "ja"], summary.json()["available_languages"])
+                self.assertEqual(3, summary.json()["printings_count"])
+                self.assertTrue(summary.json()["has_more_printings"])
+                self.assertEqual(
+                    ["api-printing-en-new", "api-printing-en-old"],
+                    [row["scryfall_id"] for row in summary.json()["printings"]],
+                )
+                self.assertEqual([True, False], [row["is_default_add_choice"] for row in summary.json()["printings"]])
+
+                missing = client.get("/cards/oracle/missing-oracle/printings/summary")
                 self.assertEqual(404, missing.status_code)
                 self.assertEqual("not_found", missing.json()["error"]["code"])
 


### PR DESCRIPTION
## Summary
- add GET /cards/oracle/{oracle_id}/printings/summary for lightweight quick-add printing data
- preserve full printing browsing on GET /cards/oracle/{oracle_id}/printings?lang=all
- wire frontend primary quick-add printing loads to the summary endpoint
- update OpenAPI, backend/docs coverage, frontend types/API, and frontend tests

## Checks
- PYTHONPATH=src .venv/bin/python -m unittest tests.test_inventory_service tests.test_web_api tests.test_api_contract -q
- npm test
- npm run build

Addresses #39