### PR TITLE
Add shared-service frontend validation fixtures

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -48,7 +48,8 @@ Current authz model:
 - global proxy-backed app roles are `editor` and `admin`
 - local inventory membership roles are `viewer`, `editor`, and `owner`
 - card-search routes require an authenticated user who can read at least one
-  inventory; `POST /me/bootstrap` is the intended first-run escape hatch
+  inventory; custom inventory creation or `POST /me/bootstrap` are the
+  intended first-run escape hatches
 - `GET /inventories` is filtered to visible inventories
 - inventory reads require inventory membership or global `admin`
 - inventory writes require inventory `editor` / `owner` membership or global
@@ -136,6 +137,18 @@ Default demo bootstrap:
 cd frontend
 npm run demo:bootstrap -- --force
 ```
+
+Shared-service validation fixtures:
+
+```bash
+npm run demo:bootstrap -- --force --shared-service-fixtures
+```
+
+This optional fixture mode adds stable actors for frontend rollout checks:
+`new-user@example.com`, `bootstrapped@example.com`, `viewer@example.com`,
+`writer@example.com`, `no-access@example.com`, and `admin@example.com`. Omit
+`X-Authenticated-Roles` for all except `admin@example.com`, where the normalized
+roles header should be `admin`.
 
 Full-catalog demo bootstrap:
 
@@ -408,7 +421,8 @@ Prefer small extractions and targeted tests over broad rewrites.
 - Do not assume `shared_service` means a full org/team permission system.
 - Do not assume `scope=all` is the default search behavior.
 - Do not assume every authenticated user can search before they own or can read
-  an inventory; `POST /me/bootstrap` exists for that reason.
+  an inventory; custom inventory creation and `POST /me/bootstrap` exist for
+  that reason.
 - Do not assume CLI-created inventories automatically have memberships.
 - Do not assume docs/examples are allowed to drift from code.
 - Do not assume the full-catalog demo should pin exact printings.

--- a/README.md
+++ b/README.md
@@ -449,10 +449,10 @@ Recommended rollout sequence:
 
 1. Migrate the DB intentionally.
 2. Start the API in `shared_service`.
-3. If you are starting from a blank system, let each first user call
-   `POST /me/bootstrap` once so they get an owned `Collection`. Otherwise,
-   create inventories through the API so creators become `owner`, or use the
-   CLI membership commands to assign owners on existing inventories.
+3. If you are starting from a blank system, let first users create inventories
+   through the app or `POST /inventories` so creators become `owner`. Use
+   `POST /me/bootstrap` only when the default `Collection` name is acceptable,
+   or use the CLI membership commands to assign owners on existing inventories.
 4. Grant `viewer` / `editor` memberships to the first cohort.
 5. Verify real user sessions against those memberships before launch.
 

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -174,6 +174,26 @@ Use this as the first-pass UI-to-endpoint map:
    npm run demo:bootstrap -- --force
    ```
 
+   To validate shared-service onboarding and permission-aware empty states with
+   stable actors and memberships:
+
+   ```bash
+   npm run demo:bootstrap -- --force --shared-service-fixtures
+   ```
+
+   Fixture users:
+
+   - `new-user@example.com`: omit `X-Authenticated-Roles`; no readable
+     inventory yet; can create a custom first collection
+   - `bootstrapped@example.com`: omit `X-Authenticated-Roles`; owns
+     `bootstrapped-collection`
+   - `viewer@example.com`: omit `X-Authenticated-Roles`; `viewer` on
+     `personal`
+   - `writer@example.com`: omit `X-Authenticated-Roles`; `editor` on
+     `trade-binder`
+   - `no-access@example.com`: omit `X-Authenticated-Roles`; no memberships
+   - `admin@example.com`: send `X-Authenticated-Roles: admin` for global bypass
+
    Or, if you want the frontend to search a real imported catalog instead of
    the tiny built-in demo catalog:
 
