### PR TITLE
Add owner-managed inventory share links

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,19 @@ local/dev testing, set `MTG_API_TRUST_ACTOR_HEADERS=true` to trust
 header-supplied actor IDs instead. `X-Request-Id` remains accepted for request
 tracing.
 
-In `shared_service`, every current app route except `/health` requires an
+In `shared_service`, every current app/API route except `/health` and public
+share-link reads under `/shared/inventories/{share_token}` requires an
 authenticated app user. The default verified identity header is
 `X-Authenticated-User`, and you can override it with
 `MTG_API_AUTHENTICATED_ACTOR_HEADER`.
 
 Deck URL preview/commit flows also use a short-lived signed snapshot token.
-`local_demo` ships with a built-in default signing secret for that flow.
-`shared_service` requires an explicit `MTG_API_SNAPSHOT_SIGNING_SECRET`.
+Public inventory share links use the same signing-secret setting to make
+reusable links recoverable without storing the full bearer token in the
+database. `local_demo` ships with a built-in default signing secret for these
+flows. `shared_service` requires an explicit
+`MTG_API_SNAPSHOT_SIGNING_SECRET`; rotating it invalidates existing deck preview
+tokens and public inventory share URLs.
 
 `shared_service` also supports a normalized roles header,
 `X-Authenticated-Roles` by default, with `editor` and `admin` as the current
@@ -544,7 +549,8 @@ checkout in multi-repo environments.
 - The demo API ignores caller-supplied `X-Actor-Id` values by default and
   stamps writes as `local-demo` unless trusted-header mode is explicitly
   enabled.
-- In `shared_service`, non-health routes require an authenticated app user.
+- In `shared_service`, non-health routes require an authenticated app user
+  except public share-link reads under `/shared/inventories/{share_token}`.
   Inventory reads and writes are scoped by local memberships. Authenticated
   users can create inventories they own; global roles are only for elevated app
   permissions such as admin bypass. The default verified identity header is

--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ header-supplied actor IDs instead. `X-Request-Id` remains accepted for request
 tracing.
 
 In `shared_service`, every current app/API route except `/health` and public
-share-link reads under `/shared/inventories/{share_token}` requires an
-authenticated app user. The default verified identity header is
+share-link backend reads under `/shared/inventories/{share_token}` requires an
+authenticated app user. Behind the recommended `/api` proxy, that public JSON
+route is published as `/api/shared/inventories/{share_token}`. Share-link
+management responses expose `public_path` as the browser-facing page path,
+currently `/shared/inventories/{share_token}`; the frontend page should call
+the proxied API route internally. The default verified identity header is
 `X-Authenticated-User`, and you can override it with
 `MTG_API_AUTHENTICATED_ACTOR_HEADER`.
 
@@ -550,7 +554,10 @@ checkout in multi-repo environments.
   stamps writes as `local-demo` unless trusted-header mode is explicitly
   enabled.
 - In `shared_service`, non-health routes require an authenticated app user
-  except public share-link reads under `/shared/inventories/{share_token}`.
+  except public share-link backend reads under
+  `/shared/inventories/{share_token}`. Behind the recommended `/api` proxy,
+  those JSON reads are published as `/api/shared/inventories/{share_token}`,
+  while share-link `public_path` remains the browser-facing page path.
   Inventory reads and writes are scoped by local memberships. Authenticated
   users can create inventories they own; global roles are only for elevated app
   permissions such as admin bypass. The default verified identity header is

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -2910,6 +2910,124 @@
         "title": "InventoryListRowResponse",
         "type": "object"
       },
+      "InventoryShareLinkStatusResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "active": {
+            "title": "Active",
+            "type": "boolean"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "inventory": {
+            "title": "Inventory",
+            "type": "string"
+          },
+          "public_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Public Path"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "inventory",
+          "active",
+          "public_path",
+          "created_at",
+          "updated_at",
+          "revoked_at"
+        ],
+        "title": "InventoryShareLinkStatusResponse",
+        "type": "object"
+      },
+      "InventoryShareLinkTokenResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "active": {
+            "title": "Active",
+            "type": "boolean"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "inventory": {
+            "title": "Inventory",
+            "type": "string"
+          },
+          "public_path": {
+            "title": "Public Path",
+            "type": "string"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inventory",
+          "token",
+          "public_path",
+          "active",
+          "created_at",
+          "updated_at",
+          "revoked_at"
+        ],
+        "title": "InventoryShareLinkTokenResponse",
+        "type": "object"
+      },
       "InventoryTransferItemResultResponse": {
         "additionalProperties": false,
         "properties": {
@@ -3529,6 +3647,180 @@
           }
         },
         "title": "PatchInventoryItemRequest",
+        "type": "object"
+      },
+      "PublicInventoryItemResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed_finishes": {
+            "description": "Canonical finish values: normal, foil, etched.",
+            "items": {
+              "enum": [
+                "normal",
+                "foil",
+                "etched"
+              ],
+              "type": "string"
+            },
+            "title": "Allowed Finishes",
+            "type": "array"
+          },
+          "collector_number": {
+            "title": "Collector Number",
+            "type": "string"
+          },
+          "condition_code": {
+            "description": "Canonical condition codes: M, NM, LP, MP, HP, DMG. Stored rows are normally normalized to these values.",
+            "title": "Condition Code",
+            "type": "string"
+          },
+          "finish": {
+            "description": "Canonical finish values: normal, foil, etched.",
+            "enum": [
+              "normal",
+              "foil",
+              "etched"
+            ],
+            "title": "Finish",
+            "type": "string"
+          },
+          "image_uri_normal": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Uri Normal"
+          },
+          "image_uri_small": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Image Uri Small"
+          },
+          "language_code": {
+            "description": "Canonical language codes: en, ja, de, fr, it, es, pt, ru, ko, zhs, zht, ph. Stored rows are normally normalized to these values.",
+            "title": "Language Code",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "oracle_id": {
+            "title": "Oracle Id",
+            "type": "string"
+          },
+          "quantity": {
+            "title": "Quantity",
+            "type": "integer"
+          },
+          "rarity": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rarity"
+          },
+          "scryfall_id": {
+            "title": "Scryfall Id",
+            "type": "string"
+          },
+          "set_code": {
+            "title": "Set Code",
+            "type": "string"
+          },
+          "set_name": {
+            "title": "Set Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "scryfall_id",
+          "oracle_id",
+          "name",
+          "set_code",
+          "set_name",
+          "rarity",
+          "collector_number",
+          "image_uri_small",
+          "image_uri_normal",
+          "quantity",
+          "condition_code",
+          "finish",
+          "allowed_finishes",
+          "language_code"
+        ],
+        "title": "PublicInventoryItemResponse",
+        "type": "object"
+      },
+      "PublicInventoryShareResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "inventory": {
+            "$ref": "#/components/schemas/PublicInventorySummaryResponse"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PublicInventoryItemResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "inventory",
+          "items"
+        ],
+        "title": "PublicInventoryShareResponse",
+        "type": "object"
+      },
+      "PublicInventorySummaryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "item_rows": {
+            "title": "Item Rows",
+            "type": "integer"
+          },
+          "total_cards": {
+            "title": "Total Cards",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "display_name",
+          "description",
+          "item_rows",
+          "total_cards"
+        ],
+        "title": "PublicInventorySummaryResponse",
         "type": "object"
       },
       "RemoveInventoryItemResponse": {
@@ -7326,6 +7618,328 @@
         "summary": "Inventory Items Set Printing"
       }
     },
+    "/inventories/{inventory_slug}/share-link": {
+      "delete": {
+        "operationId": "inventory_share_link_revoke_inventories__inventory_slug__share_link_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inventory_slug",
+            "required": true,
+            "schema": {
+              "title": "Inventory Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryShareLinkStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Inventory Share Link Revoke"
+      },
+      "get": {
+        "operationId": "inventory_share_link_status_inventories__inventory_slug__share_link_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inventory_slug",
+            "required": true,
+            "schema": {
+              "title": "Inventory Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryShareLinkStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Inventory Share Link Status"
+      },
+      "post": {
+        "operationId": "inventory_share_link_create_inventories__inventory_slug__share_link_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inventory_slug",
+            "required": true,
+            "schema": {
+              "title": "Inventory Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryShareLinkTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Inventory Share Link Create"
+      }
+    },
+    "/inventories/{inventory_slug}/share-link/rotate": {
+      "post": {
+        "operationId": "inventory_share_link_rotate_inventories__inventory_slug__share_link_rotate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inventory_slug",
+            "required": true,
+            "schema": {
+              "title": "Inventory Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryShareLinkTokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Inventory Share Link Rotate"
+      }
+    },
     "/inventories/{source_inventory_slug}/duplicate": {
       "post": {
         "operationId": "inventories_duplicate_inventories__source_inventory_slug__duplicate_post",
@@ -7668,6 +8282,65 @@
           }
         },
         "summary": "Bootstrap Default Inventory"
+      }
+    },
+    "/shared/inventories/{share_token}": {
+      "get": {
+        "operationId": "public_inventory_share_shared_inventories__share_token__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "share_token",
+            "required": true,
+            "schema": {
+              "title": "Share Token",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicInventoryShareResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Public Inventory Share"
       }
     }
   }

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -2941,6 +2941,7 @@
                 "type": "null"
               }
             ],
+            "description": "Browser-facing public share page path, for example `/shared/inventories/{share_token}`. In shared-service deployments, that page should fetch backend JSON through the proxied API route `/api/shared/inventories/{share_token}`; this field is not a proxy-aware API fetch URL.",
             "title": "Public Path"
           },
           "revoked_at": {
@@ -2993,6 +2994,7 @@
             "type": "string"
           },
           "public_path": {
+            "description": "Browser-facing public share page path, for example `/shared/inventories/{share_token}`. In shared-service deployments, that page should fetch backend JSON through the proxied API route `/api/shared/inventories/{share_token}`; this field is not a proxy-aware API fetch URL.",
             "title": "Public Path",
             "type": "string"
           },
@@ -3008,6 +3010,7 @@
             "title": "Revoked At"
           },
           "token": {
+            "description": "Reusable signed share token. Store/copy this only as part of the public share URL; it grants anonymous read-only access to this inventory's public share projection until rotated or revoked.",
             "title": "Token",
             "type": "string"
           },

--- a/docs/api_v1_contract.md
+++ b/docs/api_v1_contract.md
@@ -537,11 +537,12 @@ before the generic 500 envelope is returned.
   values to flow into audit attribution.
 - `shared_service` disables auto-migrate by default. It should be started
   against a pre-migrated database and a single app process for now.
