### PR TITLE
Split backend test dependency surfaces

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -259,31 +259,36 @@ Multipart caveat:
 
 Python command note:
 
-- prefer the repo-local `.venv/bin/python` for backend commands and tests, or
-  activate `.venv` first
-- using system `python3` can miss optional web/test deps that are installed only
-  in the repo virtualenv
-- if a unittest import fails for modules like `pydantic`, `fastapi`, or
-  `uvicorn`, confirm you are using `.venv/bin/python`
+- `./scripts/test_backend.sh` is intentionally safe for a base `pip install -e .`
+  environment and does not require the optional web stack.
+- API/web tests require the `web` extra. Activate a web-capable environment or
+  install it with `pip install -e '.[web]'` before running
+  `./scripts/test_backend_web.sh`.
+- Both backend wrappers force this checkout's `src/` tree onto `PYTHONPATH` so
+  multi-checkout editable installs do not leak into test runs.
 
-Backend:
+Backend base:
 
 ```bash
 ./scripts/test_backend.sh
-PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -q
 ```
+
+Backend API/web:
+
+```bash
+./scripts/test_backend_web.sh
+```
+
+Broad unittest discovery is still safe in a base environment because web/API
+modules skip cleanly when optional dependencies are absent. Prefer the explicit
+wrappers for routine validation because they make the intended dependency layer
+obvious.
 
 Frontend:
 
 ```bash
 cd frontend && npm test
 cd frontend && npm run build
-```
-
-Localhost API test layer:
-
-```bash
-PYTHONPATH=src .venv/bin/python -m unittest tests.test_web_api tests.test_api_app -q
 ```
 
 Importer benchmark:
@@ -338,17 +343,24 @@ Backend default:
 ./scripts/test_backend.sh
 ```
 
+Backend API/web:
+
+```bash
+./scripts/test_backend_web.sh
+```
+
 Useful targeted commands:
 
 ```bash
 PYTHONPATH=src .venv/bin/python -m unittest discover -s tests -q