@@ -305,8 +325,8 @@ export default {
     authenticated user; it currently requires a user who can read at least one
     inventory, or a global `admin`
   - authenticated users can create inventories they own
-  - first-run shared-service users can call `POST /me/bootstrap` to create a
-    personal `Collection` inventory and unlock search/add flows
+  - first-run frontend users should use the normal create-inventory flow when
+    they need a custom first collection name
 
 ## Known Limits
 
@@ -332,7 +352,7 @@ export default {
 - For shared-service first-run state, prefer `GET /me/access-summary` as the
   frontend startup probe:
   - if `has_readable_inventory` is `true`, continue normally
-  - else if `can_bootstrap` is `true`, offer `POST /me/bootstrap`
+  - else if `can_bootstrap` is `true`, offer the custom create-inventory flow
   - else show an authenticated access-needed or unavailable state
 - Browser-based local dev is expected to use a frontend proxy unless backend
   CORS behavior is changed deliberately.

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -159,13 +159,32 @@ mtg-personal-inventory revoke-inventory-membership \
 
 Recommended first-live rollout:
 
-1. If the system is blank, let each first user call `POST /me/bootstrap` once
-   so they receive an owned `Collection`. Otherwise, create new inventories
-   through the app so the creator becomes `owner`, or grant `owner`
-   memberships to existing inventories with the CLI.
+1. If the system is blank, let first users create inventories through the app
+   so custom names are preserved and the creator becomes `owner`. Use
+   `POST /me/bootstrap` only when the default `Collection` name is acceptable,
+   or grant `owner` memberships to existing inventories with the CLI.
 2. Grant `viewer` / `editor` memberships for the first cohort.
 3. Verify visible inventories, allowed writes, and denied writes with at least
    two real user identities before launch.
+
+For local rehearsal before involving real users, seed the frontend demo DB with
+shared-service fixtures:
+
+```bash
+cd frontend
+npm run demo:bootstrap -- --force --shared-service-fixtures
+```
+
+Fixture checks:
+
+| User | Roles header | Expected route behavior |
+| --- | --- | --- |
+| `new-user@example.com` | omit | `GET /me/access-summary` has no readable inventory and `can_bootstrap=true`; custom inventory creation should succeed. |
+| `bootstrapped@example.com` | omit | Can read `bootstrapped-collection`. |
+| `viewer@example.com` | omit | Can read `personal`; writes to `personal` should return `403`. |
+| `writer@example.com` | omit | Can read and write `trade-binder`. |
+| `no-access@example.com` | omit | No readable inventories; search should return `403`. |
+| `admin@example.com` | `admin` | Can see all demo inventories through global bypass. |
 
 ## Operational Expectations
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -61,6 +61,13 @@ root-mounted routes such as `/inventories` and `/cards/search`.
    npm run demo:bootstrap -- --force
    ```
 
+   To seed the shared-service validation actors and memberships used for
+   permission-aware frontend states:
+
+   ```bash
+   npm run demo:bootstrap -- --force --shared-service-fixtures
+   ```
+
    Pass extra bootstrap args through npm when needed:
 
    ```bash
@@ -154,6 +161,26 @@ Current Vite proxy:
   rewrite: (path) => path.replace(/^\/api/, ""),
 }
 ```
+
+## Shared-Service Fixtures
+
+Use `npm run demo:bootstrap -- --force --shared-service-fixtures` when you need
+stable shared-service actors for onboarding and permission-state validation.
+Start the backend in `shared_service` against that DB and inject the headers
+below through your proxy or API client.
+
+| User | Roles header | Expected state |
+| --- | --- | --- |
+| `new-user@example.com` | omit | No readable inventories yet; can create a custom first collection. |
+| `bootstrapped@example.com` | omit | Owns `bootstrapped-collection`; readable inventory count is `1`. |
+| `viewer@example.com` | omit | Viewer on `personal`; reads are allowed, writes are denied. |
+| `writer@example.com` | omit | Editor on `trade-binder`; reads and writes are allowed there. |
+| `no-access@example.com` | omit | No readable inventories; useful for access-needed states. |
+| `admin@example.com` | `admin` | Global admin bypass; all demo inventories are visible. |
+
+Check `GET /me/access-summary` first for each user. Then verify
+`GET /inventories`, catalog search availability, inventory reads, and denied
+writes match the table above.
 
 ## Working Agreement
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import App from "./App";
 import { ApiClientError } from "./api";
 import type {
+  AccessSummaryResponse,
   CatalogNameSearchResult,
   CatalogNameSearchRow,
   CatalogPrintingLookupRow,
@@ -19,12 +20,14 @@ vi.mock("./api", async () => {
   return {
     ...actual,
     listInventories: vi.fn(),
+    getAccessSummary: vi.fn(),
     listInventoryItems: vi.fn(),
     listInventoryAudit: vi.fn(),
     searchCardNames: vi.fn(),
     listCardPrintings: vi.fn(),
     addInventoryItem: vi.fn(),
     bulkMutateInventoryItems: vi.fn(),
+    bootstrapDefaultInventory: vi.fn(),
     createInventory: vi.fn(),
     patchInventoryItem: vi.fn(),
     deleteInventoryItem: vi.fn(),
@@ -37,8 +40,10 @@ vi.mock("./api", async () => {
 
 import {
   addInventoryItem,
+  bootstrapDefaultInventory,
   bulkMutateInventoryItems,
   createInventory,
+  getAccessSummary,
   importCsv,
   importDeckUrl,
   importDecklist,
@@ -50,6 +55,15 @@ import {
   searchCardNames,
   transferInventoryItems,
 } from "./api";
+
+beforeEach(() => {
+  vi.mocked(getAccessSummary).mockResolvedValue({
+    can_bootstrap: true,
+    has_readable_inventory: true,
+    visible_inventory_count: 1,
+    default_inventory_slug: null,
+  });
+});
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -146,6 +160,18 @@ describe("App", () => {
       acquisition_currency: null,
       item_rows: 0,
       total_cards: 0,
+      ...overrides,
+    };
+  }
+
+  function buildAccessSummary(
+    overrides: Partial<AccessSummaryResponse> = {},
+  ): AccessSummaryResponse {
+    return {
+      can_bootstrap: true,
+      has_readable_inventory: true,
+      visible_inventory_count: 1,
+      default_inventory_slug: null,
       ...overrides,
     };
   }
@@ -339,6 +365,19 @@ describe("App", () => {
     expect(screen.queryByText("Run a search")).not.toBeInTheDocument();
   });
 
+  it("loads readable inventories after the access summary startup probe", async () => {
+    mockBaseSearchApp();
+
+    render(<App />);
+
+    expect(await screen.findByText("Current collection: Personal Collection")).toBeInTheDocument();
+    expect(getAccessSummary).toHaveBeenCalledTimes(1);
+    expect(listInventories).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getAccessSummary).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(listInventories).mock.invocationCallOrder[0],
+    );
+  });
+
   it("opens an import menu above search with URL, text, and CSV options", async () => {
     const user = userEvent.setup();
 
@@ -488,7 +527,7 @@ describe("App", () => {
   });
 
   it("shows a generic collections-unavailable shell state when collection loading fails with 401", async () => {
-    vi.mocked(listInventories).mockRejectedValue(
+    vi.mocked(getAccessSummary).mockRejectedValue(
       new ApiClientError("Authentication required.", {
         code: "authentication_required",
         status: 401,
@@ -505,10 +544,11 @@ describe("App", () => {
     expect(screen.queryByText("Authentication required.")).not.toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Quick Add and Card Search" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Create Collection" })).not.toBeInTheDocument();
+    expect(listInventories).not.toHaveBeenCalled();
   });
 
   it("shows a generic collections-unavailable shell state when collection loading fails with 403", async () => {
-    vi.mocked(listInventories).mockRejectedValue(
+    vi.mocked(getAccessSummary).mockRejectedValue(
       new ApiClientError("Forbidden.", {
         code: "forbidden",
         status: 403,
@@ -525,10 +565,16 @@ describe("App", () => {
     expect(screen.queryByText("Forbidden.")).not.toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Quick Add and Card Search" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Create Collection" })).not.toBeInTheDocument();
+    expect(listInventories).not.toHaveBeenCalled();
   });
 
-  it("shows a no-collections shell state with a create action when no collections exist yet", async () => {
-    vi.mocked(listInventories).mockResolvedValue([]);
+  it("shows a bootstrap shell state with a create action when no readable collections exist yet", async () => {
+    vi.mocked(getAccessSummary).mockResolvedValue(
+      buildAccessSummary({
+        has_readable_inventory: false,
+        visible_inventory_count: 0,
+      }),
+    );
     vi.mocked(searchCardNames).mockResolvedValue(buildNameSearchResult());
     vi.mocked(listCardPrintings).mockResolvedValue([]);
 
@@ -539,18 +585,51 @@ describe("App", () => {
     expect(screen.getByText("Your cards will appear here")).toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Quick Add and Card Search" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Create Collection" })).toBeInTheDocument();
+    expect(listInventories).not.toHaveBeenCalled();
   });
 
-  it("creates the first collection from the empty onboarding state", async () => {
+  it("shows an access-needed shell state without a create action when bootstrap is unavailable", async () => {
+    vi.mocked(getAccessSummary).mockResolvedValue(
+      buildAccessSummary({
+        can_bootstrap: false,
+        has_readable_inventory: false,
+        visible_inventory_count: 0,
+      }),
+    );
+    vi.mocked(searchCardNames).mockResolvedValue(buildNameSearchResult());
+    vi.mocked(listCardPrintings).mockResolvedValue([]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Collection access needed").length).toBeGreaterThan(0);
+    });
+    expect(screen.getByText("Search waiting for access")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "Quick Add and Card Search" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Create Collection" })).not.toBeInTheDocument();
+    expect(listInventories).not.toHaveBeenCalled();
+  });
+
+  it("creates a custom first collection from the empty onboarding state", async () => {
     const user = userEvent.setup();
 
-    vi.mocked(listInventories)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
+    vi.mocked(getAccessSummary)
+      .mockResolvedValueOnce(
+        buildAccessSummary({
+          has_readable_inventory: false,
+          visible_inventory_count: 0,
+        }),
+      )
+      .mockResolvedValueOnce(
+        buildAccessSummary({
+          default_inventory_slug: null,
+        }),
+      );
+    vi.mocked(listInventories).mockResolvedValueOnce([
         buildInventorySummary({
-          slug: "collection",
-          display_name: "Collection",
-          description: "Main personal collection",
+          slug: "commander-decks",
+          display_name: "Commander Decks",
+          description: "Built and brewing commander lists",
         }),
       ]);
     vi.mocked(listInventoryItems).mockResolvedValue([]);
@@ -560,9 +639,9 @@ describe("App", () => {
     vi.mocked(createInventory).mockResolvedValue(
       buildInventoryCreateResponse({
         inventory_id: 9,
-        slug: "collection",
-        display_name: "Collection",
-        description: "Main personal collection",
+        slug: "commander-decks",
+        display_name: "Commander Decks",
+        description: "Built and brewing commander lists",
       }),
     );
 
@@ -571,27 +650,28 @@ describe("App", () => {
     await user.click(await screen.findByRole("button", { name: "Create Collection" }));
 
     const dialog = await screen.findByRole("dialog", { name: "Create Collection" });
-    await user.type(within(dialog).getByRole("textbox", { name: "Collection name" }), "Collection");
+    await user.type(within(dialog).getByRole("textbox", { name: "Collection name" }), "Commander Decks");
     await user.type(
       within(dialog).getByRole("textbox", { name: "Description (optional)" }),
-      "Main personal collection",
+      "Built and brewing commander lists",
     );
     await user.click(within(dialog).getByRole("button", { name: "Create Collection" }));
 
     await waitFor(() => {
       expect(createInventory).toHaveBeenCalledWith({
-        slug: "collection",
-        display_name: "Collection",
-        description: "Main personal collection",
+        slug: "commander-decks",
+        display_name: "Commander Decks",
+        description: "Built and brewing commander lists",
       });
     });
+    expect(bootstrapDefaultInventory).not.toHaveBeenCalled();
 
-    expect(await screen.findByRole("status")).toHaveTextContent("Created Collection.");
-    expect(await screen.findByText("Current collection: Collection")).toBeInTheDocument();
+    expect(await screen.findByRole("status")).toHaveTextContent("Created Commander Decks.");
+    expect(await screen.findByText("Current collection: Commander Decks")).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(listInventoryItems).toHaveBeenCalledWith("collection");
-      expect(listInventoryAudit).toHaveBeenCalledWith("collection");
+      expect(listInventoryItems).toHaveBeenCalledWith("commander-decks");
+      expect(listInventoryAudit).toHaveBeenCalledWith("commander-decks");
     });
   });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,8 +16,10 @@ import { useInventoryOverview } from "./hooks/useInventoryOverview";
 import { useInventoryMutations } from "./hooks/useInventoryMutations";
 import { decimalToNumber, formatUsd } from "./uiHelpers";
 import type { AppShellState } from "./uiTypes";
+import type { AccessSummaryResponse } from "./types";
 
 function getAppShellState(options: {
+  accessSummary: AccessSummaryResponse | null;
   inventoryCount: number;
   inventoryStatus: "idle" | "loading" | "ready" | "error";
 }): AppShellState {
@@ -33,7 +35,11 @@ function getAppShellState(options: {
     return "error";
   }
 
-  return "no_collections";
+  if (options.accessSummary && !options.accessSummary.has_readable_inventory) {
+    return options.accessSummary.can_bootstrap ? "bootstrap_available" : "access_needed";
+  }
+
+  return "access_needed";
 }
 
 function getShellStatePanelContent(
@@ -55,18 +61,33 @@ function getShellStatePanelContent(
           variant: "loading" as const,
         },
       };
-    case "no_collections":
+    case "bootstrap_available":
       return {
         collection: {
-          body: "Once you create a collection, its entries, tags, and values will show up here.",
+          body: "Once your collection exists, its entries, tags, and values will show up here.",
           eyebrow: "Collection",
           title: "Your cards will appear here",
           variant: "idle" as const,
         },
         search: {
-          body: "Create a collection to start finding cards and comparing printings.",
+          body: "Create your collection to start finding cards and comparing printings.",
           eyebrow: "Search",
           title: "Search is ready when you are",
+          variant: "idle" as const,
+        },
+      };
+    case "access_needed":
+      return {
+        collection: {
+          body: "No readable collections are available for this account yet.",
+          eyebrow: "Collection",
+          title: "Collection access needed",
+          variant: "idle" as const,
+        },
+        search: {
+          body: "Search unlocks once you can read at least one collection.",
+          eyebrow: "Search",
+          title: "Search waiting for access",
           variant: "idle" as const,
         },
       };
@@ -94,6 +115,7 @@ export default function App() {
   const [stickyControlsVisible, setStickyControlsVisible] = useState(false);
   const workspaceTopRef = useRef<HTMLDivElement | null>(null);
   const {
+    accessSummary,
     auditEvents,
     describeInventory,
     inventories,
@@ -333,6 +355,7 @@ export default function App() {
   const bannerNotice = notice && notice.tone !== "success" ? notice : null;
   const toastNotice = notice?.tone === "success" ? notice : null;
   const appShellState = getAppShellState({
+    accessSummary,
     inventoryCount: inventories.length,
     inventoryStatus,
   });

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -5,6 +5,7 @@ import {
   createInventory,
   duplicateInventory,
   exportInventoryCsv,
+  getAccessSummary,
   importCsv,
   importDeckUrl,
   importDecklist,
@@ -240,6 +241,39 @@ describe("api transport", () => {
       message: "The API request failed.",
       status: 503,
     });
+  });
+
+  it("gets the shared-service access summary from the expected endpoint", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          can_bootstrap: true,
+          has_readable_inventory: false,
+          visible_inventory_count: 0,
+          default_inventory_slug: null,
+        }),
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+          status: 200,
+        },
+      ),
+    );
+
+    const response = await getAccessSummary();
+
+    expect(response).toEqual({
+      can_bootstrap: true,
+      has_readable_inventory: false,
+      visible_inventory_count: 0,
+      default_inventory_slug: null,
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(String(url)).toContain("/api/me/access-summary");
+    expect(init?.method).toBeUndefined();
+    expect(init?.body).toBeUndefined();
   });
 
   it("posts the new JSON wrapper routes to the expected endpoints", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   AddInventoryItemRequest,
   ApiErrorEnvelope,
+  AccessSummaryResponse,
   BulkInventoryItemMutationRequest,
   BulkInventoryItemMutationResponse,
   CatalogNameSearchResult,
@@ -318,6 +319,10 @@ function buildCsvImportFormData(payload: CsvImportRequest) {
 
 export async function listInventories() {
   return requestJson<InventorySummary[]>("/inventories");
+}
+
+export async function getAccessSummary() {
+  return requestJson<AccessSummaryResponse>("/me/access-summary");
 }
 
 export async function createInventory(payload: InventoryCreateRequest) {

--- a/frontend/src/components/InventorySidebar.tsx
+++ b/frontend/src/components/InventorySidebar.tsx
@@ -506,10 +506,10 @@ export function InventorySidebar(props: {
           </div>
 
         </>
-      ) : (
+      ) : props.appShellState === "bootstrap_available" ? (
         <>
           <PanelState
-            body="Create a collection to start adding cards, tracking value, and keeping everything organized."
+            body="Create your personal collection to start adding cards, tracking value, and keeping everything organized."
             compact
             eyebrow="Collections"
             title="Start your first collection"
@@ -517,6 +517,7 @@ export function InventorySidebar(props: {
           <div className="inventory-sidebar-actions inventory-sidebar-actions-empty">
             <button
               className="primary-button inventory-sidebar-action inventory-sidebar-action-create"
+              disabled={props.createInventoryBusy}
               onClick={openCreateForm}
               type="button"
             >
@@ -525,12 +526,24 @@ export function InventorySidebar(props: {
                 className="inventory-action-icon inventory-action-icon-create"
               />
               <span className="inventory-sidebar-action-create-label">
-                Create Collection
+                {props.createInventoryBusy ? "Creating..." : "Create Collection"}
               </span>
             </button>
           </div>
           <p className="panel-hint inventory-sidebar-note">
-            You can keep everything in one collection or split it up later.
+            You can split cards into more collections later.
+          </p>
+        </>
+      ) : (
+        <>
+          <PanelState
+            body="You are signed in, but no collections are shared with this account yet. Ask an owner to grant access."
+            compact
+            eyebrow="Collections"
+            title="Collection access needed"
+          />
+          <p className="panel-hint inventory-sidebar-note">
+            Search and inventory tools unlock once you can read at least one collection.
           </p>
         </>
       )}

--- a/frontend/src/hooks/useInventoryOverview.ts
+++ b/frontend/src/hooks/useInventoryOverview.ts
@@ -2,11 +2,13 @@ import { useEffect, useRef, useState } from "react";
 
 import {
   ApiClientError,
+  getAccessSummary,
   listInventories,
   listInventoryAudit,
   listInventoryItems,
 } from "../api";
 import type {
+  AccessSummaryResponse,
   InventoryAuditEvent,
   InventorySummary,
   OwnedInventoryRow,
@@ -24,6 +26,7 @@ export function useInventoryOverview() {
   const [selectedInventory, setSelectedInventory] = useState<string | null>(null);
   const [items, setItems] = useState<OwnedInventoryRow[]>([]);
   const [auditEvents, setAuditEvents] = useState<InventoryAuditEvent[]>([]);
+  const [accessSummary, setAccessSummary] = useState<AccessSummaryResponse | null>(null);
   const [inventoryStatus, setInventoryStatus] = useState<AsyncStatus>("loading");
   const [viewStatus, setViewStatus] = useState<AsyncStatus>("idle");
   const [inventoryError, setInventoryError] = useState<string | null>(null);
@@ -44,6 +47,21 @@ export function useInventoryOverview() {
       setInventoryError(null);
 
       try {
+        const nextAccessSummary = await getAccessSummary();
+        if (cancelled) {
+          return;
+        }
+        setAccessSummary(nextAccessSummary);
+        if (!nextAccessSummary.has_readable_inventory) {
+          setInventories([]);
+          selectedInventoryRef.current = null;
+          setSelectedInventory(null);
+          setInventoryError(null);
+          setInventoryErrorStatus(null);
+          setInventoryStatus("ready");
+          return;
+        }
+
         const nextInventories = await listInventories();
         if (cancelled) {
           return;
@@ -89,6 +107,18 @@ export function useInventoryOverview() {
 
   async function reloadInventorySummaries(preferredSlug: string | null = null) {
     try {
+      const nextAccessSummary = await getAccessSummary();
+      setAccessSummary(nextAccessSummary);
+      if (!nextAccessSummary.has_readable_inventory) {
+        setInventories([]);
+        selectedInventoryRef.current = null;
+        setSelectedInventory(null);
+        setInventoryError(null);
+        setInventoryErrorStatus(null);
+        setInventoryStatus("ready");
+        return true;
+      }
+
       const nextInventories = await listInventories();
       setInventories(nextInventories);
       setInventoryError(null);
@@ -175,6 +205,7 @@ export function useInventoryOverview() {
     inventories.find((inventory) => inventory.slug === selectedInventory) ?? null;
 
   return {
+    accessSummary,
     auditEvents,
     describeInventory,
     inventories,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -633,6 +633,13 @@ export interface DefaultInventoryBootstrapResponse {
   inventory: InventoryCreateResponse;
 }
 
+export interface AccessSummaryResponse {
+  can_bootstrap: boolean;
+  has_readable_inventory: boolean;
+  visible_inventory_count: number;
+  default_inventory_slug: string | null;
+}
+
 export interface InventoryTransferItemResultResponse {
   source_item_id: number;
   target_item_id: number | null;

--- a/frontend/src/uiTypes.ts
+++ b/frontend/src/uiTypes.ts
@@ -9,7 +9,8 @@ export type AsyncStatus = "idle" | "loading" | "ready" | "error";
 export type AppShellState =
   | "loading"
   | "ready"
-  | "no_collections"
+  | "bootstrap_available"
+  | "access_needed"
   | "error";
 export type ViewRefreshOutcome = "applied" | "skipped";
 export type NoticeTone = "info" | "success" | "error";

--- a/scripts/bootstrap_frontend_demo.py
+++ b/scripts/bootstrap_frontend_demo.py
@@ -24,6 +24,8 @@ from mtg_source_stack.inventory.service import (
     add_card,
     add_card_with_connection,
     create_inventory,
+    ensure_default_inventory,
+    grant_inventory_membership,
     remove_card,
     resolve_card_row,
     set_acquisition,
@@ -39,6 +41,12 @@ from mtg_source_stack.inventory.service import (
 DEFAULT_DB_PATH = Path("var/db/frontend_demo.db")
 ACTOR_TYPE = "seed"
 ACTOR_ID = "frontend-bootstrap"
+SHARED_SERVICE_NEW_USER_ACTOR = "new-user@example.com"
+SHARED_SERVICE_BOOTSTRAPPED_ACTOR = "bootstrapped@example.com"
+SHARED_SERVICE_VIEWER_ACTOR = "viewer@example.com"
+SHARED_SERVICE_WRITER_ACTOR = "writer@example.com"
+SHARED_SERVICE_NO_ACCESS_ACTOR = "no-access@example.com"
+SHARED_SERVICE_ADMIN_ACTOR = "admin@example.com"
 
 
 def seed_price_snapshots(db_path: Path, rows: list[tuple[str, str, str, str, str, str, float, str]]) -> None:
@@ -86,6 +94,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--force",
         action="store_true",
         help="Overwrite the target database file if it already exists.",
+    )
+    parser.add_argument(
+        "--shared-service-fixtures",
+        action="store_true",
+        help="Seed stable shared-service actors, default inventory, and memberships for frontend validation.",
     )
     return parser
 
@@ -219,6 +232,26 @@ def seed_demo_inventories(db_path: Path) -> None:
         slug="trade-binder",
         display_name="Trade Binder",
         description="Intentionally empty inventory for frontend empty states",
+    )
+
+
+def seed_shared_service_validation_fixtures(db_path: Path) -> None:
+    ensure_default_inventory(
+        db_path,
+        actor_id=SHARED_SERVICE_BOOTSTRAPPED_ACTOR,
+        actor_roles=frozenset(),
+    )
+    grant_inventory_membership(
+        db_path,
+        inventory_slug="personal",
+        actor_id=SHARED_SERVICE_VIEWER_ACTOR,
+        role="viewer",
+    )
+    grant_inventory_membership(
+        db_path,
+        inventory_slug="trade-binder",
+        actor_id=SHARED_SERVICE_WRITER_ACTOR,
+        role="editor",
     )
 
 
@@ -785,6 +818,7 @@ def bootstrap_demo_data(
     scryfall_json: Path | None = None,
     identifiers_json: Path | None = None,
     prices_json: Path | None = None,
+    shared_service_fixtures: bool = False,
 ) -> dict[str, int | str]:
     initialize_database(db_path)
 
@@ -804,20 +838,26 @@ def bootstrap_demo_data(
             db_path,
             seed_demo_prices=(price_mode != "imported"),
         )
+        if shared_service_fixtures:
+            seed_shared_service_validation_fixtures(db_path)
         return {
             "catalog_mode": "full",
             "catalog_rows": catalog_rows,
             "identifiers_rows": identifiers_rows,
             "price_rows": imported_price_rows if price_mode == "imported" else 7,
             "price_mode": price_mode,
+            "shared_service_fixtures": int(shared_service_fixtures),
         }
 
     seed_small_demo_catalog_and_prices(db_path)
     seed_demo_inventories(db_path)
     seed_small_demo_inventory_items(db_path)
+    if shared_service_fixtures:
+        seed_shared_service_validation_fixtures(db_path)
     return {
         "catalog_mode": "small",
         "catalog_rows": 6,
+        "shared_service_fixtures": int(shared_service_fixtures),
     }
 
 
@@ -854,6 +894,7 @@ def main(argv: list[str] | None = None) -> None:
             scryfall_json=scryfall_json,
             identifiers_json=identifiers_json,
             prices_json=prices_json,
+            shared_service_fixtures=args.shared_service_fixtures,
         )
     except (NotFoundError, ValidationError, ValueError) as exc:
         raise SystemExit(str(exc)) from exc
@@ -871,6 +912,17 @@ def main(argv: list[str] | None = None) -> None:
         print("Curated owned-item demo rows resolved from imported catalog printings.")
     else:
         print("Cards seeded for search: Lightning Bolt, Counterspell, Swords to Plowshares, Sol Ring, Forest")
+    if summary["shared_service_fixtures"]:
+        print("Shared-service validation fixtures: enabled")
+        print("Fixture actors:")
+        print(f"  {SHARED_SERVICE_NEW_USER_ACTOR}: no roles header, no readable inventory yet")
+        print(
+            f"  {SHARED_SERVICE_BOOTSTRAPPED_ACTOR}: no roles header, owns default bootstrapped-collection"
+        )
+        print(f"  {SHARED_SERVICE_VIEWER_ACTOR}: no roles header, viewer on personal")
+        print(f"  {SHARED_SERVICE_WRITER_ACTOR}: no roles header, editor on trade-binder")
+        print(f"  {SHARED_SERVICE_NO_ACCESS_ACTOR}: no roles header, no memberships")
+        print(f"  {SHARED_SERVICE_ADMIN_ACTOR}: use X-Authenticated-Roles=admin for global bypass")
     print("Suggested API start command:")
     print(f"  (cd frontend && npm run backend:demo -- --db {db_path})")
 

--- a/tests/test_frontend_demo_bootstrap.py
+++ b/tests/test_frontend_demo_bootstrap.py
@@ -11,7 +11,13 @@ import unittest
 from pathlib import Path
 
 from mtg_source_stack.db.connection import connect
-from mtg_source_stack.inventory.service import list_inventories, list_inventory_audit_events, list_owned_filtered
+from mtg_source_stack.inventory.service import (
+    actor_inventory_role,
+    list_inventories,
+    list_inventory_audit_events,
+    list_owned_filtered,
+    summarize_actor_access,
+)
 from tests.common import REPO_ROOT, fixture_path
 
 
@@ -94,6 +100,121 @@ class FrontendDemoBootstrapTest(unittest.TestCase):
             self.assertIn("Catalog mode: small", result.stdout)
             self.assertIn("npm run backend:demo -- --db", result.stdout)
             self.assert_richer_demo_dataset(db_path)
+
+    def test_bootstrap_can_seed_shared_service_validation_fixtures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "frontend_demo_shared.db"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "scripts/bootstrap_frontend_demo.py",
+                    "--db",
+                    str(db_path),
+                    "--force",
+                    "--shared-service-fixtures",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            self.assertIn("Shared-service validation fixtures: enabled", result.stdout)
+            self.assertIn("new-user@example.com", result.stdout)
+            self.assertIn("bootstrapped@example.com", result.stdout)
+            self.assertIn("viewer@example.com", result.stdout)
+            self.assertIn("writer@example.com", result.stdout)
+            self.assertIn("admin@example.com", result.stdout)
+            inventories = list_inventories(db_path)
+            self.assertEqual(
+                ["bootstrapped-collection", "personal", "trade-binder"],
+                [row.slug for row in inventories],
+            )
+            personal = next(row for row in inventories if row.slug == "personal")
+            trade_binder = next(row for row in inventories if row.slug == "trade-binder")
+            bootstrapped = next(row for row in inventories if row.slug == "bootstrapped-collection")
+            self.assertEqual(4, personal.item_rows)
+            self.assertEqual(7, personal.total_cards)
+            self.assertEqual(0, trade_binder.item_rows)
+            self.assertEqual(0, trade_binder.total_cards)
+            self.assertEqual(0, bootstrapped.item_rows)
+            self.assertEqual(0, bootstrapped.total_cards)
+            self.assertEqual(
+                "viewer",
+                actor_inventory_role(
+                    db_path,
+                    inventory_slug="personal",
+                    actor_id="viewer@example.com",
+                ),
+            )
+            self.assertEqual(
+                "editor",
+                actor_inventory_role(
+                    db_path,
+                    inventory_slug="trade-binder",
+                    actor_id="writer@example.com",
+                ),
+            )
+
+            new_user_summary = summarize_actor_access(
+                db_path,
+                actor_id="new-user@example.com",
+                actor_roles=frozenset(),
+            )
+            self.assertTrue(new_user_summary.can_bootstrap)
+            self.assertFalse(new_user_summary.has_readable_inventory)
+            self.assertEqual(0, new_user_summary.visible_inventory_count)
+            self.assertIsNone(new_user_summary.default_inventory_slug)
+
+            no_access_summary = summarize_actor_access(
+                db_path,
+                actor_id="no-access@example.com",
+                actor_roles=frozenset(),
+            )
+            self.assertTrue(no_access_summary.can_bootstrap)
+            self.assertFalse(no_access_summary.has_readable_inventory)
+            self.assertEqual(0, no_access_summary.visible_inventory_count)
+            self.assertIsNone(no_access_summary.default_inventory_slug)
+
+            bootstrapped_summary = summarize_actor_access(
+                db_path,
+                actor_id="bootstrapped@example.com",
+                actor_roles=frozenset(),
+            )
+            self.assertTrue(bootstrapped_summary.can_bootstrap)
+            self.assertTrue(bootstrapped_summary.has_readable_inventory)
+            self.assertEqual(1, bootstrapped_summary.visible_inventory_count)
+            self.assertEqual("bootstrapped-collection", bootstrapped_summary.default_inventory_slug)
+
+            viewer_summary = summarize_actor_access(
+                db_path,
+                actor_id="viewer@example.com",
+                actor_roles=frozenset(),
+            )
+            self.assertTrue(viewer_summary.can_bootstrap)
+            self.assertTrue(viewer_summary.has_readable_inventory)
+            self.assertEqual(1, viewer_summary.visible_inventory_count)
+            self.assertIsNone(viewer_summary.default_inventory_slug)
+
+            writer_summary = summarize_actor_access(
+                db_path,
+                actor_id="writer@example.com",
+                actor_roles=frozenset(),
+            )
+            self.assertTrue(writer_summary.can_bootstrap)
+            self.assertTrue(writer_summary.has_readable_inventory)
+            self.assertEqual(1, writer_summary.visible_inventory_count)
+            self.assertIsNone(writer_summary.default_inventory_slug)
+
+            admin_summary = summarize_actor_access(
+                db_path,
+                actor_id="admin@example.com",
+                actor_roles={"admin"},
+            )
+            self.assertTrue(admin_summary.can_bootstrap)
+            self.assertTrue(admin_summary.has_readable_inventory)
+            self.assertEqual(3, admin_summary.visible_inventory_count)
+            self.assertIsNone(admin_summary.default_inventory_slug)
 
     def test_bootstrap_full_catalog_mode_imports_real_cards_without_demo_catalog_rows(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- use `GET /me/access-summary` as the frontend startup probe for shared-service onboarding states
- keep custom first-collection creation on the normal `POST /inventories` path
- add shared-service validation fixtures to the frontend demo bootstrap
- document fixture actors, headers, expected states, and rollout checks

## Validation
- `PYTHONPATH=src python3 -m unittest tests.test_frontend_demo_bootstrap tests.test_frontend_demo_scripts -q`
- `cd frontend && npm test`
- `cd frontend && npm run build`

Closes #45