-- `local_demo` uses a stable built-in deck URL snapshot signing secret so
-  preview/commit flows work without extra setup.
-- `shared_service` requires an explicit non-empty deck URL snapshot signing
-  secret via `MTG_API_SNAPSHOT_SIGNING_SECRET`.
-- In `shared_service`, every current app route except `/health` requires a
+- `local_demo` uses a stable built-in signing secret so deck URL preview/commit
+  flows and public share-link copy UX work without extra setup.
+- `shared_service` requires an explicit non-empty signing secret via
+  `MTG_API_SNAPSHOT_SIGNING_SECRET`.
+- In `shared_service`, every current app route except `/health` and public
+  share-link reads under `/shared/inventories/{share_token}` requires a
   verified upstream user header. The default header name is
   `X-Authenticated-User`, and it can be overridden with
   `MTG_API_AUTHENTICATED_ACTOR_HEADER`.

--- a/docs/api_v1_contract.md
+++ b/docs/api_v1_contract.md
@@ -529,6 +529,12 @@ before the generic 500 envelope is returned.
 - The recommended first-live browser deployment is same-origin through a reverse
   proxy that publishes `/api` publicly and strips that prefix before forwarding
   to the backend root-route surface.
+- Inventory share-link management responses expose `public_path` as a
+  browser-facing share page path, currently
+  `/shared/inventories/{share_token}`. In the shared-service proxy shape, that
+  page should fetch the public inventory JSON through
+  `/api/shared/inventories/{share_token}`; `public_path` is not a
+  proxy-aware API fetch URL.
 - In `local_demo`, the API ignores caller-supplied `X-Actor-Id` values and
   records mutating audit entries with `actor_type="api"` and
   `actor_id="local-demo"`.
@@ -542,8 +548,10 @@ before the generic 500 envelope is returned.
 - `shared_service` requires an explicit non-empty signing secret via
   `MTG_API_SNAPSHOT_SIGNING_SECRET`.
 - In `shared_service`, every current app route except `/health` and public
-  share-link reads under `/shared/inventories/{share_token}` requires a
-  verified upstream user header. The default header name is
+  share-link backend reads under `/shared/inventories/{share_token}` requires a
+  verified upstream user header. When those reads are published through the
+  recommended `/api` proxy, the public route is
+  `/api/shared/inventories/{share_token}`. The default header name is
   `X-Authenticated-User`, and it can be overridden with
   `MTG_API_AUTHENTICATED_ACTOR_HEADER`.
 - In `shared_service`, the API also accepts a normalized roles header. The

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -19,6 +19,11 @@ This is the recommended first-live deployment shape for the current backend:
   route `/shared/inventories/{share_token}`. If the frontend calls them through
   the API prefix, the public proxy route is `/api/shared/inventories/{share_token}`
   and must be forwarded without requiring a verified identity header.
+- Share-link management responses expose `public_path` as the browser-facing
+  page path, currently `/shared/inventories/{share_token}`. That path is not a
+  proxy-aware API fetch URL; the frontend page should call the backend JSON
+  route through `/api/shared/inventories/{share_token}` in this deployment
+  shape.
 - CORS is not part of this deployment shape.
 
 ## Reverse Proxy Responsibilities
@@ -134,8 +139,8 @@ Notes:
 - `shared_service` now also requires `MTG_API_SNAPSHOT_SIGNING_SECRET` so
   deck URL preview tokens and public inventory share URLs stay tamper-evident.
 - public inventory share links store only a nonce in the database; the reusable
-  bearer URL is rebuilt from the nonce plus `MTG_API_SNAPSHOT_SIGNING_SECRET`
-  for owner copy-link UX.
+  signed browser share URL is rebuilt from the nonce plus
+  `MTG_API_SNAPSHOT_SIGNING_SECRET` for owner copy-link UX.
 - rotating `MTG_API_SNAPSHOT_SIGNING_SECRET` invalidates in-flight deck URL
   preview tokens and active public inventory share URLs that were signed with
   the previous secret. Owners can copy the current URL again after the service

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -15,6 +15,10 @@ This is the recommended first-live deployment shape for the current backend:
 - The proxy strips the `/api` prefix before forwarding to the backend.
 - The backend continues to expose root routes internally such as `/health`,
   `/inventories`, and `/cards/search`.
+- Public inventory share reads are intentionally unauthenticated at backend
+  route `/shared/inventories/{share_token}`. If the frontend calls them through
+  the API prefix, the public proxy route is `/api/shared/inventories/{share_token}`
+  and must be forwarded without requiring a verified identity header.
 - CORS is not part of this deployment shape.
 
 ## Reverse Proxy Responsibilities
@@ -27,6 +31,9 @@ This is the recommended first-live deployment shape for the current backend:
 - strip any client-supplied `X-Actor-Id`
 - inject verified `X-Authenticated-User`
 - optionally inject normalized `X-Authenticated-Roles`
+- allow unauthenticated public share reads for
+  `/api/shared/inventories/{share_token}` while still stripping spoofed identity
+  headers on those requests
 
 Recommended normalized roles:
 
@@ -65,6 +72,10 @@ Effective behavior:
   inventory, or a global `admin`
 - inventory writes require `editor` or `owner` membership on that inventory,
   or a global `admin`
+- inventory share-link management requires `owner` membership on that
+  inventory, or a global `admin`
+- public share-link reads require possession of the signed share URL and do not
+  grant membership or access to private inventory fields
 - `POST /inventories` lets any authenticated user create an inventory and
   automatically become `owner`
 - `POST /me/bootstrap` lets any authenticated user create one owned personal
@@ -121,9 +132,14 @@ Notes:
   `schema_not_ready` instead of migrating during request handling.
 - `shared_service` rejects `MTG_API_TRUST_ACTOR_HEADERS=true`.
 - `shared_service` now also requires `MTG_API_SNAPSHOT_SIGNING_SECRET` so
-  deck URL preview tokens stay tamper-evident across the preview/commit flow.
+  deck URL preview tokens and public inventory share URLs stay tamper-evident.
+- public inventory share links store only a nonce in the database; the reusable
+  bearer URL is rebuilt from the nonce plus `MTG_API_SNAPSHOT_SIGNING_SECRET`
+  for owner copy-link UX.
 - rotating `MTG_API_SNAPSHOT_SIGNING_SECRET` invalidates in-flight deck URL
-  preview tokens that were signed with the previous secret
+  preview tokens and active public inventory share URLs that were signed with
+  the previous secret. Owners can copy the current URL again after the service
+  is using the new secret.
 - wildcard public bind addresses should be treated as an explicit operator
   choice, not the default posture.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,4 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 mtg_source_stack = ["*.sql"]
+"mtg_source_stack.db.migrations" = ["*.sql"]

