### PR TITLE
Expose inventory capabilities in list response

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -51,6 +51,9 @@ Current authz model:
   inventory; custom inventory creation or `POST /me/bootstrap` are the
   intended first-run escape hatches
 - `GET /inventories` is filtered to visible inventories
+- each `GET /inventories` row includes the current actor's effective
+  per-inventory capabilities: `role`, `can_read`, `can_write`,
+  `can_manage_share`, and `can_transfer_to`
 - inventory reads require inventory membership or global `admin`
 - inventory writes require inventory `editor` / `owner` membership or global
   `admin`

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Inventory access is now controlled by local inventory memberships:
 The current shared-service behavior is:
 
 - `GET /inventories` returns only the inventories visible to the current user
+  and includes per-inventory capability fields: `role`, `can_read`,
+  `can_write`, `can_manage_share`, and `can_transfer_to`
 - card search routes require a user who can read at least one inventory
 - inventory item/audit reads require membership on that inventory
 - inventory writes require `editor` or `owner` membership on that inventory

--- a/contracts/demo_payloads/inventories_list.json
+++ b/contracts/demo_payloads/inventories_list.json
@@ -9,7 +9,12 @@
     "acquisition_price": "25.00",
     "acquisition_currency": "USD",
     "item_rows": 4,
-    "total_cards": 7
+    "total_cards": 7,
+    "role": "admin",
+    "can_read": true,
+    "can_write": true,
+    "can_manage_share": true,
+    "can_transfer_to": true
   },
   {
     "slug": "trade-binder",
@@ -21,6 +26,11 @@
     "acquisition_price": null,
     "acquisition_currency": null,
     "item_rows": 0,
-    "total_cards": 0
+    "total_cards": 0,
+    "role": "admin",
+    "can_read": true,
+    "can_write": true,
+    "can_manage_share": true,
+    "can_transfer_to": true
   }
 ]

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -2834,6 +2834,22 @@
             ],
             "title": "Acquisition Price"
           },
