### PR TITLE
Add proxy-backed shared-service validation harness

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -154,6 +154,27 @@ This optional fixture mode adds stable actors for frontend rollout checks:
 `X-Authenticated-Roles` for all except `admin@example.com`, where the normalized
 roles header should be `admin`.
 
+Proxy-backed shared-service preflight:
+
+```bash
+npm run demo:bootstrap -- --force --shared-service-fixtures
+npm run build
+npm run smoke:shared-service-proxy -- --start-backend
+```
+
+Manual browser validation through the local harness:
+
+```bash
+MTG_API_SNAPSHOT_SIGNING_SECRET="local-shared-service-dev-secret" \
+npm run backend:demo -- --runtime-mode shared_service --no-auto-migrate
+
+npm run proxy:shared-service -- --fixture-preset viewer
+```
+
+The harness validates the `/api` prefix strip and fixture header injection. It
+is intentionally local-only; production reverse-proxy work is tracked
+separately in issue #57.
+
 Full-catalog demo bootstrap:
 
 ```bash

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -285,6 +285,20 @@ Use this as the first-pass UI-to-endpoint map:
   assume a same-origin reverse proxy that publishes `/api` publicly and strips
   that prefix before forwarding to the backend root-route API
 
+Proxy-backed shared-service preflight:
+
+```bash
+cd frontend
+npm run demo:bootstrap -- --force --shared-service-fixtures
+npm run build
+npm run smoke:shared-service-proxy -- --start-backend
+```
+
+For a manual browser pass against one fixture identity, start the backend in
+`shared_service` and run `npm run proxy:shared-service -- --fixture-preset
+viewer`. The local harness is a validation tool only; use a real reverse proxy
+or gateway for users.
+
 Example Vite proxy:
 
 ```ts

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -186,6 +186,45 @@ Fixture checks:
 | `no-access@example.com` | omit | No readable inventories; search should return `403`. |
 | `admin@example.com` | `admin` | Can see all demo inventories through global bypass. |
 
+## Local Proxy Preflight Harness
+
+For local rollout rehearsal, use the committed proxy harness to validate the
+same-origin `/api` topology before involving a real production proxy:
+
+```bash
+cd frontend
+npm run demo:bootstrap -- --force --shared-service-fixtures
+npm run build
+npm run smoke:shared-service-proxy -- --start-backend
+```
+
+The smoke command starts `mtg-web-api` in `shared_service`, runs local proxy
+instances with fixture identities, and checks:
+
+- `/api` path-prefix stripping
+- same-origin frontend asset serving from the built `frontend/dist`
+- removal of client-supplied `X-Authenticated-User`, `X-Authenticated-Roles`,
+  and `X-Actor-Id`
+- proxy-injected fixture identity headers
+- expected visible inventories and search denial for fixture users
+
+For browser validation of one fixture identity:
+
+```bash
+cd frontend
+MTG_API_SNAPSHOT_SIGNING_SECRET="local-shared-service-dev-secret" \
+npm run backend:demo -- --runtime-mode shared_service --no-auto-migrate
+
+npm run build
+npm run proxy:shared-service -- --fixture-preset viewer
+```
+
+Then open `http://127.0.0.1:5174`.
+
+This harness is not production infrastructure. It is a preflight tool for issue
+#44. The future transition to a real reverse proxy or gateway is tracked in
+issue #57.
+
 ## Operational Expectations
 
 - keep the SQLite database on local storage, not a network filesystem

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -182,6 +182,42 @@ Check `GET /me/access-summary` first for each user. Then verify
 `GET /inventories`, catalog search availability, inventory reads, and denied
 writes match the table above.
 
+## Proxy-Backed Shared-Service Validation
+
+Use the local proxy harness when you need to validate the same-origin `/api`
+rollout shape instead of the Vite dev proxy shortcut. The harness strips
+client-supplied auth headers, injects one fixture identity, serves the built
+frontend, and proxies `/api/*` to the root-mounted backend.
+
+One-command smoke check:
+
+```bash
+npm run demo:bootstrap -- --force --shared-service-fixtures
+npm run build
+npm run smoke:shared-service-proxy -- --start-backend
+```
+
+The smoke workflow starts `mtg-web-api` in `shared_service`, starts local proxy
+instances for fixture users, and verifies `/api` rewriting, spoofed-header
+stripping, fixture visibility, search denial, and same-origin frontend serving.
+
+For manual browser validation, start the shared-service backend and then run
+the proxy with the fixture user you want to exercise:
+
+```bash
+MTG_API_SNAPSHOT_SIGNING_SECRET="local-shared-service-dev-secret" \
+npm run backend:demo -- --runtime-mode shared_service --no-auto-migrate
+
+npm run build
+npm run proxy:shared-service -- --fixture-preset viewer
+```
+
+Open `http://127.0.0.1:5174`. Supported fixture presets are `new-user`,
+`bootstrapped`, `viewer`, `writer`, `no-access`, `admin`, and `none`.
+
+This harness is a local preflight tool only. Use a production reverse proxy or
+gateway for real users; the transition is tracked in issue #57.
+
 ## Working Agreement
 
 - Keep all UI code under `frontend/`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "demo:bootstrap": "bash ./scripts/bootstrap_demo_db.sh",
     "backend:demo": "bash ./scripts/run_demo_backend.sh",
+    "proxy:shared-service": "bash ./scripts/run_shared_service_proxy.sh",
+    "smoke:shared-service-proxy": "bash ./scripts/smoke_shared_service_proxy.sh",
     "dev": "vite",
     "build": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json && vite build",
     "preview": "vite preview",

--- a/frontend/scripts/run_shared_service_proxy.sh
+++ b/frontend/scripts/run_shared_service_proxy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${FRONTEND_DIR}/.." && pwd)"
+BACKEND_PYTHON="$(bash "${SCRIPT_DIR}/resolve_repo_python.sh")"
+
+export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+exec "${BACKEND_PYTHON}" "${REPO_ROOT}/scripts/shared_service_proxy_harness.py" "$@"