--- a/src/mtg_source_stack/api/dependencies.py
+++ b/src/mtg_source_stack/api/dependencies.py
@@ -316,6 +316,27 @@ def require_inventory_write_access(
     raise AuthorizationError(f"Write access to inventory '{inventory_slug}' is required for this shared_service request.")
 
 
+def require_inventory_share_management_access(
+    settings: ApiSettings,
+    context: RequestContext,
+    *,
+    inventory_slug: str,
+) -> None:
+    inventory_slug = normalize_inventory_slug(inventory_slug)
+    if settings.runtime_mode != "shared_service":
+        return
+    from ..inventory.service import actor_can_manage_inventory_share
+
+    if actor_can_manage_inventory_share(
+        settings.db_path,
+        inventory_slug=inventory_slug,
+        actor_id=context.actor_id,
+        actor_roles=context.roles,
+    ):
+        return
+    raise AuthorizationError(f"Owner access to inventory '{inventory_slug}' is required to manage share links.")
+
+
 def get_inventory_write_request_context(
     inventory_slug: str,
     request: "Request",

--- a/src/mtg_source_stack/api/response_models.py
+++ b/src/mtg_source_stack/api/response_models.py
@@ -96,6 +96,25 @@ class AccessSummaryResponse(ApiBaseModel):
     default_inventory_slug: str | None
 
 
+class InventoryShareLinkStatusResponse(ApiBaseModel):
+    inventory: str
+    active: bool
+    public_path: str | None
+    created_at: str | None
+    updated_at: str | None
+    revoked_at: str | None
+
+
+class InventoryShareLinkTokenResponse(ApiBaseModel):
+    inventory: str
+    token: str
+    public_path: str
+    active: bool
+    created_at: str
+    updated_at: str
+    revoked_at: str | None
+
+
 class BulkInventoryItemMutationResponse(ApiBaseModel):
     inventory: str
     operation: Literal[
@@ -218,6 +237,37 @@ class OwnedInventoryRowResponse(ApiBaseModel):
     printing_selection_mode: Literal["explicit", "defaulted"] = Field(
         description=PRINTING_SELECTION_MODE_RESPONSE_DESCRIPTION
     )
+
+
+class PublicInventorySummaryResponse(ApiBaseModel):
+    display_name: str
+    description: str | None
+    item_rows: int
+    total_cards: int
+
+
+class PublicInventoryItemResponse(ApiBaseModel):
+    scryfall_id: str
+    oracle_id: str
+    name: str
+    set_code: str
+    set_name: str
+    rarity: str | None
+    collector_number: str
+    image_uri_small: str | None
+    image_uri_normal: str | None
+    quantity: int
+    condition_code: str = Field(description=CONDITION_CODE_RESPONSE_DESCRIPTION)
+    finish: Literal["normal", "foil", "etched"] = Field(description=FINISH_RESPONSE_DESCRIPTION)
+    allowed_finishes: list[Literal["normal", "foil", "etched"]] = Field(
+        description=FINISH_RESPONSE_DESCRIPTION
+    )
+    language_code: str = Field(description=LANGUAGE_CODE_RESPONSE_DESCRIPTION)
+
+
+class PublicInventoryShareResponse(ApiBaseModel):
+    inventory: PublicInventorySummaryResponse
+    items: list[PublicInventoryItemResponse]
 
 
 class InventoryAuditEventResponse(ApiBaseModel):

--- a/src/mtg_source_stack/api/response_models.py
+++ b/src/mtg_source_stack/api/response_models.py
@@ -37,6 +37,15 @@ DEFAULT_ADD_CHOICE_RESPONSE_DESCRIPTION = (
     "True when this printing matches the backend's current default quick-add choice for the same oracle_id. "
     "When omitted-finish quick-add would fail, every row is false."
 )
+SHARE_LINK_TOKEN_RESPONSE_DESCRIPTION = (
+    "Reusable signed share token. Store/copy this only as part of the public share URL; it grants anonymous "
+    "read-only access to this inventory's public share projection until rotated or revoked."
+)
+SHARE_LINK_PUBLIC_PATH_RESPONSE_DESCRIPTION = (
+    "Browser-facing public share page path, for example `/shared/inventories/{share_token}`. "
+    "In shared-service deployments, that page should fetch backend JSON through the proxied API route "
+    "`/api/shared/inventories/{share_token}`; this field is not a proxy-aware API fetch URL."
+)
 
 
 class ApiBaseModel(BaseModel):
@@ -99,7 +108,9 @@ class AccessSummaryResponse(ApiBaseModel):
 class InventoryShareLinkStatusResponse(ApiBaseModel):
     inventory: str
     active: bool
-    public_path: str | None
+    public_path: str | None = Field(
+        description=SHARE_LINK_PUBLIC_PATH_RESPONSE_DESCRIPTION,
+    )
     created_at: str | None
     updated_at: str | None
     revoked_at: str | None
@@ -107,8 +118,8 @@ class InventoryShareLinkStatusResponse(ApiBaseModel):
 
 class InventoryShareLinkTokenResponse(ApiBaseModel):
     inventory: str
-    token: str
-    public_path: str
+    token: str = Field(description=SHARE_LINK_TOKEN_RESPONSE_DESCRIPTION)
+    public_path: str = Field(description=SHARE_LINK_PUBLIC_PATH_RESPONSE_DESCRIPTION)
     active: bool
     created_at: str
     updated_at: str

--- a/src/mtg_source_stack/api/routes.py
+++ b/src/mtg_source_stack/api/routes.py
@@ -27,8 +27,11 @@ from ..inventory.service import (
     add_card,
     bulk_mutate_inventory_items,
     create_inventory,
+    create_inventory_share_link,
     duplicate_inventory,
     ensure_default_inventory,
+    get_inventory_share_link_status,
+    get_public_inventory_share,
     import_csv_stream,
     import_decklist_text,
     import_deck_url,
@@ -38,6 +41,8 @@ from ..inventory.service import (
     list_owned_filtered,
     remove_card,
     render_inventory_csv_export,
+    revoke_inventory_share_link,
+    rotate_inventory_share_link,
     search_card_names,
     search_cards,
     set_acquisition,
@@ -60,6 +65,7 @@ from .dependencies import (
     get_inventory_scoped_read_request_context,
     get_authenticated_request_context,
     get_settings,
+    require_inventory_share_management_access,
     require_inventory_write_access,
 )
 from .request_models import (
@@ -96,10 +102,13 @@ from .response_models import (
     InventoryAuditEventResponse,
     InventoryCreateResponse,
     InventoryDuplicateResponse,
+    InventoryShareLinkStatusResponse,
+    InventoryShareLinkTokenResponse,
     InventoryItemPatchResponse,
     InventoryTransferResponse,
     InventoryListRowResponse,
     OwnedInventoryRowResponse,
+    PublicInventoryShareResponse,
     RemoveInventoryItemResponse,
     SetPrintingResponse,
 )
@@ -391,6 +400,113 @@ def get_access_summary(
             settings.db_path,
             actor_id=context.actor_id,
             actor_roles=context.roles,
+        )
+    )
+
+
+@router.get(
+    "/inventories/{inventory_slug}/share-link",
+    response_model=InventoryShareLinkStatusResponse,
+    responses=_error_responses(401, 403, 404, 503, 500),
+)
+def inventory_share_link_status(
+    inventory_slug: str,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
+) -> Any:
+    require_inventory_share_management_access(settings, context, inventory_slug=inventory_slug)
+    return _serialize(
+        get_inventory_share_link_status(
+            settings.db_path,
+            inventory_slug=inventory_slug,
+            token_secret=settings.snapshot_signing_secret,
+        )
+    )
+
+
+@router.post(
+    "/inventories/{inventory_slug}/share-link",
+    status_code=status.HTTP_201_CREATED,
+    response_model=InventoryShareLinkTokenResponse,
+    responses=_error_responses(401, 403, 404, 409, 503, 500),
+)
+def inventory_share_link_create(
+    inventory_slug: str,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
+) -> Any:
+    require_inventory_share_management_access(settings, context, inventory_slug=inventory_slug)
+    return _serialize(
+        create_inventory_share_link(
+            settings.db_path,
+            inventory_slug=inventory_slug,
+            actor_id=context.actor_id,
+            token_secret=settings.snapshot_signing_secret,
+            actor_type=context.actor_type,
+            request_id=context.request_id,
+        )
+    )
+
+
+@router.post(
+    "/inventories/{inventory_slug}/share-link/rotate",
+    response_model=InventoryShareLinkTokenResponse,
+    responses=_error_responses(401, 403, 404, 503, 500),
+)
+def inventory_share_link_rotate(
+    inventory_slug: str,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
+) -> Any:
+    require_inventory_share_management_access(settings, context, inventory_slug=inventory_slug)
+    return _serialize(
+        rotate_inventory_share_link(
+            settings.db_path,
+            inventory_slug=inventory_slug,
+            actor_id=context.actor_id,
+            token_secret=settings.snapshot_signing_secret,
+            actor_type=context.actor_type,
+            request_id=context.request_id,
+        )
+    )
+
+
+@router.delete(
+    "/inventories/{inventory_slug}/share-link",
+    response_model=InventoryShareLinkStatusResponse,
+    responses=_error_responses(401, 403, 404, 503, 500),
+)
+def inventory_share_link_revoke(
+    inventory_slug: str,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
+) -> Any:
+    require_inventory_share_management_access(settings, context, inventory_slug=inventory_slug)
+    return _serialize(
+        revoke_inventory_share_link(
+            settings.db_path,
+            inventory_slug=inventory_slug,
+            actor_id=context.actor_id,
+            actor_type=context.actor_type,
+            request_id=context.request_id,
+        )
+    )
+
+
+@router.get(
+    "/shared/inventories/{share_token}",
+    response_model=PublicInventoryShareResponse,
+    responses=_error_responses(404, 503, 500),
+)
+def public_inventory_share(
+    share_token: str,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+) -> Any:
+    return _serialize(
+        get_public_inventory_share(
+            settings.db_path,
+            token=share_token,
+            token_secret=settings.snapshot_signing_secret,
         )
     )
 

--- a/src/mtg_source_stack/db/migrations/0015_add_inventory_share_links.sql
+++ b/src/mtg_source_stack/db/migrations/0015_add_inventory_share_links.sql
@@ -1,0 +1,20 @@
+-- Add owner-managed read-only inventory share links.
+--
+-- Public links use signed reusable tokens. The database stores the nonce needed
+-- to rebuild an active link for owners, but not the full bearer token.
+-- Rotating the API signing secret invalidates existing public share URLs.
+
+CREATE TABLE IF NOT EXISTS inventory_share_links (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    inventory_id INTEGER NOT NULL UNIQUE,
+    token_nonce TEXT NOT NULL UNIQUE,
+    issued_by_actor_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TEXT,
+    revoked_by_actor_id TEXT,
+    FOREIGN KEY (inventory_id) REFERENCES inventories (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_inventory_share_links_token_nonce
+    ON inventory_share_links (token_nonce);

--- a/src/mtg_source_stack/inventory/access.py
+++ b/src/mtg_source_stack/inventory/access.py
@@ -16,6 +16,7 @@ from .normalize import normalize_inventory_slug
 INVENTORY_MEMBERSHIP_ROLES = frozenset({"viewer", "editor", "owner"})
 INVENTORY_READ_ROLES = frozenset({"viewer", "editor", "owner"})
 INVENTORY_WRITE_ROLES = frozenset({"editor", "owner"})
+INVENTORY_SHARE_MANAGE_ROLES = frozenset({"owner"})
 
 
 def normalize_inventory_membership_role(role: str) -> str:
@@ -274,6 +275,23 @@ def actor_can_write_inventory(
     return can_write_inventory(inventory_role=inventory_role, actor_roles=actor_roles)
 
 
+def actor_can_manage_inventory_share(
+    db_path: str | Path,
+    *,
+    inventory_slug: str,
+    actor_id: str | None,
+    actor_roles: Iterable[str],
+) -> bool:
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        inventory_role = actor_inventory_role_with_connection(
+            connection,
+            inventory_slug=inventory_slug,
+            actor_id=actor_id,
+        )
+    return can_manage_inventory_share(inventory_role=inventory_role, actor_roles=actor_roles)
+
+
 def actor_can_read_any_inventory(
     db_path: str | Path,
     *,
@@ -309,3 +327,9 @@ def can_write_inventory(*, inventory_role: str | None, actor_roles: Iterable[str
     if is_global_admin(actor_roles):
         return True
     return inventory_role in INVENTORY_WRITE_ROLES
+
+
+def can_manage_inventory_share(*, inventory_role: str | None, actor_roles: Iterable[str]) -> bool:
+    if is_global_admin(actor_roles):
+        return True
+    return inventory_role in INVENTORY_SHARE_MANAGE_ROLES

--- a/src/mtg_source_stack/inventory/response_models.py
+++ b/src/mtg_source_stack/inventory/response_models.py
@@ -153,6 +153,27 @@ class AccessSummaryResult(ResponseModel):
 
 
 @dataclass(frozen=True, slots=True)
+class InventoryShareLinkStatusResult(ResponseModel):
+    inventory: str
+    active: bool
+    public_path: str | None
+    created_at: str | None
+    updated_at: str | None
+    revoked_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryShareLinkTokenResult(ResponseModel):
+    inventory: str
+    token: str
+    public_path: str
+    active: bool
+    created_at: str
+    updated_at: str
+    revoked_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class BulkInventoryItemMutationResult(ResponseModel):
     inventory: str
     operation: str
@@ -237,6 +258,38 @@ class OwnedInventoryRow(ResponseModel):
     price_date: str | None
     notes: str | None
     printing_selection_mode: str
+
+
+@dataclass(frozen=True, slots=True)
+class PublicInventorySummary(ResponseModel):
+    display_name: str
+    description: str | None
+    item_rows: int
+    total_cards: int
+
+
+@dataclass(frozen=True, slots=True)
+class PublicInventoryItem(ResponseModel):
+    scryfall_id: str
+    oracle_id: str
+    name: str
+    set_code: str
+    set_name: str
+    rarity: str | None
+    collector_number: str
+    image_uri_small: str | None
+    image_uri_normal: str | None
+    quantity: int
+    condition_code: str
+    finish: str
+    allowed_finishes: list[str]
+    language_code: str
+
+
+@dataclass(frozen=True, slots=True)
+class PublicInventoryShareResult(ResponseModel):
+    inventory: PublicInventorySummary
+    items: list[PublicInventoryItem]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mtg_source_stack/inventory/service.py
+++ b/src/mtg_source_stack/inventory/service.py
@@ -3,9 +3,11 @@
 from .access import (
     actor_can_read_any_inventory,
     actor_can_read_inventory,
+    actor_can_manage_inventory_share,
     actor_can_write_inventory,
     actor_inventory_role,
     actor_inventory_role_with_connection,
+    can_manage_inventory_share,
     can_read_inventory,
     can_write_inventory,
     grant_inventory_membership,
@@ -57,5 +59,12 @@ from .mutations import (
     set_quantity,
     set_tags,
     split_row,
+)
+from .sharing import (
+    create_inventory_share_link,
+    get_inventory_share_link_status,
+    get_public_inventory_share,
+    revoke_inventory_share_link,
+    rotate_inventory_share_link,
 )
 from .transfer import duplicate_inventory, transfer_inventory_items

--- a/src/mtg_source_stack/inventory/sharing.py
+++ b/src/mtg_source_stack/inventory/sharing.py
@@ -27,7 +27,10 @@ from .response_models import (
 
 SHARE_TOKEN_NONCE_BYTES = 24
 SHARE_TOKEN_VERSION = "v1"
-PUBLIC_SHARE_PATH_PREFIX = "/shared/inventories"
+# Browser-facing route the frontend should own. In shared-service deployments,
+# that page fetches JSON through the proxied API route
+# `/api/shared/inventories/{share_token}`.
+PUBLIC_SHARE_PAGE_PATH_PREFIX = "/shared/inventories"
 
 
 def _normalize_actor_id(actor_id: str | None) -> str:
@@ -103,7 +106,7 @@ def _parse_share_token(token: str, *, token_secret: str | None) -> tuple[int, st
 
 
 def _public_path(token: str) -> str:
-    return f"{PUBLIC_SHARE_PATH_PREFIX}/{token}"
+    return f"{PUBLIC_SHARE_PAGE_PATH_PREFIX}/{token}"
 
 
 def _status_from_row(

--- a/src/mtg_source_stack/inventory/sharing.py
+++ b/src/mtg_source_stack/inventory/sharing.py
@@ -1,0 +1,527 @@
+"""Owner-managed read-only inventory share links."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import secrets
+import sqlite3
+from pathlib import Path
+
+from ..db.connection import connect
+from ..db.schema import require_current_schema
+from ..errors import ConflictError, NotFoundError, ValidationError
+from .audit import write_inventory_audit_event
+from .normalize import extract_image_uri_fields, normalize_inventory_slug, normalized_catalog_finish_list, text_or_none
+from .query_inventory import get_inventory_row
+from .response_models import (
+    InventoryShareLinkStatusResult,
+    InventoryShareLinkTokenResult,
+    PublicInventoryItem,
+    PublicInventoryShareResult,
+    PublicInventorySummary,
+)
+
+
+SHARE_TOKEN_NONCE_BYTES = 24
+SHARE_TOKEN_VERSION = "v1"
+PUBLIC_SHARE_PATH_PREFIX = "/shared/inventories"
+
+
+def _normalize_actor_id(actor_id: str | None) -> str:
+    normalized = (actor_id or "").strip()
+    if not normalized:
+        raise ValidationError("actor_id is required to manage inventory share links.")
+    return normalized
+
+
+def _normalize_token_secret(token_secret: str | None) -> bytes:
+    normalized = (token_secret or "").strip()
+    if not normalized:
+        raise ValidationError("A share token signing secret is required to manage public inventory links.")
+    return normalized.encode("utf-8")
+
+
+def _base64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _base64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.urlsafe_b64decode(f"{value}{padding}".encode("ascii"))
+    except (binascii.Error, UnicodeEncodeError, ValueError) as exc:
+        raise NotFoundError("Shared inventory link was not found.") from exc
+
+
+def _sign_share_token_payload(*, share_link_id: int, token_nonce: str, token_secret: str | None) -> str:
+    secret = _normalize_token_secret(token_secret)
+    payload = f"{SHARE_TOKEN_VERSION}.{share_link_id}.{token_nonce}".encode("utf-8")
+    return _base64url_encode(hmac.new(secret, payload, hashlib.sha256).digest())
+
+
+def generate_share_token_nonce() -> str:
+    return secrets.token_urlsafe(SHARE_TOKEN_NONCE_BYTES)
+
+
+def build_share_token(*, share_link_id: int, token_nonce: str, token_secret: str | None) -> str:
+    signature = _sign_share_token_payload(
+        share_link_id=share_link_id,
+        token_nonce=token_nonce,
+        token_secret=token_secret,
+    )
+    return f"{SHARE_TOKEN_VERSION}.{share_link_id}.{token_nonce}.{signature}"
+
+
+def _parse_share_token(token: str, *, token_secret: str | None) -> tuple[int, str]:
+    normalized = token.strip()
+    if not normalized:
+        raise NotFoundError("Shared inventory link was not found.")
+    parts = normalized.split(".")
+    if len(parts) != 4 or parts[0] != SHARE_TOKEN_VERSION:
+        raise NotFoundError("Shared inventory link was not found.")
+    _version, share_link_id_text, token_nonce, signature = parts
+    if not token_nonce or not signature:
+        raise NotFoundError("Shared inventory link was not found.")
+    try:
+        share_link_id = int(share_link_id_text)
+    except ValueError as exc:
+        raise NotFoundError("Shared inventory link was not found.") from exc
+    if share_link_id < 1:
+        raise NotFoundError("Shared inventory link was not found.")
+    expected_signature = _sign_share_token_payload(
+        share_link_id=share_link_id,
+        token_nonce=token_nonce,
+        token_secret=token_secret,
+    )
+    # Decode first so malformed base64 cannot compare equal as text.
+    if not hmac.compare_digest(_base64url_decode(signature), _base64url_decode(expected_signature)):
+        raise NotFoundError("Shared inventory link was not found.")
+    return share_link_id, token_nonce
+
+
+def _public_path(token: str) -> str:
+    return f"{PUBLIC_SHARE_PATH_PREFIX}/{token}"
+
+
+def _status_from_row(
+    inventory_slug: str,
+    row: sqlite3.Row | None,
+    *,
+    token_secret: str | None,
+) -> InventoryShareLinkStatusResult:
+    if row is None:
+        return InventoryShareLinkStatusResult(
+            inventory=inventory_slug,
+            active=False,
+            public_path=None,
+            created_at=None,
+            updated_at=None,
+            revoked_at=None,
+        )
+    revoked_at = text_or_none(row["revoked_at"])
+    token = (
+        build_share_token(
+            share_link_id=int(row["id"]),
+            token_nonce=row["token_nonce"],
+            token_secret=token_secret,
+        )
+        if revoked_at is None
+        else None
+    )
+    return InventoryShareLinkStatusResult(
+        inventory=inventory_slug,
+        active=revoked_at is None,
+        public_path=_public_path(token) if token is not None else None,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        revoked_at=revoked_at,
+    )
+
+
+def _token_result_from_row(
+    *,
+    inventory_slug: str,
+    row: sqlite3.Row,
+    token_secret: str | None,
+) -> InventoryShareLinkTokenResult:
+    token = build_share_token(
+        share_link_id=int(row["id"]),
+        token_nonce=row["token_nonce"],
+        token_secret=token_secret,
+    )
+    return InventoryShareLinkTokenResult(
+        inventory=inventory_slug,
+        token=token,
+        public_path=_public_path(token),
+        active=row["revoked_at"] is None,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        revoked_at=text_or_none(row["revoked_at"]),
+    )
+
+
+def _share_link_row_for_inventory(
+    connection: sqlite3.Connection,
+    *,
+    inventory_id: int,
+) -> sqlite3.Row | None:
+    return connection.execute(
+        """
+        SELECT
+            id,
+            token_nonce,
+            issued_by_actor_id,
+            created_at,
+            updated_at,
+            revoked_at,
+            revoked_by_actor_id
+        FROM inventory_share_links
+        WHERE inventory_id = ?
+        """,
+        (inventory_id,),
+    ).fetchone()
+
+
+def _share_link_row_by_id(connection: sqlite3.Connection, share_link_id: int) -> sqlite3.Row:
+    row = connection.execute(
+        """
+        SELECT
+            id,
+            token_nonce,
+            issued_by_actor_id,
+            created_at,
+            updated_at,
+            revoked_at,
+            revoked_by_actor_id
+        FROM inventory_share_links
+        WHERE id = ?
+        """,
+        (share_link_id,),
+    ).fetchone()
+    if row is None:
+        raise NotFoundError("Inventory share link was not found after write.")
+    return row
+
+
+def _new_unique_token_nonce(connection: sqlite3.Connection) -> str:
+    for _attempt in range(16):
+        token_nonce = generate_share_token_nonce()
+        existing = connection.execute(
+            """
+            SELECT 1
+            FROM inventory_share_links
+            WHERE token_nonce = ?
+            """,
+            (token_nonce,),
+        ).fetchone()
+        if existing is None:
+            return token_nonce
+    raise ConflictError("Could not generate a unique inventory share token nonce.")
+
+
+def _write_share_link_audit(
+    connection: sqlite3.Connection,
+    *,
+    inventory_slug: str,
+    action: str,
+    share_link_id: int,
+    actor_type: str,
+    actor_id: str | None,
+    request_id: str | None,
+    metadata: dict[str, object] | None = None,
+) -> None:
+    write_inventory_audit_event(
+        connection,
+        inventory_slug=inventory_slug,
+        action=action,
+        metadata={
+            "share_link_id": share_link_id,
+            **(metadata or {}),
+        },
+        actor_type=actor_type,
+        actor_id=actor_id,
+        request_id=request_id,
+    )
+
+
+def get_inventory_share_link_status(
+    db_path: str | Path,
+    *,
+    inventory_slug: str,
+    token_secret: str | None,
+) -> InventoryShareLinkStatusResult:
+    normalized_slug = normalize_inventory_slug(inventory_slug)
+    _normalize_token_secret(token_secret)
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        inventory = get_inventory_row(connection, normalized_slug)
+        row = _share_link_row_for_inventory(connection, inventory_id=int(inventory["id"]))
+    return _status_from_row(normalized_slug, row, token_secret=token_secret)
+
+
+def create_inventory_share_link(
+    db_path: str | Path,
+    *,
+    inventory_slug: str,
+    actor_id: str | None,
+    token_secret: str | None,
+    actor_type: str = "cli",
+    request_id: str | None = None,
+) -> InventoryShareLinkTokenResult:
+    normalized_slug = normalize_inventory_slug(inventory_slug)
+    normalized_actor_id = _normalize_actor_id(actor_id)
+    _normalize_token_secret(token_secret)
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        inventory = get_inventory_row(connection, normalized_slug)
+        inventory_id = int(inventory["id"])
+        existing = _share_link_row_for_inventory(connection, inventory_id=inventory_id)
+        if existing is not None and existing["revoked_at"] is None:
+            raise ConflictError(
+                f"Inventory '{normalized_slug}' already has an active share link. Rotate it to issue a new token."
+            )
+
+        token_nonce = _new_unique_token_nonce(connection)
+        if existing is None:
+            cursor = connection.execute(
+                """
+                INSERT INTO inventory_share_links (
+                    inventory_id,
+                    token_nonce,
+                    issued_by_actor_id
+                )
+                VALUES (?, ?, ?)
+                """,
+                (inventory_id, token_nonce, normalized_actor_id),
+            )
+            share_link_id = int(cursor.lastrowid)
+            audit_action = "create_share_link"
+            audit_metadata = {"recreated": False}
+        else:
+            share_link_id = int(existing["id"])
+            connection.execute(
+                """
+                UPDATE inventory_share_links
+                SET
+                    token_nonce = ?,
+                    issued_by_actor_id = ?,
+                    created_at = CURRENT_TIMESTAMP,
+                    updated_at = CURRENT_TIMESTAMP,
+                    revoked_at = NULL,
+                    revoked_by_actor_id = NULL
+                WHERE id = ?
+                """,
+                (token_nonce, normalized_actor_id, share_link_id),
+            )
+            audit_action = "create_share_link"
+            audit_metadata = {"recreated": True}
+        row = _share_link_row_by_id(connection, share_link_id)
+        _write_share_link_audit(
+            connection,
+            inventory_slug=normalized_slug,
+            action=audit_action,
+            share_link_id=share_link_id,
+            actor_type=actor_type,
+            actor_id=normalized_actor_id,
+            request_id=request_id,
+            metadata=audit_metadata,
+        )
+        connection.commit()
+    return _token_result_from_row(inventory_slug=normalized_slug, row=row, token_secret=token_secret)
+
+
+def rotate_inventory_share_link(
+    db_path: str | Path,
+    *,
+    inventory_slug: str,
+    actor_id: str | None,
+    token_secret: str | None,
+    actor_type: str = "cli",
+    request_id: str | None = None,
+) -> InventoryShareLinkTokenResult:
+    normalized_slug = normalize_inventory_slug(inventory_slug)
+    normalized_actor_id = _normalize_actor_id(actor_id)
+    _normalize_token_secret(token_secret)
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        inventory = get_inventory_row(connection, normalized_slug)
+        existing = _share_link_row_for_inventory(connection, inventory_id=int(inventory["id"]))
+        if existing is None or existing["revoked_at"] is not None:
+            raise NotFoundError(f"Inventory '{normalized_slug}' does not have an active share link.")
+
+        token_nonce = _new_unique_token_nonce(connection)
+        connection.execute(
+            """
+            UPDATE inventory_share_links
+            SET
+                token_nonce = ?,
+                issued_by_actor_id = ?,
+                created_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP,
+                revoked_at = NULL,
+                revoked_by_actor_id = NULL
+            WHERE id = ?
+            """,
+            (token_nonce, normalized_actor_id, int(existing["id"])),
+        )
+        row = _share_link_row_by_id(connection, int(existing["id"]))
+        _write_share_link_audit(
+            connection,
+            inventory_slug=normalized_slug,
+            action="rotate_share_link",
+            share_link_id=int(existing["id"]),
+            actor_type=actor_type,
+            actor_id=normalized_actor_id,
+            request_id=request_id,
+        )
+        connection.commit()
+    return _token_result_from_row(inventory_slug=normalized_slug, row=row, token_secret=token_secret)
+
+
+def revoke_inventory_share_link(
+    db_path: str | Path,
+    *,
+    inventory_slug: str,
+    actor_id: str | None,
+    actor_type: str = "cli",
+    request_id: str | None = None,
+) -> InventoryShareLinkStatusResult:
+    normalized_slug = normalize_inventory_slug(inventory_slug)
+    normalized_actor_id = _normalize_actor_id(actor_id)
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        inventory = get_inventory_row(connection, normalized_slug)
+        existing = _share_link_row_for_inventory(connection, inventory_id=int(inventory["id"]))
+        if existing is None:
+            return _status_from_row(normalized_slug, None, token_secret=None)
+        if existing["revoked_at"] is not None:
+            return _status_from_row(normalized_slug, existing, token_secret=None)
+        connection.execute(
+            """
+            UPDATE inventory_share_links
+            SET
+                updated_at = CURRENT_TIMESTAMP,
+                revoked_at = CURRENT_TIMESTAMP,
+                revoked_by_actor_id = ?
+            WHERE id = ?
+            """,
+            (normalized_actor_id, int(existing["id"])),
+        )
+        row = _share_link_row_by_id(connection, int(existing["id"]))
+        _write_share_link_audit(
+            connection,
+            inventory_slug=normalized_slug,
+            action="revoke_share_link",
+            share_link_id=int(existing["id"]),
+            actor_type=actor_type,
+            actor_id=normalized_actor_id,
+            request_id=request_id,
+        )
+        connection.commit()
+    return _status_from_row(normalized_slug, row, token_secret=None)
+
+
+def _public_item_from_row(row: sqlite3.Row) -> PublicInventoryItem:
+    image_uri_small, image_uri_normal = extract_image_uri_fields(row["image_uris_json"])
+    return PublicInventoryItem(
+        scryfall_id=row["scryfall_id"],
+        oracle_id=row["oracle_id"],
+        name=row["name"],
+        set_code=row["set_code"],
+        set_name=row["set_name"],
+        rarity=text_or_none(row["rarity"]),
+        collector_number=row["collector_number"],
+        image_uri_small=image_uri_small,
+        image_uri_normal=image_uri_normal,
+        quantity=int(row["quantity"]),
+        condition_code=row["condition_code"],
+        finish=row["finish"],
+        allowed_finishes=normalized_catalog_finish_list(row["finishes_json"]),
+        language_code=row["language_code"],
+    )
+
+
+def _public_summary_from_row(row: sqlite3.Row) -> PublicInventorySummary:
+    return PublicInventorySummary(
+        display_name=row["display_name"],
+        description=text_or_none(row["description"]),
+        item_rows=int(row["item_rows"]),
+        total_cards=int(row["total_cards"]),
+    )
+
+
+def get_public_inventory_share(
+    db_path: str | Path,
+    *,
+    token: str,
+    token_secret: str | None,
+) -> PublicInventoryShareResult:
+    share_link_id, token_nonce = _parse_share_token(token, token_secret=token_secret)
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        share = connection.execute(
+            """
+            SELECT
+                isl.inventory_id,
+                i.display_name,
+                i.description
+            FROM inventory_share_links isl
+            JOIN inventories i ON i.id = isl.inventory_id
+            WHERE isl.id = ?
+              AND isl.token_nonce = ?
+              AND isl.revoked_at IS NULL
+            """,
+            (share_link_id, token_nonce),
+        ).fetchone()
+        if share is None:
+            raise NotFoundError("Shared inventory link was not found.")
+
+        inventory_id = int(share["inventory_id"])
+        summary_row = connection.execute(
+            """
+            SELECT
+                i.display_name,
+                COALESCE(i.description, '') AS description,
+                COUNT(ii.id) AS item_rows,
+                COALESCE(SUM(ii.quantity), 0) AS total_cards
+            FROM inventories i
+            LEFT JOIN inventory_items ii ON ii.inventory_id = i.id
+            WHERE i.id = ?
+            GROUP BY i.id, i.display_name, i.description
+            """,
+            (inventory_id,),
+        ).fetchone()
+        if summary_row is None:
+            raise NotFoundError("Shared inventory link was not found.")
+
+        item_rows = connection.execute(
+            """
+            SELECT
+                ii.scryfall_id,
+                c.oracle_id,
+                c.name,
+                c.set_code,
+                c.set_name,
+                c.rarity,
+                c.collector_number,
+                c.image_uris_json,
+                c.finishes_json,
+                ii.quantity,
+                ii.condition_code,
+                ii.finish,
+                ii.language_code
+            FROM inventory_items ii
+            JOIN mtg_cards c ON c.scryfall_id = ii.scryfall_id
+            WHERE ii.inventory_id = ?
+            ORDER BY c.name, c.set_code, c.collector_number, ii.condition_code, ii.finish
+            """,
+            (inventory_id,),
+        ).fetchall()
+
+    return PublicInventoryShareResult(
+        inventory=_public_summary_from_row(summary_row),
+        items=[_public_item_from_row(row) for row in item_rows],
+    )

--- a/src/mtg_source_stack/mtg_mvp_schema.sql
+++ b/src/mtg_source_stack/mtg_mvp_schema.sql
@@ -204,3 +204,18 @@ CREATE INDEX IF NOT EXISTS idx_inventory_items_inventory
 
 CREATE INDEX IF NOT EXISTS idx_inventory_items_card
     ON inventory_items (scryfall_id);
+
+CREATE TABLE IF NOT EXISTS inventory_share_links (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    inventory_id INTEGER NOT NULL UNIQUE,
+    token_nonce TEXT NOT NULL UNIQUE,
+    issued_by_actor_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TEXT,
+    revoked_by_actor_id TEXT,
+    FOREIGN KEY (inventory_id) REFERENCES inventories (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_inventory_share_links_token_nonce
+    ON inventory_share_links (token_nonce);

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -40,8 +40,11 @@ from mtg_source_stack.api.response_models import (
     InventoryCreateResponse,
     InventoryDuplicateResponse,
     InventoryListRowResponse,
+    InventoryShareLinkStatusResponse,
+    InventoryShareLinkTokenResponse,
     InventoryTransferResponse,
     OwnedInventoryRowResponse,
+    PublicInventoryShareResponse,
     RemoveInventoryItemResponse,
     SetAcquisitionResponse,
     SetConditionResponse,
@@ -290,6 +293,49 @@ class ApiContractTest(RepoSmokeTestCase):
                 "total_cards": 45,
             }
         ]
+        share_link_status_payload = {
+            "inventory": "alice-collection",
+            "active": False,
+            "public_path": None,
+            "created_at": None,
+            "updated_at": None,
+            "revoked_at": None,
+        }
+        share_link_token_payload = {
+            "inventory": "alice-collection",
+            "token": "public-token",
+            "public_path": "/shared/inventories/public-token",
+            "active": True,
+            "created_at": "2026-04-21 12:00:00",
+            "updated_at": "2026-04-21 12:00:00",
+            "revoked_at": None,
+        }
+        public_share_payload = {
+            "inventory": {
+                "display_name": "Collection",
+                "description": "Shared view",
+                "item_rows": 1,
+                "total_cards": 4,
+            },
+            "items": [
+                {
+                    "scryfall_id": "card-1",
+                    "oracle_id": "oracle-lightning-bolt",
+                    "name": "Lightning Bolt",
+                    "set_code": "lea",
+                    "set_name": "Limited Edition Alpha",
+                    "rarity": "common",
+                    "collector_number": "161",
+                    "image_uri_small": "https://example.test/cards/card-1-small.jpg",
+                    "image_uri_normal": "https://example.test/cards/card-1-normal.jpg",
+                    "quantity": 4,
+                    "condition_code": "NM",
+                    "finish": "normal",
+                    "allowed_finishes": ["normal", "foil"],
+                    "language_code": "en",
+                }
+            ],
+        }
         csv_import_payload = {
             "csv_filename": "inventory_import.csv",
             "detected_format": "generic_csv",
@@ -431,6 +477,9 @@ class ApiContractTest(RepoSmokeTestCase):
         )
         inventory_create = InventoryCreateResponse.model_validate(inventory_create_payload)
         inventory_list = [InventoryListRowResponse.model_validate(row) for row in inventory_list_payload]
+        share_link_status = InventoryShareLinkStatusResponse.model_validate(share_link_status_payload)
+        share_link_token = InventoryShareLinkTokenResponse.model_validate(share_link_token_payload)
+        public_share = PublicInventoryShareResponse.model_validate(public_share_payload)
         bootstrap = DefaultInventoryBootstrapResponse.model_validate(bootstrap_payload)
         csv_import = CsvImportResponse.model_validate(csv_import_payload)
         decklist_import = DecklistImportResponse.model_validate(decklist_import_payload)
@@ -461,6 +510,10 @@ class ApiContractTest(RepoSmokeTestCase):
         self.assertEqual("USD", inventory_create.acquisition_currency)
         self.assertEqual("Main trade stock", inventory_list[0].notes)
         self.assertEqual(45, inventory_list[0].total_cards)
+        self.assertFalse(share_link_status.active)
+        self.assertEqual("/shared/inventories/public-token", share_link_token.public_path)
+        self.assertEqual("Collection", public_share.inventory.display_name)
+        self.assertEqual("Lightning Bolt", public_share.items[0].name)
         self.assertTrue(bootstrap.created)
         self.assertEqual("Collection", bootstrap.inventory.display_name)
         self.assertEqual("generic_csv", csv_import.detected_format)

--- a/tests/test_inventory_access.py
+++ b/tests/test_inventory_access.py
@@ -10,10 +10,12 @@ from mtg_source_stack.db.connection import connect
 from mtg_source_stack.db.schema import initialize_database
 from mtg_source_stack.errors import NotFoundError, ValidationError
 from mtg_source_stack.inventory.service import (
+    actor_can_manage_inventory_share,
     actor_can_read_any_inventory,
     actor_can_read_inventory,
     actor_can_write_inventory,
     actor_inventory_role,
+    can_manage_inventory_share,
     can_read_inventory,
     can_write_inventory,
     create_inventory,
@@ -38,14 +40,19 @@ class InventoryAccessTest(unittest.TestCase):
     def test_can_read_and_write_inventory_roles(self) -> None:
         self.assertTrue(can_read_inventory(inventory_role="viewer", actor_roles={"editor"}))
         self.assertFalse(can_write_inventory(inventory_role="viewer", actor_roles={"editor"}))
+        self.assertFalse(can_manage_inventory_share(inventory_role="viewer", actor_roles={"editor"}))
         self.assertTrue(can_read_inventory(inventory_role="editor", actor_roles={"editor"}))
         self.assertTrue(can_write_inventory(inventory_role="editor", actor_roles={"editor"}))
+        self.assertFalse(can_manage_inventory_share(inventory_role="editor", actor_roles={"editor"}))
         self.assertTrue(can_read_inventory(inventory_role="owner", actor_roles={"editor"}))
         self.assertTrue(can_write_inventory(inventory_role="owner", actor_roles={"editor"}))
+        self.assertTrue(can_manage_inventory_share(inventory_role="owner", actor_roles={"editor"}))
         self.assertFalse(can_read_inventory(inventory_role=None, actor_roles={"editor"}))
         self.assertFalse(can_write_inventory(inventory_role=None, actor_roles={"editor"}))
+        self.assertFalse(can_manage_inventory_share(inventory_role=None, actor_roles={"editor"}))
         self.assertTrue(can_read_inventory(inventory_role=None, actor_roles={"admin"}))
         self.assertTrue(can_write_inventory(inventory_role=None, actor_roles={"admin"}))
+        self.assertTrue(can_manage_inventory_share(inventory_role=None, actor_roles={"admin"}))
 
     def test_grant_list_and_revoke_inventory_memberships(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -473,6 +480,69 @@ class InventoryAccessTest(unittest.TestCase):
                 actor_can_write_inventory(
                     db_path,
                     inventory_slug="admin-only",
+                    actor_id="admin@example.com",
+                    actor_roles={"admin"},
+                )
+            )
+
+    def test_actor_share_link_management_requires_owner_or_admin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description=None,
+            )
+            grant_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                actor_id="viewer@example.com",
+                role="viewer",
+            )
+            grant_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                actor_id="editor@example.com",
+                role="editor",
+            )
+            grant_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                actor_id="owner@example.com",
+                role="owner",
+            )
+
+            self.assertFalse(
+                actor_can_manage_inventory_share(
+                    db_path,
+                    inventory_slug="personal",
+                    actor_id="viewer@example.com",
+                    actor_roles=frozenset(),
+                )
+            )
+            self.assertFalse(
+                actor_can_manage_inventory_share(
+                    db_path,
+                    inventory_slug="personal",
+                    actor_id="editor@example.com",
+                    actor_roles=frozenset(),
+                )
+            )
+            self.assertTrue(
+                actor_can_manage_inventory_share(
+                    db_path,
+                    inventory_slug="personal",
+                    actor_id="owner@example.com",
+                    actor_roles=frozenset(),
+                )
+            )
+            self.assertTrue(
+                actor_can_manage_inventory_share(
+                    db_path,
+                    inventory_slug="personal",
                     actor_id="admin@example.com",
                     actor_roles={"admin"},
                 )

--- a/tests/test_inventory_service.py
+++ b/tests/test_inventory_service.py
@@ -35,8 +35,11 @@ from mtg_source_stack.inventory.service import (
     add_card,
     bulk_mutate_inventory_items,
     create_inventory,
+    create_inventory_share_link,
     duplicate_inventory,
     export_inventory_csv,
+    get_inventory_share_link_status,
+    get_public_inventory_share,
     inventory_health,
     inventory_report,
     list_card_printings_for_oracle,
@@ -50,6 +53,8 @@ from mtg_source_stack.inventory.service import (
     remove_card,
     render_inventory_csv_export,
     resolve_card_row,
+    revoke_inventory_share_link,
+    rotate_inventory_share_link,
     search_card_names,
     search_cards,
     set_acquisition,
@@ -66,6 +71,9 @@ from mtg_source_stack.inventory.service import (
     valuation_filtered,
 )
 from tests.common import RepoSmokeTestCase, materialize_fixture_bundle
+
+
+TEST_SHARE_TOKEN_SECRET = "test-share-token-secret"
 
 
 class InventoryServiceTest(RepoSmokeTestCase):
@@ -2077,6 +2085,175 @@ class InventoryServiceTest(RepoSmokeTestCase):
             self.assertEqual("Main collection notes", listed[0].notes)
             self.assertEqual(Decimal("12.50"), listed[0].acquisition_price)
             self.assertEqual("USD", listed[0].acquisition_currency)
+
+    def test_inventory_share_links_expose_public_read_only_projection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="share-card-1",
+                oracle_id="share-oracle-1",
+                name="Shared Test Card",
+                finishes_json='["normal","foil"]',
+            )
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description="Public description",
+                actor_id="owner-user",
+            )
+            self._insert_inventory_item(
+                db_path,
+                inventory_slug="personal",
+                scryfall_id="share-card-1",
+                quantity=3,
+                location="Private Binder",
+                acquisition_price="1.25",
+                acquisition_currency="USD",
+                notes="private note",
+                tags_json='["private", "trade"]',
+            )
+
+            initial_status = get_inventory_share_link_status(
+                db_path,
+                inventory_slug="personal",
+                token_secret=TEST_SHARE_TOKEN_SECRET,
+            )
+            self.assertFalse(initial_status.active)
+            self.assertIsNone(initial_status.public_path)
+            self.assertIsNone(initial_status.created_at)
+
+            created = create_inventory_share_link(
+                db_path,
+                inventory_slug="personal",
+                actor_id="owner-user",
+                token_secret=TEST_SHARE_TOKEN_SECRET,
+                actor_type="api",
+                request_id="req-create-share",
+            )
+            self.assertTrue(created.active)
+            self.assertEqual("personal", created.inventory)
+            self.assertEqual(f"/shared/inventories/{created.token}", created.public_path)
+            with connect(db_path) as connection:
+                share_row = connection.execute(
+                    """
+                    SELECT token_nonce, issued_by_actor_id
+                    FROM inventory_share_links
+                    WHERE inventory_id = (
+                        SELECT id
+                        FROM inventories
+                        WHERE slug = ?
+                    )
+                    """,
+                    ("personal",),
+                ).fetchone()
+            self.assertIn(share_row["token_nonce"], created.token)
+            self.assertNotEqual(created.token, share_row["token_nonce"])
+            self.assertEqual("owner-user", share_row["issued_by_actor_id"])
+            active_status = get_inventory_share_link_status(
+                db_path,
+                inventory_slug="personal",
+                token_secret=TEST_SHARE_TOKEN_SECRET,
+            )
+            self.assertEqual(created.public_path, active_status.public_path)
+
+            with self.assertRaises(ConflictError):
+                create_inventory_share_link(
+                    db_path,
+                    inventory_slug="personal",
+                    actor_id="owner-user",
+                    token_secret=TEST_SHARE_TOKEN_SECRET,
+                )
+
+            public_share = get_public_inventory_share(
+                db_path,
+                token=created.token,
+                token_secret=TEST_SHARE_TOKEN_SECRET,
+            )
+            with self.assertRaises(NotFoundError):
+                get_public_inventory_share(
+                    db_path,
+                    token=created.token,
+                    token_secret="different-share-token-secret",
+                )
+            self.assertEqual("Personal Collection", public_share.inventory.display_name)
+            self.assertEqual("Public description", public_share.inventory.description)
+            self.assertEqual(1, public_share.inventory.item_rows)
+            self.assertEqual(3, public_share.inventory.total_cards)
+            self.assertEqual(1, len(public_share.items))
+            public_item = serialize_response(public_share.items[0])
+            self.assertEqual("Shared Test Card", public_item["name"])
+            self.assertEqual(3, public_item["quantity"])
+            self.assertEqual(["normal", "foil"], public_item["allowed_finishes"])
+            for private_key in (
+                "item_id",
+                "location",
+                "tags",
+                "acquisition_price",
+                "acquisition_currency",
+                "unit_price",
+                "est_value",
+                "notes",
+            ):
+                self.assertNotIn(private_key, public_item)
+
+            rotated = rotate_inventory_share_link(
+                db_path,
+                inventory_slug="personal",
+                actor_id="owner-user",
+                token_secret=TEST_SHARE_TOKEN_SECRET,
+                actor_type="api",
+                request_id="req-rotate-share",
+            )
+            self.assertNotEqual(created.token, rotated.token)
+            with self.assertRaises(NotFoundError):
+                get_public_inventory_share(
+                    db_path,
+                    token=created.token,
+                    token_secret=TEST_SHARE_TOKEN_SECRET,
+                )
+            rotated_public_share = get_public_inventory_share(
+                db_path,
+                token=rotated.token,
+                token_secret=TEST_SHARE_TOKEN_SECRET,
+            )
+            self.assertEqual("Personal Collection", rotated_public_share.inventory.display_name)
+
+            revoked = revoke_inventory_share_link(
+                db_path,
+                inventory_slug="personal",
+                actor_id="owner-user",
+                actor_type="api",
+                request_id="req-revoke-share",
+            )
+            self.assertFalse(revoked.active)
+            self.assertIsNone(revoked.public_path)
+            self.assertIsNotNone(revoked.revoked_at)
+            with self.assertRaises(NotFoundError):
+                get_public_inventory_share(
+                    db_path,
+                    token=rotated.token,
+                    token_secret=TEST_SHARE_TOKEN_SECRET,
+                )
+
+            revoked_again = revoke_inventory_share_link(
+                db_path,
+                inventory_slug="personal",
+                actor_id="owner-user",
+            )
+            self.assertFalse(revoked_again.active)
+            self.assertEqual(revoked.revoked_at, revoked_again.revoked_at)
+            audit_rows = list_inventory_audit_events(db_path, inventory_slug="personal", limit=10)
+            self.assertEqual(
+                ["revoke_share_link", "rotate_share_link", "create_share_link"],
+                [row.action for row in audit_rows[:3]],
+            )
+            self.assertEqual("req-revoke-share", audit_rows[0].request_id)
+            self.assertEqual("req-rotate-share", audit_rows[1].request_id)
+            self.assertEqual("req-create-share", audit_rows[2].request_id)
+            self.assertTrue(all("token" not in row.metadata for row in audit_rows[:3]))
 
     def test_add_card_uses_inventory_default_location_and_tags_when_omitted(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -13,6 +13,8 @@ from mtg_source_stack.db.schema import initialize_database
 
 
 class SchemaMigrationTest(unittest.TestCase):
+    CURRENT_MIGRATION_VERSIONS = list(range(1, 16))
+
     def _build_legacy_card_scope_db(self, *, type_line: str | None) -> Path:
         temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(temp_dir.cleanup)
@@ -94,6 +96,9 @@ class SchemaMigrationTest(unittest.TestCase):
                 sync_run_issues_exists = connection.execute(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_issues'"
                 ).fetchone()[0]
+                inventory_share_links_exists = connection.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'inventory_share_links'"
+                ).fetchone()[0]
                 update_trigger_sql = connection.execute(
                     """
                     SELECT sql
@@ -109,9 +114,13 @@ class SchemaMigrationTest(unittest.TestCase):
                     row["name"]
                     for row in connection.execute("PRAGMA table_info(inventories)").fetchall()
                 }
+                share_link_columns = {
+                    row["name"]
+                    for row in connection.execute("PRAGMA table_info(inventory_share_links)").fetchall()
+                }
 
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], versions)
-            self.assertEqual(14, latest_version)
+            self.assertEqual(self.CURRENT_MIGRATION_VERSIONS, versions)
+            self.assertEqual(15, latest_version)
             self.assertEqual(1, audit_log_exists)
             self.assertEqual(1, card_search_fts_exists)
             self.assertEqual(1, inventory_memberships_exists)
@@ -121,6 +130,14 @@ class SchemaMigrationTest(unittest.TestCase):
             self.assertEqual(1, sync_run_steps_exists)
             self.assertEqual(1, sync_run_artifacts_exists)
             self.assertEqual(1, sync_run_issues_exists)
+            self.assertEqual(1, inventory_share_links_exists)
+            self.assertTrue(
+                {
+                    "token_nonce",
+                    "issued_by_actor_id",
+                    "revoked_by_actor_id",
+                }.issubset(share_link_columns)
+            )
             self.assertIn(
                 "AFTER UPDATE OF scryfall_id, name, set_code, set_name, collector_number, lang ON mtg_cards",
                 update_trigger_sql,
@@ -161,7 +178,7 @@ class SchemaMigrationTest(unittest.TestCase):
                     "SELECT version, name FROM schema_migrations ORDER BY version"
                 ).fetchall()
 
-            self.assertEqual(14, len(rows))
+            self.assertEqual(15, len(rows))
             self.assertEqual(
                 [
                     (1, "mvp base"),
@@ -178,6 +195,7 @@ class SchemaMigrationTest(unittest.TestCase):
                     (12, "add mtgjson card links"),
                     (13, "add sync run tracking"),
                     (14, "narrow card search fts updates"),
+                    (15, "add inventory share links"),
                 ],
                 [(row["version"], row["name"]) for row in rows],
             )
@@ -256,13 +274,16 @@ class SchemaMigrationTest(unittest.TestCase):
                 sync_run_issues_exists = migrated.execute(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'sync_run_issues'"
                 ).fetchone()[0]
+                inventory_share_links_exists = migrated.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'inventory_share_links'"
+                ).fetchone()[0]
                 inventory_columns = {row["name"] for row in migrated.execute("PRAGMA table_info(inventories)")}
 
             self.assertIn("tags_json", columns)
             self.assertIn("printing_selection_mode", columns)
             self.assertEqual("[]", tags_value)
             self.assertEqual("explicit", printing_selection_mode)
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], versions)
+            self.assertEqual(self.CURRENT_MIGRATION_VERSIONS, versions)
             self.assertIn("before_json", audit_columns)
             self.assertIn("after_json", audit_columns)
             self.assertIn("metadata_json", audit_columns)
@@ -274,6 +295,7 @@ class SchemaMigrationTest(unittest.TestCase):
             self.assertEqual(1, sync_run_steps_exists)
             self.assertEqual(1, sync_run_artifacts_exists)
             self.assertEqual(1, sync_run_issues_exists)
+            self.assertEqual(1, inventory_share_links_exists)
             self.assertTrue(
                 {
                     "default_location",
@@ -358,7 +380,7 @@ class SchemaMigrationTest(unittest.TestCase):
                 ]
 
             self.assertEqual([("normal", 1.5)], [(row["finish"], row["price_value"]) for row in rows])
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], versions)
+            self.assertEqual(self.CURRENT_MIGRATION_VERSIONS, versions)
 
     def test_initialize_database_backfills_default_add_search_scope_for_legacy_rows(self) -> None:
         for type_line, expected in (
@@ -460,4 +482,4 @@ class SchemaMigrationTest(unittest.TestCase):
                 ]
 
             self.assertEqual([("uuid-1", "card-with-uuid")], [(row["mtgjson_uuid"], row["scryfall_id"]) for row in rows])
-            self.assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], versions)
+            self.assertEqual(self.CURRENT_MIGRATION_VERSIONS, versions)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -439,6 +439,14 @@ class WebApiSchemaTest(unittest.TestCase):
             share_link_properties = components[share_link_schema_name]["properties"]
             self.assertEqual("string", share_link_properties["token"]["type"])
             self.assertEqual("string", share_link_properties["public_path"]["type"])
+            self.assertIn(
+                "Browser-facing public share page path",
+                share_link_properties["public_path"]["description"],
+            )
+            self.assertIn(
+                "/api/shared/inventories/{share_token}",
+                share_link_properties["public_path"]["description"],
+            )
             self.assertEqual("boolean", share_link_properties["active"]["type"])
 
             public_share_schema = spec["paths"]["/shared/inventories/{share_token}"]["get"]["responses"]["200"][
@@ -4914,8 +4922,9 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual("personal", created_payload["inventory"])
                 self.assertTrue(created_payload["active"])
                 self.assertTrue(created_payload["token"])
+                created_backend_route = f"/shared/inventories/{created_payload['token']}"
                 self.assertEqual(
-                    f"/shared/inventories/{created_payload['token']}",
+                    created_backend_route,
                     created_payload["public_path"],
                 )
                 active_status = client.get("/inventories/personal/share-link", headers=owner_headers)
@@ -4940,7 +4949,7 @@ class WebApiTest(unittest.TestCase):
                 duplicate_create = client.post("/inventories/personal/share-link", headers=owner_headers)
                 self.assertEqual(409, duplicate_create.status_code)
 
-                public_view = client.get(created_payload["public_path"])
+                public_view = client.get(created_backend_route)
                 self.assertEqual(200, public_view.status_code)
                 public_payload = public_view.json()
                 self.assertEqual(
@@ -4974,10 +4983,12 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual(200, rotated.status_code)
                 rotated_payload = rotated.json()
                 self.assertNotEqual(created_payload["token"], rotated_payload["token"])
+                rotated_backend_route = f"/shared/inventories/{rotated_payload['token']}"
+                self.assertEqual(rotated_backend_route, rotated_payload["public_path"])
 
-                old_public_view = client.get(created_payload["public_path"])
+                old_public_view = client.get(created_backend_route)
                 self.assertEqual(404, old_public_view.status_code)
-                new_public_view = client.get(rotated_payload["public_path"])
+                new_public_view = client.get(rotated_backend_route)
                 self.assertEqual(200, new_public_view.status_code)
 
                 revoked = client.delete("/inventories/personal/share-link", headers=owner_headers)
@@ -4985,7 +4996,7 @@ class WebApiTest(unittest.TestCase):
                 self.assertFalse(revoked.json()["active"])
                 self.assertIsNotNone(revoked.json()["revoked_at"])
 
-                revoked_public_view = client.get(rotated_payload["public_path"])
+                revoked_public_view = client.get(rotated_backend_route)
                 self.assertEqual(404, revoked_public_view.status_code)
 
                 revoked_again = client.delete("/inventories/personal/share-link", headers=owner_headers)

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -117,6 +117,11 @@ class WebApiSchemaTest(unittest.TestCase):
                 ("/imports/deck-url", "post"),
                 ("/me/access-summary", "get"),
                 ("/me/bootstrap", "post"),
+                ("/inventories/{inventory_slug}/share-link", "get"),
+                ("/inventories/{inventory_slug}/share-link", "post"),
+                ("/inventories/{inventory_slug}/share-link/rotate", "post"),
+                ("/inventories/{inventory_slug}/share-link", "delete"),
+                ("/shared/inventories/{share_token}", "get"),
                 ("/cards/search", "get"),
                 ("/cards/search/names", "get"),
                 ("/cards/oracle/{oracle_id}/printings", "get"),
@@ -144,6 +149,10 @@ class WebApiSchemaTest(unittest.TestCase):
                 ("/inventories/{inventory_slug}/export.csv", "get"),
                 ("/me/access-summary", "get"),
                 ("/me/bootstrap", "post"),
+                ("/inventories/{inventory_slug}/share-link", "get"),
+                ("/inventories/{inventory_slug}/share-link", "post"),
+                ("/inventories/{inventory_slug}/share-link/rotate", "post"),
+                ("/inventories/{inventory_slug}/share-link", "delete"),
                 ("/cards/search", "get"),
                 ("/cards/search/names", "get"),
                 ("/cards/oracle/{oracle_id}/printings", "get"),
@@ -422,6 +431,28 @@ class WebApiSchemaTest(unittest.TestCase):
                 [{"type": "string"}, {"type": "null"}],
                 access_summary_properties["default_inventory_slug"]["anyOf"],
             )
+            share_link_schema = spec["paths"]["/inventories/{inventory_slug}/share-link"]["post"]["responses"][
+                "201"
+            ]["content"]["application/json"]["schema"]
+            share_link_schema_name = self._schema_name_from_ref(share_link_schema["$ref"])
+            self.assertEqual("InventoryShareLinkTokenResponse", share_link_schema_name)
+            share_link_properties = components[share_link_schema_name]["properties"]
+            self.assertEqual("string", share_link_properties["token"]["type"])
+            self.assertEqual("string", share_link_properties["public_path"]["type"])
+            self.assertEqual("boolean", share_link_properties["active"]["type"])
+
+            public_share_schema = spec["paths"]["/shared/inventories/{share_token}"]["get"]["responses"]["200"][
+                "content"
+            ]["application/json"]["schema"]
+            public_share_schema_name = self._schema_name_from_ref(public_share_schema["$ref"])
+            self.assertEqual("PublicInventoryShareResponse", public_share_schema_name)
+            public_item_schema_name = self._schema_name_from_ref(
+                components[public_share_schema_name]["properties"]["items"]["items"]["$ref"]
+            )
+            public_item_properties = components[public_item_schema_name]["properties"]
+            self.assertNotIn("notes", public_item_properties)
+            self.assertNotIn("acquisition_price", public_item_properties)
+            self.assertNotIn("location", public_item_properties)
             duplicate_schema = spec["paths"]["/inventories/{source_inventory_slug}/duplicate"]["post"]["responses"][
                 "201"
             ]["content"]["application/json"]["schema"]
@@ -4808,6 +4839,178 @@ class WebApiTest(unittest.TestCase):
                 )
                 self.assertEqual(403, outsider_printings.status_code)
                 self.assertEqual("forbidden", outsider_printings.json()["error"]["code"])
+
+    def test_inventory_share_links_are_owner_managed_and_public_read_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            initialize_database(db_path)
+            owner_headers = {"X-Authenticated-User": "owner-user"}
+            viewer_headers = {"X-Authenticated-User": "viewer-user"}
+            editor_headers = {"X-Authenticated-User": "editor-user"}
+
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description="Cards I want to share",
+                actor_id="owner-user",
+            )
+            grant_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                actor_id="viewer-user",
+                role="viewer",
+            )
+            grant_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                actor_id="editor-user",
+                role="editor",
+            )
+
+            with self._client(db_path, runtime_mode="shared_service", auto_migrate=False) as client:
+                self._seed_card(db_path)
+
+                added = client.post(
+                    "/inventories/personal/items",
+                    headers=owner_headers,
+                    json={
+                        "scryfall_id": "api-card-1",
+                        "quantity": 2,
+                        "condition_code": "NM",
+                        "finish": "normal",
+                        "location": "Private Binder",
+                        "acquisition_price": "1.25",
+                        "acquisition_currency": "USD",
+                        "notes": "private owner note",
+                        "tags": ["trade", "private"],
+                    },
+                )
+                self.assertEqual(201, added.status_code)
+
+                viewer_create = client.post("/inventories/personal/share-link", headers=viewer_headers)
+                self.assertEqual(403, viewer_create.status_code)
+
+                editor_create = client.post("/inventories/personal/share-link", headers=editor_headers)
+                self.assertEqual(403, editor_create.status_code)
+
+                initial_status = client.get("/inventories/personal/share-link", headers=owner_headers)
+                self.assertEqual(200, initial_status.status_code)
+                self.assertEqual(
+                    {
+                        "inventory": "personal",
+                        "active": False,
+                        "public_path": None,
+                        "created_at": None,
+                        "updated_at": None,
+                        "revoked_at": None,
+                    },
+                    initial_status.json(),
+                )
+
+                created = client.post("/inventories/personal/share-link", headers=owner_headers)
+                self.assertEqual(201, created.status_code)
+                created_payload = created.json()
+                self.assertEqual("personal", created_payload["inventory"])
+                self.assertTrue(created_payload["active"])
+                self.assertTrue(created_payload["token"])
+                self.assertEqual(
+                    f"/shared/inventories/{created_payload['token']}",
+                    created_payload["public_path"],
+                )
+                active_status = client.get("/inventories/personal/share-link", headers=owner_headers)
+                self.assertEqual(200, active_status.status_code)
+                self.assertEqual(created_payload["public_path"], active_status.json()["public_path"])
+                with connect(db_path) as connection:
+                    share_row = connection.execute(
+                        """
+                        SELECT token_nonce
+                        FROM inventory_share_links
+                        WHERE inventory_id = (
+                            SELECT id
+                            FROM inventories
+                            WHERE slug = ?
+                        )
+                        """,
+                        ("personal",),
+                    ).fetchone()
+                self.assertIn(share_row["token_nonce"], created_payload["token"])
+                self.assertNotEqual(created_payload["token"], share_row["token_nonce"])
+
+                duplicate_create = client.post("/inventories/personal/share-link", headers=owner_headers)
+                self.assertEqual(409, duplicate_create.status_code)
+
+                public_view = client.get(created_payload["public_path"])
+                self.assertEqual(200, public_view.status_code)
+                public_payload = public_view.json()
+                self.assertEqual(
+                    {
+                        "display_name": "Personal Collection",
+                        "description": "Cards I want to share",
+                        "item_rows": 1,
+                        "total_cards": 2,
+                    },
+                    public_payload["inventory"],
+                )
+                self.assertEqual(1, len(public_payload["items"]))
+                public_item = public_payload["items"][0]
+                self.assertEqual("API Test Card", public_item["name"])
+                self.assertEqual(2, public_item["quantity"])
+                self.assertEqual("normal", public_item["finish"])
+                self.assertNotIn("notes", public_item)
+                self.assertNotIn("acquisition_price", public_item)
+                self.assertNotIn("acquisition_currency", public_item)
+                self.assertNotIn("location", public_item)
+                self.assertNotIn("tags", public_item)
+                self.assertNotIn("item_id", public_item)
+                self.assertNotIn("currency", public_item)
+                self.assertNotIn("unit_price", public_item)
+                self.assertNotIn("est_value", public_item)
+
+                anonymous_private_route = client.get("/inventories/personal/items")
+                self.assertEqual(401, anonymous_private_route.status_code)
+
+                rotated = client.post("/inventories/personal/share-link/rotate", headers=owner_headers)
+                self.assertEqual(200, rotated.status_code)
+                rotated_payload = rotated.json()
+                self.assertNotEqual(created_payload["token"], rotated_payload["token"])
+
+                old_public_view = client.get(created_payload["public_path"])
+                self.assertEqual(404, old_public_view.status_code)
+                new_public_view = client.get(rotated_payload["public_path"])
+                self.assertEqual(200, new_public_view.status_code)
+
+                revoked = client.delete("/inventories/personal/share-link", headers=owner_headers)
+                self.assertEqual(200, revoked.status_code)
+                self.assertFalse(revoked.json()["active"])
+                self.assertIsNotNone(revoked.json()["revoked_at"])
+
+                revoked_public_view = client.get(rotated_payload["public_path"])
+                self.assertEqual(404, revoked_public_view.status_code)
+
+                revoked_again = client.delete("/inventories/personal/share-link", headers=owner_headers)
+                self.assertEqual(200, revoked_again.status_code)
+                self.assertFalse(revoked_again.json()["active"])
+
+    def test_inventory_share_links_allow_global_admin_management(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            initialize_database(db_path)
+            admin_headers = {
+                "X-Authenticated-User": "admin-user",
+                "X-Authenticated-Roles": "admin",
+            }
+            create_inventory(
+                db_path,
+                slug="admin-only",
+                display_name="Admin Only",
+                description=None,
+            )
+
+            with self._client(db_path, runtime_mode="shared_service", auto_migrate=False) as client:
+                created = client.post("/inventories/admin-only/share-link", headers=admin_headers)
+                self.assertEqual(201, created.status_code)
+                self.assertEqual("admin-only", created.json()["inventory"])
 
     def test_shared_service_mutating_requests_require_authenticated_actor_header(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

- Adds owner/admin-managed inventory share-link APIs for status, create, rotate, and revoke.
- Adds anonymous `GET /shared/inventories/{share_token}` with a public read-only projection that excludes private inventory fields.
- Keeps active links reusable for copy-link-later UX without storing the full bearer token: the DB stores a nonce and the URL token is rebuilt/validated with an HMAC signature from `MTG_API_SNAPSHOT_SIGNING_SECRET`.
- Defines `public_path` as the browser-facing share page path, currently `/shared/inventories/{share_token}`. In shared-service deployments, that page should fetch backend JSON through `/api/shared/inventories/{share_token}`; `public_path` is not a proxy-aware API fetch URL.
- Adds audit events for share-link create, rotate, and revoke, including actor/request context but no token material.
- Adds migration `0015_add_inventory_share_links.sql`, base schema updates, OpenAPI snapshot updates, deployment/auth docs, and focused authorization/service/API contract tests.

Refs #52.

## Testing

- `PYTHONPATH=src .venv/bin/python -m unittest tests.test_api_contract tests.test_web_api.WebApiSchemaTest tests.test_web_api.WebApiTest.test_inventory_share_links_are_owner_managed_and_public_read_only tests.test_web_api.WebApiTest.test_inventory_share_links_allow_global_admin_management -q`
- `PYTHONPATH=src .venv/bin/python -m unittest -q`
- `git diff --check`

The live FastAPI endpoint tests for these routes are included, but they skip in this sandbox because localhost socket tests are unavailable.

## Remaining Frontend Work

- Add owner/admin inventory sharing controls: status, create, copy active link, rotate, and revoke.
- Add the anonymous public inventory page for `/shared/inventories/{share_token}`.
- Have that page fetch public inventory JSON through the deployed API path, `/api/shared/inventories/{share_token}`, in the shared-service proxy shape.
- Add loading, empty inventory, revoked/not-found, and permission-denied states.
- Add/refresh frontend docs after the UI behavior lands.