+          "can_manage_share": {
+            "title": "Can Manage Share",
+            "type": "boolean"
+          },
+          "can_read": {
+            "title": "Can Read",
+            "type": "boolean"
+          },
+          "can_transfer_to": {
+            "title": "Can Transfer To",
+            "type": "boolean"
+          },
+          "can_write": {
+            "title": "Can Write",
+            "type": "boolean"
+          },
           "default_location": {
             "anyOf": [
               {
@@ -2886,6 +2902,23 @@
             ],
             "title": "Notes"
           },
+          "role": {
+            "anyOf": [
+              {
+                "enum": [
+                  "viewer",
+                  "editor",
+                  "owner",
+                  "admin"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role"
+          },
           "slug": {
             "title": "Slug",
             "type": "string"
@@ -2905,7 +2938,12 @@
           "acquisition_price",
           "acquisition_currency",
           "item_rows",
-          "total_cards"
+          "total_cards",
+          "role",
+          "can_read",
+          "can_write",
+          "can_manage_share",
+          "can_transfer_to"
         ],
         "title": "InventoryListRowResponse",
         "type": "object"

--- a/docs/api_v1_contract.md
+++ b/docs/api_v1_contract.md
@@ -568,7 +568,10 @@ before the generic 500 envelope is returned.
   - `owner` can read and write a specific inventory
   - global `admin` bypasses inventory membership checks
 - `GET /inventories` returns only the inventories visible to the caller, while
-  global `admin` can see all inventories.
+  global `admin` can see all inventories. Each inventory list row includes
+  permission-aware frontend fields: `role`, `can_read`, `can_write`,
+  `can_manage_share`, and `can_transfer_to`. `role="admin"` means an effective
+  global admin bypass, not a local inventory membership row.
 - `GET /cards/search`, `GET /cards/search/names`, and
   `GET /cards/oracle/{oracle_id}/printings` require a caller who can read at
   least one inventory, or a global `admin`.

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -337,6 +337,9 @@ export default {
 - Shared-service inventory access is now membership-scoped. Frontend code
   should assume:
   - inventory lists are filtered to the current user
+  - each inventory list row includes `role`, `can_read`, `can_write`,
+    `can_manage_share`, and `can_transfer_to` so write/share/transfer controls
+    can be hidden or disabled before a `403`
   - some inventory reads may return `403`
   - inventory writes may return `403` if the user is a viewer or non-member
   - catalog search should not be treated as globally available to every

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -71,6 +71,9 @@ Local inventory membership roles:
 Effective behavior:
 
 - `GET /inventories` returns only the inventories visible to the caller
+- each `GET /inventories` row includes permission-aware frontend hints:
+  `role`, `can_read`, `can_write`, `can_manage_share`, and `can_transfer_to`
+  using the same policy as the read, write, share-link, and transfer routes
 - inventory card search routes require a caller who can read at least one
   inventory, or a global `admin`
 - inventory reads require `viewer`, `editor`, or `owner` membership on that

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -182,6 +182,11 @@ Check `GET /me/access-summary` first for each user. Then verify
 `GET /inventories`, catalog search availability, inventory reads, and denied
 writes match the table above.
 
+`GET /inventories` now includes capability fields for permission-aware UI:
+`role`, `can_read`, `can_write`, `can_manage_share`, and `can_transfer_to`.
+Use those fields to gate write, import, transfer, duplicate, and share-link
+controls instead of rendering the control first and relying on a later `403`.
+
 ## Proxy-Backed Shared-Service Validation
 
 Use the local proxy harness when you need to validate the same-origin `/api`

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -184,6 +184,11 @@ describe("App", () => {
       acquisition_currency: null,
       item_rows: 0,
       total_cards: 0,
+      role: "owner",
+      can_read: true,
+      can_write: true,
+      can_manage_share: true,
+      can_transfer_to: true,
       ...overrides,
     };
   }

--- a/frontend/src/components/AuditFeed.test.tsx
+++ b/frontend/src/components/AuditFeed.test.tsx
@@ -15,6 +15,11 @@ const inventory: InventorySummary = {
   acquisition_currency: null,
   item_rows: 1,
   total_cards: 3,
+  role: "owner",
+  can_read: true,
+  can_write: true,
+  can_manage_share: true,
+  can_transfer_to: true,
 };
 
 const event: InventoryAuditEvent = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,7 @@ export type InventoryAcquisitionMergePolicy = "target" | "source";
 export type InventoryTransferMode = "copy" | "move";
 export type InventoryTransferConflictPolicy = "fail" | "merge";
 export type InventoryTransferSelectionKind = "items" | "all_items";
+export type InventoryCapabilityRole = "viewer" | "editor" | "owner" | "admin";
 export type InventoryTransferItemStatus =
   | "would_copy"
   | "would_move"
@@ -79,6 +80,11 @@ export interface InventorySummary {
   acquisition_currency: string | null;
   item_rows: number;
   total_cards: number;
+  role: InventoryCapabilityRole | null;
+  can_read: boolean;
+  can_write: boolean;
+  can_manage_share: boolean;
+  can_transfer_to: boolean;
 }
 
 export interface InventoryCreateRequest {

--- a/src/mtg_source_stack/api/response_models.py
+++ b/src/mtg_source_stack/api/response_models.py
@@ -79,6 +79,11 @@ class InventoryListRowResponse(ApiBaseModel):
     acquisition_currency: str | None
     item_rows: int
     total_cards: int
+    role: Literal["viewer", "editor", "owner", "admin"] | None
+    can_read: bool
+    can_write: bool
+    can_manage_share: bool
+    can_transfer_to: bool
 
 
 class InventoryCreateResponse(ApiBaseModel):

--- a/src/mtg_source_stack/inventory/inventories.py
+++ b/src/mtg_source_stack/inventory/inventories.py
@@ -9,28 +9,63 @@ from typing import Iterable
 from ..db.connection import connect
 from ..db.schema import require_current_schema
 from ..errors import ConflictError, ValidationError
-from .access import grant_inventory_membership_with_connection, is_global_admin
+from .access import (
+    can_manage_inventory_share,
+    can_read_inventory,
+    can_write_inventory,
+    grant_inventory_membership_with_connection,
+    is_global_admin,
+)
 from .money import coerce_decimal
 from .normalize import normalize_currency_code, normalize_inventory_slug, normalize_tag_text, slugify_inventory_name, text_or_none
 from .response_models import AccessSummaryResult, DefaultInventoryBootstrapResult, InventoryCreateResult, InventoryListRow
 
 
-def _inventory_list_rows(rows: list[sqlite3.Row]) -> list[InventoryListRow]:
-    return [
-        InventoryListRow(
-            slug=row["slug"],
-            display_name=row["display_name"],
-            description=text_or_none(row["description"]),
-            default_location=text_or_none(row["default_location"]),
-            default_tags=text_or_none(row["default_tags"]),
-            notes=text_or_none(row["notes"]),
-            acquisition_price=coerce_decimal(row["acquisition_price"]),
-            acquisition_currency=text_or_none(row["acquisition_currency"]),
-            item_rows=int(row["item_rows"]),
-            total_cards=int(row["total_cards"]),
+def _inventory_capabilities(
+    *,
+    inventory_role: str | None,
+    actor_roles: Iterable[str],
+) -> tuple[str | None, bool, bool, bool, bool]:
+    roles = frozenset(actor_roles)
+    effective_role = "admin" if is_global_admin(roles) else inventory_role
+    can_read = can_read_inventory(inventory_role=inventory_role, actor_roles=roles)
+    can_write = can_write_inventory(inventory_role=inventory_role, actor_roles=roles)
+    can_manage_share = can_manage_inventory_share(inventory_role=inventory_role, actor_roles=roles)
+    return effective_role, can_read, can_write, can_manage_share, can_write
+
+
+def _inventory_list_rows(
+    rows: list[sqlite3.Row],
+    *,
+    actor_roles: Iterable[str],
+) -> list[InventoryListRow]:
+    result: list[InventoryListRow] = []
+    for row in rows:
+        inventory_role = row["inventory_role"] if "inventory_role" in row.keys() else None
+        role, can_read, can_write, can_manage_share, can_transfer_to = _inventory_capabilities(
+            inventory_role=inventory_role,
+            actor_roles=actor_roles,
         )
-        for row in rows
-    ]
+        result.append(
+            InventoryListRow(
+                slug=row["slug"],
+                display_name=row["display_name"],
+                description=text_or_none(row["description"]),
+                default_location=text_or_none(row["default_location"]),
+                default_tags=text_or_none(row["default_tags"]),
+                notes=text_or_none(row["notes"]),
+                acquisition_price=coerce_decimal(row["acquisition_price"]),
+                acquisition_currency=text_or_none(row["acquisition_currency"]),
+                item_rows=int(row["item_rows"]),
+                total_cards=int(row["total_cards"]),
+                role=role,
+                can_read=can_read,
+                can_write=can_write,
+                can_manage_share=can_manage_share,
+                can_transfer_to=can_transfer_to,
+            )
+        )
+    return result
 
 
 def _normalized_visible_actor_id(actor_id: str | None) -> str | None:
@@ -358,7 +393,7 @@ def list_inventories(db_path: str | Path) -> list[InventoryListRow]:
             ORDER BY i.slug
             """
         ).fetchall()
-    return _inventory_list_rows(rows)
+    return _inventory_list_rows(rows, actor_roles={"admin"})
 
 
 def list_visible_inventories(
@@ -385,6 +420,7 @@ def list_visible_inventories(
                 COALESCE(i.notes, '') AS notes,
                 i.acquisition_price,
                 COALESCE(i.acquisition_currency, '') AS acquisition_currency,
+                im.role AS inventory_role,
                 COUNT(ii.id) AS item_rows,
                 COALESCE(SUM(ii.quantity), 0) AS total_cards
             FROM inventories i
@@ -401,12 +437,13 @@ def list_visible_inventories(
                 i.default_tags,
                 i.notes,
                 i.acquisition_price,
-                i.acquisition_currency
+                i.acquisition_currency,
+                im.role
             ORDER BY i.slug
             """,
             (normalized_actor_id,),
         ).fetchall()
-    return _inventory_list_rows(rows)
+    return _inventory_list_rows(rows, actor_roles=actor_roles)
 
 
 def summarize_actor_access(

--- a/src/mtg_source_stack/inventory/response_models.py
+++ b/src/mtg_source_stack/inventory/response_models.py
@@ -123,6 +123,11 @@ class InventoryListRow(ResponseModel):
     acquisition_currency: str | None
     item_rows: int
     total_cards: int
+    role: str | None
+    can_read: bool
+    can_write: bool
+    can_manage_share: bool
+    can_transfer_to: bool
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -300,6 +300,11 @@ class ApiContractTest(RepoSmokeTestCase):
                 "acquisition_currency": "USD",
                 "item_rows": 12,
                 "total_cards": 45,
+                "role": "owner",
+                "can_read": True,
+                "can_write": True,
+                "can_manage_share": True,
+                "can_transfer_to": True,
             }
         ]
         share_link_status_payload = {
@@ -640,6 +645,17 @@ class ApiContractTest(RepoSmokeTestCase):
             [{"type": "string"}, {"type": "null"}],
             inventory_list_properties["acquisition_currency"]["anyOf"],
         )
+        self.assertEqual(
+            [
+                {"enum": ["viewer", "editor", "owner", "admin"], "type": "string"},
+                {"type": "null"},
+            ],
+            inventory_list_properties["role"]["anyOf"],
+        )
+        self.assertEqual("boolean", inventory_list_properties["can_read"]["type"])
+        self.assertEqual("boolean", inventory_list_properties["can_write"]["type"])
+        self.assertEqual("boolean", inventory_list_properties["can_manage_share"]["type"])
+        self.assertEqual("boolean", inventory_list_properties["can_transfer_to"]["type"])
 
         inventory_create_response_schema = InventoryCreateResponse.model_json_schema()
         inventory_create_response_properties = inventory_create_response_schema["properties"]

--- a/tests/test_inventory_access.py
+++ b/tests/test_inventory_access.py
@@ -22,6 +22,7 @@ from mtg_source_stack.inventory.service import (
     ensure_default_inventory,
     grant_inventory_membership,
     list_inventory_memberships,
+    list_inventories,
     list_visible_inventories,
     normalize_inventory_membership_role,
     revoke_inventory_membership,
@@ -321,6 +322,29 @@ class InventoryAccessTest(unittest.TestCase):
                 actor_roles=frozenset(),
             )
             self.assertEqual(["personal", "team"], [row.slug for row in viewer_rows])
+            viewer_by_slug = {row.slug: row for row in viewer_rows}
+            self.assertEqual("viewer", viewer_by_slug["personal"].role)
+            self.assertTrue(viewer_by_slug["personal"].can_read)
+            self.assertFalse(viewer_by_slug["personal"].can_write)
+            self.assertFalse(viewer_by_slug["personal"].can_manage_share)
+            self.assertFalse(viewer_by_slug["personal"].can_transfer_to)
+            self.assertEqual("editor", viewer_by_slug["team"].role)
+            self.assertTrue(viewer_by_slug["team"].can_read)
+            self.assertTrue(viewer_by_slug["team"].can_write)
+            self.assertFalse(viewer_by_slug["team"].can_manage_share)
+            self.assertTrue(viewer_by_slug["team"].can_transfer_to)
+
+            owner_rows = list_visible_inventories(
+                db_path,
+                actor_id="owner@example.com",
+                actor_roles=frozenset(),
+            )
+            self.assertEqual(["personal"], [row.slug for row in owner_rows])
+            self.assertEqual("owner", owner_rows[0].role)
+            self.assertTrue(owner_rows[0].can_read)
+            self.assertTrue(owner_rows[0].can_write)
+            self.assertTrue(owner_rows[0].can_manage_share)
+            self.assertTrue(owner_rows[0].can_transfer_to)
 
             admin_rows = list_visible_inventories(
                 db_path,
@@ -328,6 +352,19 @@ class InventoryAccessTest(unittest.TestCase):
                 actor_roles={"admin"},
             )
             self.assertEqual(["admin-only", "personal", "team"], [row.slug for row in admin_rows])
+            self.assertTrue(all(row.role == "admin" for row in admin_rows))
+            self.assertTrue(all(row.can_read for row in admin_rows))
+            self.assertTrue(all(row.can_write for row in admin_rows))
+            self.assertTrue(all(row.can_manage_share for row in admin_rows))
+            self.assertTrue(all(row.can_transfer_to for row in admin_rows))
+
+            local_rows = list_inventories(db_path)
+            self.assertEqual(["admin-only", "personal", "team"], [row.slug for row in local_rows])
+            self.assertTrue(all(row.role == "admin" for row in local_rows))
+            self.assertTrue(all(row.can_read for row in local_rows))
+            self.assertTrue(all(row.can_write for row in local_rows))
+            self.assertTrue(all(row.can_manage_share for row in local_rows))
+            self.assertTrue(all(row.can_transfer_to for row in local_rows))
 
             self.assertEqual(
                 [],

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -351,6 +351,17 @@ class WebApiSchemaTest(unittest.TestCase):
                 [{"type": "string"}, {"type": "null"}],
                 inventories_list_properties["acquisition_currency"]["anyOf"],
             )
+            self.assertEqual(
+                [
+                    {"enum": ["viewer", "editor", "owner", "admin"], "type": "string"},
+                    {"type": "null"},
+                ],
+                inventories_list_properties["role"]["anyOf"],
+            )
+            self.assertEqual("boolean", inventories_list_properties["can_read"]["type"])
+            self.assertEqual("boolean", inventories_list_properties["can_write"]["type"])
+            self.assertEqual("boolean", inventories_list_properties["can_manage_share"]["type"])
+            self.assertEqual("boolean", inventories_list_properties["can_transfer_to"]["type"])
 
             inventories_create_request_schema = spec["paths"]["/inventories"]["post"]["requestBody"]["content"][
                 "application/json"
@@ -1304,6 +1315,11 @@ class WebApiTest(unittest.TestCase):
                             "acquisition_currency": "USD",
                             "item_rows": 0,
                             "total_cards": 0,
+                            "role": "admin",
+                            "can_read": True,
+                            "can_write": True,
+                            "can_manage_share": True,
+                            "can_transfer_to": True,
                         }
                     ],
                     inventories.json(),
@@ -4687,6 +4703,7 @@ class WebApiTest(unittest.TestCase):
                 "X-Authenticated-User": "outsider-user",
                 "X-Authenticated-Roles": "viewer",
             }
+            owner_headers = {"X-Authenticated-User": "owner-user"}
             admin_headers = {
                 "X-Authenticated-User": "shared-admin",
                 "X-Authenticated-Roles": "admin",
@@ -4720,10 +4737,26 @@ class WebApiTest(unittest.TestCase):
                 viewer_inventories = client.get("/inventories", headers=viewer_headers)
                 self.assertEqual(200, viewer_inventories.status_code)
                 self.assertEqual(["personal"], [row["slug"] for row in viewer_inventories.json()])
+                viewer_inventory = viewer_inventories.json()[0]
+                self.assertEqual("viewer", viewer_inventory["role"])
+                self.assertTrue(viewer_inventory["can_read"])
+                self.assertFalse(viewer_inventory["can_write"])
+                self.assertFalse(viewer_inventory["can_manage_share"])
+                self.assertFalse(viewer_inventory["can_transfer_to"])
 
                 outsider_inventories = client.get("/inventories", headers=outsider_headers)
                 self.assertEqual(200, outsider_inventories.status_code)
                 self.assertEqual([], outsider_inventories.json())
+
+                owner_inventories = client.get("/inventories", headers=owner_headers)
+                self.assertEqual(200, owner_inventories.status_code)
+                self.assertEqual(["personal"], [row["slug"] for row in owner_inventories.json()])
+                owner_inventory = owner_inventories.json()[0]
+                self.assertEqual("owner", owner_inventory["role"])
+                self.assertTrue(owner_inventory["can_read"])
+                self.assertTrue(owner_inventory["can_write"])
+                self.assertTrue(owner_inventory["can_manage_share"])
+                self.assertTrue(owner_inventory["can_transfer_to"])
 
                 admin_inventories = client.get("/inventories", headers=admin_headers)
                 self.assertEqual(200, admin_inventories.status_code)
@@ -4731,6 +4764,11 @@ class WebApiTest(unittest.TestCase):
                     ["admin-only", "personal"],
                     [row["slug"] for row in admin_inventories.json()],
                 )
+                self.assertTrue(all(row["role"] == "admin" for row in admin_inventories.json()))
+                self.assertTrue(all(row["can_read"] for row in admin_inventories.json()))
+                self.assertTrue(all(row["can_write"] for row in admin_inventories.json()))
+                self.assertTrue(all(row["can_manage_share"] for row in admin_inventories.json()))
+                self.assertTrue(all(row["can_transfer_to"] for row in admin_inventories.json()))
 
     def test_shared_service_inventory_read_routes_allow_viewers_and_reject_non_members(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

- Adds per-inventory capability fields to `GET /inventories`: `role`, `can_read`, `can_write`, `can_manage_share`, and `can_transfer_to`.
- Computes capability values from the existing shared-service access policy helpers instead of adding a parallel permission model.
- Keeps local/demo inventory listing permissive with effective `role="admin"` capabilities.
- Updates OpenAPI, demo payloads, frontend `InventorySummary` typing, and shared-service/API/frontend docs.

Closes #62.

## Testing

- `PYTHONPATH=src .venv/bin/python -m unittest -q`
- `npm test` in `frontend/`
- `npm run build` in `frontend/`
- `git diff --check`