-PYTHONPATH=src .venv/bin/python -m unittest tests.test_web_api tests.test_api_app -q
+PYTHONPATH=src .venv/bin/python -m unittest tests.test_api_contract tests.test_api_app tests.test_web_api -q
 cd frontend && npm test
 cd frontend && npm run build
 ```
 
-OpenAPI parity lives in `tests/test_api_contract.py`. If API behavior changes,
-expect that suite to fail until `contracts/openapi.json` is refreshed.
+OpenAPI parity lives in `tests/test_api_contract.py` and is part of the API/web
+test surface. If API behavior changes, expect `./scripts/test_backend_web.sh` to
+fail until `contracts/openapi.json` is refreshed.
 
 ## Refreshing OpenAPI
 

--- a/README.md
+++ b/README.md
@@ -466,15 +466,26 @@ mtg-web-api --db "var/db/mtg_mvp.db" --runtime-mode shared_service
 
 ## Testing
 
-With the virtualenv active, run the full local test suite:
+Run the base backend suite after a normal `pip install -e .` install:
 
 ```bash
 ./scripts/test_backend.sh
 ```
 
-That wrapper forces this checkout's `src/` tree onto `PYTHONPATH` before
-running `unittest`, which avoids accidentally importing a different editable
-checkout in multi-repo environments.
+That wrapper forces this checkout's `src/` tree onto `PYTHONPATH`, then runs the
+core service, importer, CLI, and database tests. Optional API/web tests skip
+cleanly from a base environment.
+
+Run the API/web test surface only after installing the web extra:
+
+```bash
+pip install -e '.[web]'
+./scripts/test_backend_web.sh
+```
+
+The web test wrapper covers OpenAPI parity, FastAPI app behavior, and route
+integration tests. It fails fast with an install hint if the optional web
+dependencies are missing.
 
 ## Repo Map
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ version = "0.1.0"
 description = "Local-first Magic: The Gathering source stack and personal inventory CLI"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-    "python-multipart>=0.0.20,<1",
-]
+dependencies = []
 
 [project.optional-dependencies]
 web = [
     "fastapi>=0.115,<1",
     "httpx>=0.27,<1",
+    "pydantic>=2,<3",
+    "python-multipart>=0.0.20,<1",
     "uvicorn>=0.30,<1",
 ]
 

--- a/scripts/test_backend_web.sh
+++ b/scripts/test_backend_web.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${REPO_ROOT}"
+export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+python3 -c 'import pathlib, mtg_source_stack; expected = pathlib.Path("src").resolve(); actual = pathlib.Path(mtg_source_stack.__file__).resolve(); raise SystemExit(0 if expected in actual.parents else f"mtg_source_stack resolved from unexpected checkout: {actual}")'
+
+if ! python3 -c 'import fastapi, httpx, multipart, pydantic, uvicorn' >/dev/null 2>&1; then
+  echo "Backend web/API tests require the optional web dependencies." >&2
+  echo "Install them first with: pip install -e '.[web]'" >&2
+  exit 1
+fi
+
+python3 -m unittest tests.test_api_contract tests.test_api_app tests.test_web_api -q

--- a/tests/optional_dependencies.py
+++ b/tests/optional_dependencies.py
@@ -1,0 +1,28 @@
+"""Helpers for tests that depend on optional dependency groups."""
+
+from __future__ import annotations
+
+import importlib.util
+
+
+WEB_TEST_DEPENDENCIES = ("fastapi", "httpx", "pydantic", "uvicorn", "multipart")
+WEB_TEST_SKIP_REASON = (
+    "optional web/API test dependencies are not installed; run `pip install -e '.[web]'` "
+    "before running API contract or web shell tests."
+)
+
+
+def has_module(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+def web_test_dependencies_available() -> bool:
+    return all(has_module(module_name) for module_name in WEB_TEST_DEPENDENCIES)
+
+
+def missing_web_test_dependencies() -> tuple[str, ...]:
+    return tuple(
+        module_name
+        for module_name in WEB_TEST_DEPENDENCIES
+        if not has_module(module_name)
+    )

--- a/tests/test_api_app.py
+++ b/tests/test_api_app.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-import importlib.util
 import socket
 import tempfile
 import threading
@@ -13,15 +12,15 @@ from pathlib import Path
 from unittest.mock import patch
 
 from mtg_source_stack.api.app import build_arg_parser, main, settings_from_cli_args
-
-
-FASTAPI_TESTING_AVAILABLE = (
-    importlib.util.find_spec("fastapi") is not None
-    and importlib.util.find_spec("httpx") is not None
-    and importlib.util.find_spec("uvicorn") is not None
+from tests.optional_dependencies import (
+    WEB_TEST_SKIP_REASON,
+    web_test_dependencies_available,
 )
 
-if FASTAPI_TESTING_AVAILABLE:
+
+WEB_TESTING_AVAILABLE = web_test_dependencies_available()
+
+if WEB_TESTING_AVAILABLE:
     import httpx
     from fastapi import status
     import uvicorn
@@ -74,8 +73,8 @@ def _live_test_server(app):
 
 
 @unittest.skipUnless(
-    FASTAPI_TESTING_AVAILABLE and LOCALHOST_SERVER_TESTING_AVAILABLE,
-    "fastapi/httpx/uvicorn or localhost socket access are unavailable; live API app tests are skipped.",
+    WEB_TESTING_AVAILABLE and LOCALHOST_SERVER_TESTING_AVAILABLE,
+    f"{WEB_TEST_SKIP_REASON} Localhost socket access is also required.",
 )
 class ApiAppTest(unittest.TestCase):
     @contextmanager
@@ -333,6 +332,9 @@ class ApiCliSettingsTest(unittest.TestCase):
         self.assertEqual("10.0.0.1", settings.forwarded_allow_ips)
 
     def test_main_passes_explicit_proxy_settings_to_uvicorn(self) -> None:
+        if not WEB_TESTING_AVAILABLE:
+            self.skipTest(WEB_TEST_SKIP_REASON)
+
         with patch("mtg_source_stack.api.app.create_app", return_value=object()) as mock_create_app:
             with patch("uvicorn.run") as mock_run:
                 main(

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -6,10 +6,19 @@ import json
 from decimal import Decimal
 import sqlite3
 import tempfile
+import unittest
 from pathlib import Path
 from textwrap import dedent
 
 from tests.common import RepoSmokeTestCase
+from tests.optional_dependencies import (
+    WEB_TEST_SKIP_REASON,
+    web_test_dependencies_available,
+)
+
+if not web_test_dependencies_available():
+    raise unittest.SkipTest(WEB_TEST_SKIP_REASON)
+
 from mtg_source_stack.api.app import create_app
 from mtg_source_stack.api.dependencies import ApiSettings
 from mtg_source_stack.api_contract import api_error_payload, api_error_status

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-import importlib.util
 import io
 import json
 import socket
@@ -23,15 +22,15 @@ from mtg_source_stack.inventory.service import (
     grant_inventory_membership,
     import_deck_url,
 )
-
-
-FASTAPI_TESTING_AVAILABLE = (
-    importlib.util.find_spec("fastapi") is not None
-    and importlib.util.find_spec("httpx") is not None
-    and importlib.util.find_spec("uvicorn") is not None
+from tests.optional_dependencies import (
+    WEB_TEST_SKIP_REASON,
+    web_test_dependencies_available,
 )
 
-if FASTAPI_TESTING_AVAILABLE:
+
+WEB_TESTING_AVAILABLE = web_test_dependencies_available()
+
+if WEB_TESTING_AVAILABLE:
     import httpx
     import uvicorn
 
@@ -89,8 +88,8 @@ def _live_test_server(app):
 
 
 @unittest.skipUnless(
-    FASTAPI_TESTING_AVAILABLE,
-    "fastapi/httpx/uvicorn are not installed in this environment; API shell tests are skipped.",
+    WEB_TESTING_AVAILABLE,
+    WEB_TEST_SKIP_REASON,
 )
 class WebApiSchemaTest(unittest.TestCase):
     def _schema_name_from_ref(self, ref: str) -> str:
@@ -752,8 +751,8 @@ class WebApiSchemaTest(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    FASTAPI_TESTING_AVAILABLE,
-    "fastapi/httpx/uvicorn are not installed in this environment; API shell tests are skipped.",
+    WEB_TESTING_AVAILABLE,
+    WEB_TEST_SKIP_REASON,
 )
 class WebApiImportHelperTest(unittest.TestCase):
     def test_parse_resolutions_json_form_accepts_array_of_objects(self) -> None:
@@ -834,8 +833,8 @@ class WebApiImportHelperTest(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    FASTAPI_TESTING_AVAILABLE and LOCALHOST_SERVER_TESTING_AVAILABLE,
-    "fastapi/httpx/uvicorn or localhost socket access are unavailable; live API shell tests are skipped.",
+    WEB_TESTING_AVAILABLE and LOCALHOST_SERVER_TESTING_AVAILABLE,
+    f"{WEB_TEST_SKIP_REASON} Localhost socket access is also required for live API shell tests.",
 )
 class WebApiTest(unittest.TestCase):
     @contextmanager


### PR DESCRIPTION
## Summary
- keep base backend tests runnable without optional web dependencies
- move multipart/Pydantic API requirements into the web extra
- add an explicit web/API test wrapper with dependency preflight
- make API contract/app/web tests skip cleanly when web deps are absent
- document the base vs web/API test command split

## Checks
- ./scripts/test_backend.sh
- . .venv/bin/activate && ./scripts/test_backend_web.sh
- git diff --check

Addresses #46