--- a/frontend/scripts/smoke_shared_service_proxy.sh
+++ b/frontend/scripts/smoke_shared_service_proxy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${FRONTEND_DIR}/.." && pwd)"
+BACKEND_PYTHON="$(bash "${SCRIPT_DIR}/resolve_repo_python.sh")"
+
+export PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}"
+
+exec "${BACKEND_PYTHON}" "${REPO_ROOT}/scripts/smoke_shared_service_proxy.py" "$@"

--- a/scripts/shared_service_proxy_harness.py
+++ b/scripts/shared_service_proxy_harness.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Local reverse-proxy harness for shared-service rollout validation.
+
+This is a development and smoke-test tool. It intentionally models the
+shared-service proxy contract, but it is not production infrastructure.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import mimetypes
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import sys
+from typing import Iterable
+from urllib.error import HTTPError, URLError
+from urllib.parse import unquote, urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BACKEND_URL = "http://127.0.0.1:8000"
+DEFAULT_FRONTEND_DIST = REPO_ROOT / "frontend" / "dist"
+DEFAULT_PROXY_HOST = "127.0.0.1"
+DEFAULT_PROXY_PORT = 5174
+AUTHENTICATED_USER_HEADER = "X-Authenticated-User"
+AUTHENTICATED_ROLES_HEADER = "X-Authenticated-Roles"
+ACTOR_ID_HEADER = "X-Actor-Id"
+STRIPPED_AUTH_HEADERS = frozenset(
+    {
+        AUTHENTICATED_USER_HEADER.casefold(),
+        AUTHENTICATED_ROLES_HEADER.casefold(),
+        ACTOR_ID_HEADER.casefold(),
+    }
+)
+HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FixtureIdentity:
+    actor: str | None
+    roles: str | None = None
+
+
+FIXTURE_PRESETS: dict[str, FixtureIdentity] = {
+    "none": FixtureIdentity(actor=None, roles=None),
+    "new-user": FixtureIdentity(actor="new-user@example.com", roles=None),
+    "bootstrapped": FixtureIdentity(actor="bootstrapped@example.com", roles=None),
+    "viewer": FixtureIdentity(actor="viewer@example.com", roles=None),
+    "writer": FixtureIdentity(actor="writer@example.com", roles=None),
+    "no-access": FixtureIdentity(actor="no-access@example.com", roles=None),
+    "admin": FixtureIdentity(actor="admin@example.com", roles="admin"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ProxyHarnessConfig:
+    backend_url: str
+    frontend_dist: Path
+    actor: str | None
+    roles: str | None = None
+    timeout_seconds: float = 10.0
+
+
+class HarnessError(ValueError):
+    """Raised when proxy harness configuration is invalid."""
+
+
+class _ReusableThreadingHTTPServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def normalize_backend_url(raw_backend_url: str) -> str:
+    normalized = raw_backend_url.rstrip("/")
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise HarnessError(f"Backend URL must be absolute HTTP(S), got: {raw_backend_url!r}")
+    return normalized
+
+
+def resolve_fixture_identity(
+    preset: str,
+    *,
+    actor: str | None = None,
+    roles: str | None = None,
+) -> FixtureIdentity:
+    try:
+        preset_identity = FIXTURE_PRESETS[preset]
+    except KeyError as exc:
+        choices = ", ".join(sorted(FIXTURE_PRESETS))
+        raise HarnessError(f"Unknown fixture preset {preset!r}. Choose one of: {choices}.") from exc
+    return FixtureIdentity(
+        actor=actor if actor is not None else preset_identity.actor,
+        roles=roles if roles is not None else preset_identity.roles,
+    )
+
+
+def rewrite_api_url(backend_url: str, request_target: str) -> str:
+    parsed_target = urlsplit(request_target)
+    if parsed_target.path == "/api":
+        upstream_path = "/"
+    elif parsed_target.path.startswith("/api/"):
+        upstream_path = parsed_target.path.removeprefix("/api")
+    else:
+        raise HarnessError(f"Request target is not under /api: {request_target!r}")
+
+    parsed_backend = urlsplit(normalize_backend_url(backend_url))
+    return urlunsplit(
+        (
+            parsed_backend.scheme,
+            parsed_backend.netloc,
+            upstream_path or "/",
+            parsed_target.query,
+            "",
+        )
+    )
+
+
+def build_forward_headers(
+    incoming_headers: Iterable[tuple[str, str]],
+    *,
+    config: ProxyHarnessConfig,
+    client_host: str,
+    original_host: str | None,
+) -> dict[str, str]:
+    forwarded: dict[str, str] = {}
+    for header_name, header_value in incoming_headers:
+        normalized_name = header_name.casefold()
+        if normalized_name in HOP_BY_HOP_HEADERS:
+            continue
+        if normalized_name in STRIPPED_AUTH_HEADERS:
+            continue
+        if normalized_name in {"host", "content-length"}:
+            continue
+        forwarded[header_name] = header_value
+
+    if config.actor:
+        forwarded[AUTHENTICATED_USER_HEADER] = config.actor
+    if config.roles:
+        forwarded[AUTHENTICATED_ROLES_HEADER] = config.roles
+
+    forwarded["X-Forwarded-For"] = client_host
+    forwarded["X-Forwarded-Proto"] = "http"
+    if original_host:
+        forwarded["X-Forwarded-Host"] = original_host
+    return forwarded
+
+
+def _json_error(message: str) -> bytes:
+    return json.dumps(
+        {"error": {"code": "proxy_harness_error", "message": message}},
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolve_static_path(frontend_dist: Path, request_target: str) -> Path | None:
+    root = frontend_dist.resolve()
+    parsed_target = urlsplit(request_target)
+    raw_path = unquote(parsed_target.path).lstrip("/")
+    if raw_path in {"", "."}:
+        return root / "index.html"
+
+    candidate = (root / raw_path).resolve()
+    if not _is_relative_to(candidate, root):
+        return None
+    if candidate.is_dir():
+        return candidate / "index.html"
+    if candidate.is_file():
+        return candidate
+    if "." not in Path(raw_path).name:
+        return root / "index.html"
+    return None
+
+
+def make_proxy_handler(config: ProxyHarnessConfig) -> type[BaseHTTPRequestHandler]:
+    normalized_config = ProxyHarnessConfig(
+        backend_url=normalize_backend_url(config.backend_url),
+        frontend_dist=config.frontend_dist,
+        actor=config.actor,
+        roles=config.roles,
+        timeout_seconds=config.timeout_seconds,
+    )
+
+    class SharedServiceProxyHandler(BaseHTTPRequestHandler):
+        server_version = "MtgSharedServiceProxyHarness/0.1"
+
+        def log_message(self, format: str, *args) -> None:  # noqa: A002 - stdlib signature
+            return
+
+        def do_DELETE(self) -> None:  # noqa: N802 - http.server method naming
+            self._handle_request()
+
+        def do_GET(self) -> None:  # noqa: N802 - http.server method naming
+            self._handle_request()
+
+        def do_HEAD(self) -> None:  # noqa: N802 - http.server method naming
+            self._handle_request(head_only=True)
+
+        def do_OPTIONS(self) -> None:  # noqa: N802 - http.server method naming
+            self._handle_request()
+
+        def do_PATCH(self) -> None:  # noqa: N802 - http.server method naming
+            self._handle_request()
+
+        def do_POST(self) -> None:  # noqa: N802 - http.server method naming
+            self._handle_request()
+
+        def do_PUT(self) -> None:  # noqa: N802 - http.server method naming
+            self._handle_request()
+
+        def _handle_request(self, *, head_only: bool = False) -> None:
+            parsed_target = urlsplit(self.path)
+            if parsed_target.path == "/api" or parsed_target.path.startswith("/api/"):
+                self._proxy_api_request(head_only=head_only)
+                return
+            self._serve_static(head_only=head_only)
+
+        def _read_request_body(self) -> bytes | None:
+            content_length = self.headers.get("Content-Length")
+            if not content_length:
+                return None
+            try:
+                length = int(content_length)
+            except ValueError:
+                self._send_error_json(400, "Invalid Content-Length header.")
+                return None
+            if length <= 0:
+                return None
+            return self.rfile.read(length)
+
+        def _proxy_api_request(self, *, head_only: bool = False) -> None:
+            body = self._read_request_body()
+            if body is None and self.headers.get("Content-Length") not in {None, "0"}:
+                return
+            upstream_url = rewrite_api_url(normalized_config.backend_url, self.path)
+            headers = build_forward_headers(
+                self.headers.items(),
+                config=normalized_config,
+                client_host=self.client_address[0],
+                original_host=self.headers.get("Host"),
+            )
+            request = Request(
+                upstream_url,
+                data=body,
+                headers=headers,
+                method=self.command,
+            )
+            try:
+                with urlopen(request, timeout=normalized_config.timeout_seconds) as response:
+                    response_body = response.read()
+                    self._send_response(
+                        response.status,
+                        response.reason,
+                        response.headers.items(),
+                        b"" if head_only else response_body,
+                    )
+            except HTTPError as exc:
+                response_body = exc.read()
+                self._send_response(
+                    exc.code,
+                    exc.reason,
+                    exc.headers.items(),
+                    b"" if head_only else response_body,
+                )
+            except URLError as exc:
+                self._send_error_json(502, f"Backend request failed: {exc.reason}")
+
+        def _serve_static(self, *, head_only: bool = False) -> None:
+            if self.command not in {"GET", "HEAD"}:
+                self._send_error_json(405, "Static frontend assets only support GET and HEAD.")
+                return
+            index_path = normalized_config.frontend_dist / "index.html"
+            if not index_path.is_file():
+                self._send_error_json(
+                    503,
+                    "Frontend build output is missing. Run `npm run build` in frontend/ first.",
+                )
+                return
+            static_path = _resolve_static_path(normalized_config.frontend_dist, self.path)
+            if static_path is None:
+                self._send_error_json(403, "Requested static path is outside the frontend build directory.")
+                return
+            if not static_path.is_file():
+                self._send_error_json(404, "Static asset not found.")
+                return
+            content_type = mimetypes.guess_type(static_path.name)[0] or "application/octet-stream"
+            body = b"" if head_only else static_path.read_bytes()
+            self._send_response(
+                200,
+                "OK",
+                [("Content-Type", content_type)],
+                body,
+            )
+
+        def _send_error_json(self, status_code: int, message: str) -> None:
+            self._send_response(
+                status_code,
+                "Proxy Harness Error",
+                [("Content-Type", "application/json")],
+                _json_error(message),
+            )
+
+        def _send_response(
+            self,
+            status_code: int,
+            reason: str,
+            response_headers: Iterable[tuple[str, str]],
+            body: bytes,
+        ) -> None:
+            self.send_response(status_code, reason)
+            for header_name, header_value in response_headers:
+                normalized_name = header_name.casefold()
+                if normalized_name in HOP_BY_HOP_HEADERS or normalized_name == "content-length":
+                    continue
+                self.send_header(header_name, header_value)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if body:
+                self.wfile.write(body)
+
+    return SharedServiceProxyHandler
+
+
+def build_server(
+    config: ProxyHarnessConfig,
+    *,
+    host: str = DEFAULT_PROXY_HOST,
+    port: int = DEFAULT_PROXY_PORT,
+) -> ThreadingHTTPServer:
+    return _ReusableThreadingHTTPServer((host, port), make_proxy_handler(config))
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the local shared-service reverse-proxy validation harness."
+    )
+    parser.add_argument("--backend-url", default=DEFAULT_BACKEND_URL)
+    parser.add_argument("--frontend-dist", type=Path, default=DEFAULT_FRONTEND_DIST)
+    parser.add_argument("--host", default=DEFAULT_PROXY_HOST)
+    parser.add_argument("--port", default=DEFAULT_PROXY_PORT, type=int)
+    parser.add_argument(
+        "--fixture-preset",
+        choices=sorted(FIXTURE_PRESETS),
+        default="viewer",
+        help="Fixture identity to inject into proxied API requests.",
+    )
+    parser.add_argument("--actor", default=None, help="Override the injected authenticated actor.")
+    parser.add_argument(
+        "--roles",
+        default=None,
+        help="Override the injected authenticated roles. Use an empty string to omit the header.",
+    )
+    parser.add_argument("--timeout", default=10.0, type=float, help="Backend request timeout in seconds.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    identity = resolve_fixture_identity(
+        args.fixture_preset,
+        actor=args.actor,
+        roles=args.roles,
+    )
+    config = ProxyHarnessConfig(
+        backend_url=args.backend_url,
+        frontend_dist=args.frontend_dist,
+        actor=identity.actor,
+        roles=identity.roles or None,
+        timeout_seconds=args.timeout,
+    )
+    try:
+        server = build_server(config, host=args.host, port=args.port)
+    except OSError as exc:
+        parser.error(str(exc))
+
+    host, port = server.server_address
+    print(
+        "Shared-service proxy harness listening at "
+        f"http://{host}:{port} -> {normalize_backend_url(args.backend_url)}"
+    )
+    if identity.actor:
+        role_summary = identity.roles or "<omitted>"
+        print(f"Injecting {AUTHENTICATED_USER_HEADER}: {identity.actor}")
+        print(f"Injecting {AUTHENTICATED_ROLES_HEADER}: {role_summary}")
+    else:
+        print("No authenticated user header will be injected.")
+    print(f"Serving frontend build from {args.frontend_dist}")
+    print("This harness is for local validation only; do not use it for real users.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nStopping shared-service proxy harness.")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/shared_service_proxy_harness.py
+++ b/scripts/shared_service_proxy_harness.py
@@ -160,6 +160,18 @@ def build_forward_headers(
     return forwarded
 
 
+def parse_content_length(raw_content_length: str | None) -> int:
+    if raw_content_length in {None, ""}:
+        return 0
+    try:
+        content_length = int(raw_content_length)
+    except ValueError as exc:
+        raise HarnessError("Invalid Content-Length header.") from exc
+    if content_length < 0:
+        raise HarnessError("Invalid Content-Length header.")
+    return content_length
+
+
 def _json_error(message: str) -> bytes:
     return json.dumps(
         {"error": {"code": "proxy_harness_error", "message": message}},
@@ -237,22 +249,19 @@ def make_proxy_handler(config: ProxyHarnessConfig) -> type[BaseHTTPRequestHandle
                 return
             self._serve_static(head_only=head_only)
 
-        def _read_request_body(self) -> bytes | None:
-            content_length = self.headers.get("Content-Length")
-            if not content_length:
-                return None
+        def _read_request_body(self) -> tuple[bytes | None, bool]:
             try:
-                length = int(content_length)
-            except ValueError:
-                self._send_error_json(400, "Invalid Content-Length header.")
-                return None
-            if length <= 0:
-                return None
-            return self.rfile.read(length)
+                length = parse_content_length(self.headers.get("Content-Length"))
+            except HarnessError as exc:
+                self._send_error_json(400, str(exc))
+                return None, False
+            if length == 0:
+                return None, True
+            return self.rfile.read(length), True
 
         def _proxy_api_request(self, *, head_only: bool = False) -> None:
-            body = self._read_request_body()
-            if body is None and self.headers.get("Content-Length") not in {None, "0"}:
+            body, body_ok = self._read_request_body()
+            if not body_ok:
                 return
             upstream_url = rewrite_api_url(normalized_config.backend_url, self.path)
             headers = build_forward_headers(

--- a/scripts/smoke_shared_service_proxy.py
+++ b/scripts/smoke_shared_service_proxy.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""Smoke-test the local shared-service proxy harness."""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import threading
+import time
+from typing import Iterator
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from shared_service_proxy_harness import (
+    DEFAULT_BACKEND_URL,
+    DEFAULT_FRONTEND_DIST,
+    DEFAULT_PROXY_HOST,
+    ACTOR_ID_HEADER,
+    AUTHENTICATED_ROLES_HEADER,
+    AUTHENTICATED_USER_HEADER,
+    ProxyHarnessConfig,
+    build_server,
+    resolve_fixture_identity,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DB_PATH = REPO_ROOT / "var" / "db" / "frontend_demo.db"
+DEFAULT_BACKEND_HOST = "127.0.0.1"
+DEFAULT_BACKEND_STARTUP_TIMEOUT = 15.0
+DEFAULT_REQUEST_TIMEOUT = 10.0
+
+
+class SmokeFailure(AssertionError):
+    """Raised when the proxy smoke workflow observes unexpected behavior."""
+
+
+@dataclass(frozen=True, slots=True)
+class HttpResult:
+    status: int
+    body: bytes
+    headers: dict[str, str]
+
+    def json(self):
+        return json.loads(self.body.decode("utf-8"))
+
+    def text(self) -> str:
+        return self.body.decode("utf-8")
+
+
+def _free_port(host: str = DEFAULT_BACKEND_HOST) -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+def _request(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    expected_status: int | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT,
+) -> HttpResult:
+    request = Request(url, headers=headers or {})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            result = HttpResult(
+                status=response.status,
+                body=response.read(),
+                headers=dict(response.headers.items()),
+            )
+    except HTTPError as exc:
+        result = HttpResult(
+            status=exc.code,
+            body=exc.read(),
+            headers=dict(exc.headers.items()),
+        )
+    except URLError as exc:
+        raise SmokeFailure(f"Request failed for {url}: {exc.reason}") from exc
+
+    if expected_status is not None and result.status != expected_status:
+        body = result.text()[:500]
+        raise SmokeFailure(f"Expected {expected_status} from {url}, got {result.status}: {body}")
+    return result
+
+
+def _wait_for_backend(base_url: str, *, timeout_seconds: float) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            health = _request(f"{base_url}/health", expected_status=200, timeout=2.0)
+            if health.json().get("status") == "ok":
+                return
+        except Exception as exc:  # pragma: no cover - exercised by timeout path
+            last_error = exc
+        time.sleep(0.1)
+    detail = f" Last error: {last_error}" if last_error else ""
+    raise SmokeFailure(f"Timed out waiting for backend at {base_url}.{detail}")
+
+
+@contextmanager
+def _started_backend(args: argparse.Namespace) -> Iterator[str]:
+    if not args.start_backend:
+        yield args.backend_url.rstrip("/")
+        return
+
+    backend_port = args.backend_port or _free_port()
+    backend_url = f"http://{DEFAULT_BACKEND_HOST}:{backend_port}"
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    src_path = str(REPO_ROOT / "src")
+    env["PYTHONPATH"] = f"{src_path}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else src_path
+    env.setdefault("MTG_API_SNAPSHOT_SIGNING_SECRET", "local-shared-service-smoke-secret")
+    command = [
+        sys.executable,
+        "-c",
+        "from mtg_source_stack.api.app import main; import sys; main(sys.argv[1:])",
+        "--db",
+        str(args.db),
+        "--runtime-mode",
+        "shared_service",
+        "--host",
+        DEFAULT_BACKEND_HOST,
+        "--port",
+        str(backend_port),
+        "--forwarded-allow-ips",
+        DEFAULT_BACKEND_HOST,
+    ]
+    process = subprocess.Popen(
+        command,
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        _wait_for_backend(backend_url, timeout_seconds=args.backend_startup_timeout)
+        yield backend_url
+    except Exception:
+        if process.poll() is not None:
+            output, _ = process.communicate(timeout=2)
+            if output:
+                print(output, file=sys.stderr)
+        raise
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
+
+@contextmanager
+def _proxy_for_preset(
+    preset: str,
+    *,
+    backend_url: str,
+    frontend_dist: Path,
+    proxy_host: str,
+    proxy_port: int,
+    timeout_seconds: float,
+) -> Iterator[str]:
+    identity = resolve_fixture_identity(preset)
+    config = ProxyHarnessConfig(
+        backend_url=backend_url,
+        frontend_dist=frontend_dist,
+        actor=identity.actor,
+        roles=identity.roles,
+        timeout_seconds=timeout_seconds,
+    )
+    server = build_server(config, host=proxy_host, port=proxy_port)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def _proxy_request(
+    base_url: str,
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+    expected_status: int | None = None,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT,
+) -> HttpResult:
+    return _request(
+        f"{base_url}{path}",
+        headers=headers,
+        expected_status=expected_status,
+        timeout=timeout,
+    )
+
+
+def _inventory_slugs(base_url: str, *, expected_status: int = 200) -> list[str]:
+    response = _proxy_request(base_url, "/api/inventories", expected_status=expected_status)
+    if expected_status != 200:
+        return []
+    return [row["slug"] for row in response.json()]
+
+
+def _search_path(query: str) -> str:
+    return f"/api/cards/search?{urlencode({'query': query})}"
+
+
+def run_smoke(args: argparse.Namespace) -> None:
+    frontend_dist = args.frontend_dist
+    if not args.skip_static and not (frontend_dist / "index.html").is_file():
+        raise SmokeFailure(
+            f"Missing frontend build at {frontend_dist}. Run `npm run build` in frontend/ or pass --skip-static."
+        )
+
+    with _started_backend(args) as backend_url:
+        print(f"Backend target: {backend_url}")
+
+        with _proxy_for_preset(
+            "none",
+            backend_url=backend_url,
+            frontend_dist=frontend_dist,
+            proxy_host=args.proxy_host,
+            proxy_port=args.proxy_port,
+            timeout_seconds=args.timeout,
+        ) as proxy_url:
+            health = _proxy_request(proxy_url, "/api/health", expected_status=200)
+            if health.json().get("status") != "ok":
+                raise SmokeFailure("/api/health did not return status=ok through the proxy.")
+            print("PASS /api path rewriting via /api/health")
+
+            spoofed_headers = {
+                AUTHENTICATED_USER_HEADER: "admin@example.com",
+                AUTHENTICATED_ROLES_HEADER: "admin",
+                ACTOR_ID_HEADER: "local-demo",
+            }
+            _proxy_request(
+                proxy_url,
+                "/api/inventories",
+                headers=spoofed_headers,
+                expected_status=401,
+            )
+            print("PASS spoofed auth headers are stripped when no identity is injected")
+
+            if not args.skip_static:
+                index = _proxy_request(proxy_url, "/", expected_status=200)
+                if "<html" not in index.text().lower():
+                    raise SmokeFailure("Frontend index did not look like HTML.")
+                print("PASS frontend assets are served from the same origin")
+
+        with _proxy_for_preset(
+            "viewer",
+            backend_url=backend_url,
+            frontend_dist=frontend_dist,
+            proxy_host=args.proxy_host,
+            proxy_port=args.proxy_port,
+            timeout_seconds=args.timeout,
+        ) as proxy_url:
+            viewer_slugs = _inventory_slugs(proxy_url)
+            if viewer_slugs != ["personal"]:
+                raise SmokeFailure(f"Expected viewer to see ['personal'], got {viewer_slugs!r}.")
+            print("PASS viewer fixture sees only personal")
+
+            spoofed_admin_response = _proxy_request(
+                proxy_url,
+                "/api/inventories",
+                headers={
+                    AUTHENTICATED_USER_HEADER: "admin@example.com",
+                    AUTHENTICATED_ROLES_HEADER: "admin",
+                    ACTOR_ID_HEADER: "local-demo",
+                },
+                expected_status=200,
+            )
+            spoofed_admin_slugs = [row["slug"] for row in spoofed_admin_response.json()]
+            if spoofed_admin_slugs != ["personal"]:
+                raise SmokeFailure(
+                    "Spoofed client admin headers were not neutralized; "
+                    f"viewer proxy saw {spoofed_admin_slugs!r}."
+                )
+            print("PASS spoofed client admin headers do not override proxy identity")
+
+            _proxy_request(proxy_url, _search_path("Lightning"), expected_status=200)
+            print("PASS readable fixture can use catalog search")
+
+        with _proxy_for_preset(
+            "writer",
+            backend_url=backend_url,
+            frontend_dist=frontend_dist,
+            proxy_host=args.proxy_host,
+            proxy_port=args.proxy_port,
+            timeout_seconds=args.timeout,
+        ) as proxy_url:
+            writer_slugs = _inventory_slugs(proxy_url)
+            if writer_slugs != ["trade-binder"]:
+                raise SmokeFailure(f"Expected writer to see ['trade-binder'], got {writer_slugs!r}.")
+            print("PASS writer fixture sees only trade-binder")
+
+        with _proxy_for_preset(
+            "no-access",
+            backend_url=backend_url,
+            frontend_dist=frontend_dist,
+            proxy_host=args.proxy_host,
+            proxy_port=args.proxy_port,
+            timeout_seconds=args.timeout,
+        ) as proxy_url:
+            no_access_slugs = _inventory_slugs(proxy_url)
+            if no_access_slugs != []:
+                raise SmokeFailure(f"Expected no-access fixture to see no inventories, got {no_access_slugs!r}.")
+            _proxy_request(proxy_url, _search_path("Lightning"), expected_status=403)
+            print("PASS no-access fixture is denied catalog search")
+
+        with _proxy_for_preset(
+            "admin",
+            backend_url=backend_url,
+            frontend_dist=frontend_dist,
+            proxy_host=args.proxy_host,
+            proxy_port=args.proxy_port,
+            timeout_seconds=args.timeout,
+        ) as proxy_url:
+            admin_slugs = set(_inventory_slugs(proxy_url))
+            expected_admin_slugs = {"bootstrapped-collection", "personal", "trade-binder"}
+            if admin_slugs != expected_admin_slugs:
+                raise SmokeFailure(
+                    f"Expected admin to see {sorted(expected_admin_slugs)!r}, got {sorted(admin_slugs)!r}."
+                )
+            print("PASS admin fixture sees all shared-service demo inventories")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Smoke-test the shared-service proxy harness.")
+    parser.add_argument("--backend-url", default=DEFAULT_BACKEND_URL)
+    parser.add_argument(
+        "--start-backend",
+        action="store_true",
+        help="Launch mtg-web-api in shared_service mode for the duration of the smoke run.",
+    )
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+    parser.add_argument("--backend-port", type=int, default=0)
+    parser.add_argument("--backend-startup-timeout", type=float, default=DEFAULT_BACKEND_STARTUP_TIMEOUT)
+    parser.add_argument("--frontend-dist", type=Path, default=DEFAULT_FRONTEND_DIST)
+    parser.add_argument("--proxy-host", default=DEFAULT_PROXY_HOST)
+    parser.add_argument("--proxy-port", type=int, default=0)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_REQUEST_TIMEOUT)
+    parser.add_argument(
+        "--skip-static",
+        action="store_true",
+        help="Skip the frontend index check and validate only the proxied API surface.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    try:
+        run_smoke(args)
+    except SmokeFailure as exc:
+        print(f"FAIL {exc}", file=sys.stderr)
+        return 1
+    print("Shared-service proxy smoke checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_frontend_demo_scripts.py
+++ b/tests/test_frontend_demo_scripts.py
@@ -130,6 +130,64 @@ class FrontendDemoScriptsTest(unittest.TestCase):
             self.assertIn(str(REPO_ROOT / "var/db/frontend_demo.db"), argv)
             self.assertIn("--force", argv)
 
+    def test_run_shared_service_proxy_uses_override_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            fake_python = tmp / "fake-python.sh"
+            args_file = tmp / "args.txt"
+            _write_fake_python(fake_python)
+
+            env = os.environ.copy()
+            env["MTG_FRONTEND_PYTHON"] = str(fake_python)
+            env["FAKE_PYTHON_ARGS_FILE"] = str(args_file)
+
+            subprocess.run(
+                [
+                    "bash",
+                    "frontend/scripts/run_shared_service_proxy.sh",
+                    "--fixture-preset",
+                    "admin",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            argv = args_file.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(str(REPO_ROOT / "scripts/shared_service_proxy_harness.py"), argv[0])
+            self.assertIn("--fixture-preset", argv)
+            self.assertIn("admin", argv)
+
+    def test_smoke_shared_service_proxy_uses_override_python(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            fake_python = tmp / "fake-python.sh"
+            args_file = tmp / "args.txt"
+            _write_fake_python(fake_python)
+
+            env = os.environ.copy()
+            env["MTG_FRONTEND_PYTHON"] = str(fake_python)
+            env["FAKE_PYTHON_ARGS_FILE"] = str(args_file)
+
+            subprocess.run(
+                [
+                    "bash",
+                    "frontend/scripts/smoke_shared_service_proxy.sh",
+                    "--skip-static",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+            argv = args_file.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(str(REPO_ROOT / "scripts/smoke_shared_service_proxy.py"), argv[0])
+            self.assertIn("--skip-static", argv)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_shared_service_proxy_harness.py
+++ b/tests/test_shared_service_proxy_harness.py
@@ -120,6 +120,18 @@ class SharedServiceProxyHarnessTest(unittest.TestCase):
         self.assertEqual("127.0.0.1", headers["X-Forwarded-For"])
         self.assertEqual("app.example.test", headers["X-Forwarded-Host"])
 
+    def test_parse_content_length_rejects_negative_values(self) -> None:
+        with self.assertRaisesRegex(
+            shared_service_proxy_harness.HarnessError,
+            "Invalid Content-Length header",
+        ):
+            shared_service_proxy_harness.parse_content_length("-1")
+
+    def test_parse_content_length_accepts_zero_and_missing_values(self) -> None:
+        self.assertEqual(0, shared_service_proxy_harness.parse_content_length(None))
+        self.assertEqual(0, shared_service_proxy_harness.parse_content_length(""))
+        self.assertEqual(0, shared_service_proxy_harness.parse_content_length("0"))
+
     @unittest.skipUnless(
         LOCALHOST_SERVER_TESTING_AVAILABLE,
         "localhost socket access is unavailable; live proxy harness test is skipped.",
@@ -155,6 +167,38 @@ class SharedServiceProxyHarnessTest(unittest.TestCase):
         self.assertIsNone(payload["roles"])
         self.assertIsNone(payload["actor_id"])
         self.assertEqual("/inventories?limit=1", backend_server.records[0]["path"])  # type: ignore[index, attr-defined]
+
+    @unittest.skipUnless(
+        LOCALHOST_SERVER_TESTING_AVAILABLE,
+        "localhost socket access is unavailable; live proxy harness test is skipped.",
+    )
+    def test_proxy_returns_400_for_negative_content_length(self) -> None:
+        backend_server = ThreadingHTTPServer(("127.0.0.1", 0), RecordingBackendHandler)
+        backend_server.records = []  # type: ignore[attr-defined]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            frontend_dist = Path(tmp_dir)
+            (frontend_dist / "index.html").write_text("<html>demo</html>", encoding="utf-8")
+            with _running_server(backend_server) as (backend_url, _backend):
+                config = shared_service_proxy_harness.ProxyHarnessConfig(
+                    backend_url=backend_url,
+                    frontend_dist=frontend_dist,
+                    actor="viewer@example.com",
+                    roles=None,
+                )
+                proxy_server = shared_service_proxy_harness.build_server(config, port=0)
+                with _running_server(proxy_server) as (_proxy_url, proxy):
+                    host, port = proxy.server_address
+                    with socket.create_connection((host, port), timeout=5) as sock:
+                        sock.sendall(
+                            b"POST /api/inventories HTTP/1.1\r\n"
+                            + f"Host: {host}:{port}\r\n".encode("ascii")
+                            + b"Content-Length: -1\r\n"
+                            + b"\r\n"
+                        )
+                        response = sock.recv(1024)
+
+        self.assertIn(b"400 Proxy Harness Error", response)
+        self.assertEqual([], backend_server.records)  # type: ignore[attr-defined]
 
     @unittest.skipUnless(
         LOCALHOST_SERVER_TESTING_AVAILABLE,

--- a/tests/test_shared_service_proxy_harness.py
+++ b/tests/test_shared_service_proxy_harness.py
@@ -1,0 +1,218 @@
+"""Regression coverage for the shared-service proxy validation harness."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import importlib.util
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import socket
+import sys
+import tempfile
+import threading
+import unittest
+from urllib.request import Request, urlopen
+
+from tests.common import REPO_ROOT
+
+
+HARNESS_PATH = REPO_ROOT / "scripts" / "shared_service_proxy_harness.py"
+SPEC = importlib.util.spec_from_file_location("shared_service_proxy_harness", HARNESS_PATH)
+assert SPEC is not None
+shared_service_proxy_harness = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = shared_service_proxy_harness
+SPEC.loader.exec_module(shared_service_proxy_harness)
+
+
+def _localhost_server_testing_available() -> bool:
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+    except OSError:
+        return False
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+    return True
+
+
+LOCALHOST_SERVER_TESTING_AVAILABLE = _localhost_server_testing_available()
+
+
+@contextmanager
+def _running_server(server: ThreadingHTTPServer):
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://{host}:{port}", server
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+class RecordingBackendHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - http.server method naming
+        self.server.records.append(  # type: ignore[attr-defined]
+            {
+                "path": self.path,
+                "headers": dict(self.headers.items()),
+            }
+        )
+        payload = {
+            "path": self.path,
+            "user": self.headers.get("X-Authenticated-User"),
+            "roles": self.headers.get("X-Authenticated-Roles"),
+            "actor_id": self.headers.get("X-Actor-Id"),
+        }
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A002 - stdlib signature
+        return
+
+
+class SharedServiceProxyHarnessTest(unittest.TestCase):
+    def test_rewrite_api_url_strips_api_prefix_and_preserves_query(self) -> None:
+        url = shared_service_proxy_harness.rewrite_api_url(
+            "http://127.0.0.1:8000/",
+            "/api/inventories?limit=10",
+        )
+
+        self.assertEqual("http://127.0.0.1:8000/inventories?limit=10", url)
+
+    def test_build_forward_headers_strips_spoofed_auth_and_injects_fixture_identity(self) -> None:
+        config = shared_service_proxy_harness.ProxyHarnessConfig(
+            backend_url="http://127.0.0.1:8000",
+            frontend_dist=Path("frontend/dist"),
+            actor="viewer@example.com",
+            roles=None,
+        )
+
+        headers = shared_service_proxy_harness.build_forward_headers(
+            [
+                ("X-Authenticated-User", "admin@example.com"),
+                ("X-Authenticated-Roles", "admin"),
+                ("X-Actor-Id", "local-demo"),
+                ("Accept", "application/json"),
+                ("Connection", "keep-alive"),
+                ("Host", "app.example.test"),
+            ],
+            config=config,
+            client_host="127.0.0.1",
+            original_host="app.example.test",
+        )
+
+        self.assertEqual("viewer@example.com", headers["X-Authenticated-User"])
+        self.assertNotIn("X-Authenticated-Roles", headers)
+        self.assertNotIn("X-Actor-Id", headers)
+        self.assertEqual("application/json", headers["Accept"])
+        self.assertNotIn("Connection", headers)
+        self.assertEqual("127.0.0.1", headers["X-Forwarded-For"])
+        self.assertEqual("app.example.test", headers["X-Forwarded-Host"])
+
+    @unittest.skipUnless(
+        LOCALHOST_SERVER_TESTING_AVAILABLE,
+        "localhost socket access is unavailable; live proxy harness test is skipped.",
+    )
+    def test_proxy_rewrites_api_requests_and_neutralizes_spoofed_admin_headers(self) -> None:
+        backend_server = ThreadingHTTPServer(("127.0.0.1", 0), RecordingBackendHandler)
+        backend_server.records = []  # type: ignore[attr-defined]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            frontend_dist = Path(tmp_dir)
+            (frontend_dist / "index.html").write_text("<html>demo</html>", encoding="utf-8")
+            with _running_server(backend_server) as (backend_url, _backend):
+                config = shared_service_proxy_harness.ProxyHarnessConfig(
+                    backend_url=backend_url,
+                    frontend_dist=frontend_dist,
+                    actor="viewer@example.com",
+                    roles=None,
+                )
+                proxy_server = shared_service_proxy_harness.build_server(config, port=0)
+                with _running_server(proxy_server) as (proxy_url, _proxy):
+                    request = Request(
+                        f"{proxy_url}/api/inventories?limit=1",
+                        headers={
+                            "X-Authenticated-User": "admin@example.com",
+                            "X-Authenticated-Roles": "admin",
+                            "X-Actor-Id": "local-demo",
+                        },
+                    )
+                    with urlopen(request, timeout=5) as response:
+                        payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertEqual("/inventories?limit=1", payload["path"])
+        self.assertEqual("viewer@example.com", payload["user"])
+        self.assertIsNone(payload["roles"])
+        self.assertIsNone(payload["actor_id"])
+        self.assertEqual("/inventories?limit=1", backend_server.records[0]["path"])  # type: ignore[index, attr-defined]
+
+    @unittest.skipUnless(
+        LOCALHOST_SERVER_TESTING_AVAILABLE,
+        "localhost socket access is unavailable; live proxy harness test is skipped.",
+    )
+    def test_proxy_without_identity_strips_client_supplied_auth_headers(self) -> None:
+        backend_server = ThreadingHTTPServer(("127.0.0.1", 0), RecordingBackendHandler)
+        backend_server.records = []  # type: ignore[attr-defined]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            frontend_dist = Path(tmp_dir)
+            (frontend_dist / "index.html").write_text("<html>demo</html>", encoding="utf-8")
+            with _running_server(backend_server) as (backend_url, _backend):
+                config = shared_service_proxy_harness.ProxyHarnessConfig(
+                    backend_url=backend_url,
+                    frontend_dist=frontend_dist,
+                    actor=None,
+                    roles=None,
+                )
+                proxy_server = shared_service_proxy_harness.build_server(config, port=0)
+                with _running_server(proxy_server) as (proxy_url, _proxy):
+                    request = Request(
+                        f"{proxy_url}/api/inventories",
+                        headers={
+                            "X-Authenticated-User": "admin@example.com",
+                            "X-Authenticated-Roles": "admin",
+                        },
+                    )
+                    with urlopen(request, timeout=5) as response:
+                        payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertIsNone(payload["user"])
+        self.assertIsNone(payload["roles"])
+        self.assertIsNone(payload["actor_id"])
+
+    @unittest.skipUnless(
+        LOCALHOST_SERVER_TESTING_AVAILABLE,
+        "localhost socket access is unavailable; live proxy harness test is skipped.",
+    )
+    def test_proxy_serves_frontend_index_and_spa_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            frontend_dist = Path(tmp_dir)
+            (frontend_dist / "index.html").write_text("<html>demo app</html>", encoding="utf-8")
+            config = shared_service_proxy_harness.ProxyHarnessConfig(
+                backend_url="http://127.0.0.1:9",
+                frontend_dist=frontend_dist,
+                actor=None,
+                roles=None,
+            )
+            proxy_server = shared_service_proxy_harness.build_server(config, port=0)
+            with _running_server(proxy_server) as (proxy_url, _proxy):
+                with urlopen(f"{proxy_url}/", timeout=5) as index_response:
+                    index_body = index_response.read().decode("utf-8")
+                with urlopen(f"{proxy_url}/collections/personal", timeout=5) as route_response:
+                    route_body = route_response.read().decode("utf-8")
+
+        self.assertEqual("<html>demo app</html>", index_body)
+        self.assertEqual("<html>demo app</html>", route_body)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a local shared-service proxy harness that serves the built frontend and proxies `/api/*` to root-mounted backend routes
- strip client-supplied `X-Authenticated-User`, `X-Authenticated-Roles`, and `X-Actor-Id` before injecting fixture identities
- add a smoke workflow and npm wrappers for proxy-backed shared-service validation
- document the automated smoke path, manual browser path, and boundary that this is not production reverse-proxy infrastructure

Closes #44.

## Validation

- `python3 -m py_compile scripts/shared_service_proxy_harness.py scripts/smoke_shared_service_proxy.py`
- `PYTHONPATH=src python3 -m unittest tests.test_shared_service_proxy_harness tests.test_frontend_demo_scripts tests.test_frontend_demo_bootstrap -q`
- `.venv/bin/python -m unittest tests.test_shared_service_proxy_harness -q`
- `npm run demo:bootstrap -- --force --shared-service-fixtures`
- `npm run build`
- `npm run smoke:shared-service-proxy -- --start-backend`
- `npm test`

Not run yet: full backend suite via `python3 -m unittest discover -s tests -q`.

## Follow-Up

Production reverse-proxy/gateway transition is tracked separately in #57.
