### PR TITLE
Add inventory membership management API

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -54,6 +54,9 @@ Current authz model:
 - inventory reads require inventory membership or global `admin`
 - inventory writes require inventory `editor` / `owner` membership or global
   `admin`
+- inventory membership management requires inventory `owner` membership or
+  global `admin`; managed changes are audited and cannot remove or demote the
+  last owner
 - `POST /inventories` lets any authenticated user create an inventory and
   become `owner`
 - `POST /inventories/{inventory_slug}/items/bulk` now supports grouped:
@@ -83,7 +86,8 @@ Important limitation:
   organization/team system
 - existing inventories with no memberships are effectively admin-only until
   memberships are granted
-- membership management is currently CLI-first, not a full app UI workflow
+- membership management now has a backend API and CLI repair path, but not a
+  richer org/team workflow
 - CLI `create-inventory` does not carry an authenticated actor context by
   default, so inventories created that way may need membership grants afterward
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The current shared-service behavior is:
 - card search routes require a user who can read at least one inventory
 - inventory item/audit reads require membership on that inventory
 - inventory writes require `editor` or `owner` membership on that inventory
+- inventory membership management requires `owner` membership on that
+  inventory or global `admin`
 - `POST /inventories` lets any authenticated user create an owned inventory
 - `POST /me/bootstrap` creates one personal default inventory named
   `Collection` for an authenticated user, grants `owner`, and returns the same
@@ -266,8 +268,19 @@ mtg-personal-inventory add-card \
 `--scryfall-id`. Inventory rows still store the resolved printing, and if you
 omit `--language-code` the owned row inherits the resolved printing language.
 
-For shared-service rollout and ongoing membership management, the inventory CLI
-now also provides:
+For shared-service rollout and ongoing membership management, the API exposes:
+
+```text
+GET    /inventories/{inventory_slug}/members
+POST   /inventories/{inventory_slug}/members
+PATCH  /inventories/{inventory_slug}/members/{actor_id}
+DELETE /inventories/{inventory_slug}/members/{actor_id}
+```
+
+These routes require inventory `owner` access or global `admin`, preserve at
+least one owner per inventory, and write audit events for grant, role-change,
+and revoke actions. For operator seeding or repair, the inventory CLI still
+provides:
 
 ```bash
 mtg-personal-inventory grant-inventory-membership \
@@ -461,8 +474,9 @@ Recommended rollout sequence:
 3. If you are starting from a blank system, let first users create inventories
    through the app or `POST /inventories` so creators become `owner`. Use
    `POST /me/bootstrap` only when the default `Collection` name is acceptable,
-   or use the CLI membership commands to assign owners on existing inventories.
-4. Grant `viewer` / `editor` memberships to the first cohort.
+   or use the membership API/CLI to assign owners on existing inventories.
+4. Grant `viewer` / `editor` memberships to the first cohort through the app,
+   API, or CLI.
 5. Verify real user sessions against those memberships before launch.
 
 A typical startup flow is:
@@ -570,7 +584,8 @@ dependencies are missing.
   those JSON reads are published as `/api/shared/inventories/{share_token}`,
   while share-link `public_path` remains the browser-facing page path.
   Inventory reads and writes are scoped by local memberships. Authenticated
-  users can create inventories they own; global roles are only for elevated app
+  users can create inventories they own, and owners/admins can manage
+  inventory memberships through the API. Global roles are only for elevated app
   permissions such as admin bypass. The default verified identity header is
   `X-Authenticated-User`, and the default roles header is
   `X-Authenticated-Roles`.

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -2910,6 +2910,117 @@
         "title": "InventoryListRowResponse",
         "type": "object"
       },
+      "InventoryMembershipGrantRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "actor_id": {
+            "title": "Actor Id",
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "viewer",
+              "editor",
+              "owner"
+            ],
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "actor_id",
+          "role"
+        ],
+        "title": "InventoryMembershipGrantRequest",
+        "type": "object"
+      },
+      "InventoryMembershipRemovalResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "actor_id": {
+            "title": "Actor Id",
+            "type": "string"
+          },
+          "inventory": {
+            "title": "Inventory",
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "viewer",
+              "editor",
+              "owner"
+            ],
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inventory",
+          "actor_id",
+          "role"
+        ],
+        "title": "InventoryMembershipRemovalResponse",
+        "type": "object"
+      },
+      "InventoryMembershipResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "actor_id": {
+            "title": "Actor Id",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "inventory": {
+            "title": "Inventory",
+            "type": "string"
+          },
+          "role": {
+            "enum": [
+              "viewer",
+              "editor",
+              "owner"
+            ],
+            "title": "Role",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "inventory",
+          "actor_id",
+          "role",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "InventoryMembershipResponse",
+        "type": "object"
+      },
+      "InventoryMembershipUpdateRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "role": {
+            "enum": [
+              "viewer",
+              "editor",
+              "owner"
+            ],
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "InventoryMembershipUpdateRequest",
+        "type": "object"
+      },
       "InventoryShareLinkStatusResponse": {
         "additionalProperties": false,
         "properties": {
@@ -7619,6 +7730,410 @@
           }
         },
         "summary": "Inventory Items Set Printing"
+      }
+    },
+    "/inventories/{inventory_slug}/members": {
+      "get": {
+        "operationId": "inventory_members_list_inventories__inventory_slug__members_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inventory_slug",
+            "required": true,
+            "schema": {
+              "title": "Inventory Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/InventoryMembershipResponse"
+                  },
+                  "title": "Response Inventory Members List Inventories  Inventory Slug  Members Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Inventory Members List"
+      },
+      "post": {
+        "operationId": "inventory_member_grant_inventories__inventory_slug__members_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inventory_slug",
+            "required": true,
+            "schema": {
+              "title": "Inventory Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InventoryMembershipGrantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryMembershipResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Inventory Member Grant"
+      }
+    },
+    "/inventories/{inventory_slug}/members/{actor_id}": {
+      "delete": {
+        "operationId": "inventory_member_revoke_inventories__inventory_slug__members__actor_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inventory_slug",
+            "required": true,
+            "schema": {
+              "title": "Inventory Slug",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "actor_id",
+            "required": true,
+            "schema": {
+              "title": "Actor Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryMembershipRemovalResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Inventory Member Revoke"
+      },
+      "patch": {
+        "operationId": "inventory_member_update_inventories__inventory_slug__members__actor_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "inventory_slug",
+            "required": true,
+            "schema": {
+              "title": "Inventory Slug",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "actor_id",
+            "required": true,
+            "schema": {
+              "title": "Actor Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InventoryMembershipUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryMembershipResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Validation error"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Authentication required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            },
+            "description": "Schema not ready"
+          }
+        },
+        "summary": "Inventory Member Update"
       }
     },
     "/inventories/{inventory_slug}/share-link": {

--- a/docs/api_v1_contract.md
+++ b/docs/api_v1_contract.md
@@ -34,6 +34,9 @@ preserve for the first API-backed version of the project.
 - Inventory create/list/bootstrap responses include inventory-level metadata
   fields such as `default_location`, `default_tags`, `notes`,
   `acquisition_price`, and `acquisition_currency`.
+- Inventory membership responses include `inventory`, `actor_id`, `role`,
+  `created_at`, and `updated_at`. Membership removal responses include the
+  removed `inventory`, `actor_id`, and previous `role`.
 - Dates remain ISO-8601 strings. Audit timestamps are emitted in UTC with an
   explicit timezone suffix, for example `2026-04-01T20:41:10Z`.
 - `PATCH /inventories/{inventory_slug}/items/{item_id}` accepts exactly one
@@ -300,6 +303,37 @@ preserve for the first API-backed version of the project.
   - `target_description` is optional; when omitted, the source inventory
     description is copied to the new inventory
   - source inventory memberships are not copied to the new inventory
+- `GET /inventories/{inventory_slug}/members`
+  - returns current memberships ordered by `actor_id`
+  - requires inventory `owner` access in shared-service mode, or global
+    `admin`
+- `POST /inventories/{inventory_slug}/members`
+  - request body is JSON
+  - `actor_id` is required
+  - `role` must be `viewer`, `editor`, or `owner`
+  - grants a new membership or updates an existing membership without creating
+    duplicate rows
+  - returns the resulting membership with `201`
+  - requires inventory `owner` access in shared-service mode, or global
+    `admin`
+  - writes an audit event when the membership is created or role is changed
+- `PATCH /inventories/{inventory_slug}/members/{actor_id}`
+  - request body is JSON with replacement `role`
+  - updates an existing membership and returns `404 not_found` when the member
+    does not exist
+  - role must be `viewer`, `editor`, or `owner`
+  - demoting the last owner returns `409 conflict`
+  - requires inventory `owner` access in shared-service mode, or global
+    `admin`
+  - writes an audit event when the role changes
+- `DELETE /inventories/{inventory_slug}/members/{actor_id}`
+  - revokes an existing membership and returns the removed membership identity
+    plus previous role
+  - removing the last owner returns `409 conflict`
+  - requires inventory `owner` access in shared-service mode, or global
+    `admin`
+  - writes an audit event when a membership is revoked
+  - clients should URL-encode `actor_id` path values
 - `POST /imports/csv`
   - request body is `multipart/form-data`, not JSON
   - multipart field `file` is required
@@ -567,6 +601,10 @@ before the generic 500 envelope is returned.
   - `editor` can read and write a specific inventory
   - `owner` can read and write a specific inventory
   - global `admin` bypasses inventory membership checks
+- `owner` or global `admin` can list, grant, update, and revoke memberships
+  through the `/inventories/{inventory_slug}/members` API. The API preserves at
+  least one owner per inventory and audits grant, role-change, and revoke
+  actions.
 - `GET /inventories` returns only the inventories visible to the caller, while
   global `admin` can see all inventories.
 - `GET /cards/search`, `GET /cards/search/names`, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,6 +133,9 @@ shared service.
   - local inventory membership roles: `viewer`, `editor`, `owner`
 - Inventory listing, inventory reads, and inventory writes are now scoped by
   local memberships, with global `admin` as the bypass.
+- Inventory owners and global admins can manage local memberships over the API;
+  the backend preserves at least one owner and audits grant, role-change, and
+  revoke actions.
 - Inventory creation is available to authenticated users, and the creator
   becomes `owner` on the new inventory.
 - First-run shared-service onboarding can now use `POST /me/bootstrap` to

--- a/docs/backend_v1_contract.md
+++ b/docs/backend_v1_contract.md
@@ -55,6 +55,8 @@ The live backend contract consists of five primary tables:
   ledger.
 - Shared-service access is inventory-scoped through local memberships:
   `viewer`, `editor`, and `owner`.
+- Managed membership changes preserve at least one owner and write audit events
+  for grant, role-change, and revoke actions.
 - Quantity edits mutate `inventory_items` in place.
 - Per-edit inventory mutations are recorded in `inventory_audit_log`.
 - Operator safety comes from explicit commands, per-edit audit history, and

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -48,6 +48,7 @@ discussion.
 The current intended demo surface is:
 
 - inventory selector
+- inventory member management
 - card search
 - card-name search plus printing lookup
 - add card flow
@@ -69,6 +70,15 @@ Use this as the first-pass UI-to-endpoint map:
   Returns only the inventories visible to the current shared-service user.
   Inventory rows also include inventory metadata such as `default_location`,
   `default_tags`, `notes`, `acquisition_price`, and `acquisition_currency`.
+- Inventory member management:
+  - list members -> `GET /inventories/{inventory_slug}/members`
+  - grant member -> `POST /inventories/{inventory_slug}/members`
+  - update role -> `PATCH /inventories/{inventory_slug}/members/{actor_id}`
+  - revoke member -> `DELETE /inventories/{inventory_slug}/members/{actor_id}`
+  These routes are for inventory owners or global admins. Role values are
+  `viewer`, `editor`, and `owner`. The backend prevents removing or demoting
+  the last owner and audits grant, update, and revoke actions. Frontend code
+  should URL-encode `actor_id` when putting it in the path.
 - Card search -> `GET /cards/search`
 - Card search scope guidance:
   - omit `scope` for the ordinary mainline add flow
@@ -339,6 +349,9 @@ export default {
   - inventory lists are filtered to the current user
   - some inventory reads may return `403`
   - inventory writes may return `403` if the user is a viewer or non-member
+  - membership-management routes may return `403` unless the user is an owner
+    or global admin
+  - last-owner demotion/removal returns `409`
   - catalog search should not be treated as globally available to every
     authenticated user; it currently requires a user who can read at least one
     inventory, or a global `admin`

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -77,6 +77,8 @@ Effective behavior:
   inventory, or a global `admin`
 - inventory writes require `editor` or `owner` membership on that inventory,
   or a global `admin`
+- inventory membership management requires `owner` membership on that
+  inventory, or a global `admin`
 - inventory share-link management requires `owner` membership on that
   inventory, or a global `admin`
 - public share-link reads require possession of the signed share URL and do not
@@ -157,9 +159,41 @@ Useful environment settings:
 - `MTG_API_FORWARDED_ALLOW_IPS`
 - `MTG_API_AUTO_MIGRATE`
 
-## Membership Rollout Commands
+## Membership Management
 
-Use the inventory CLI to seed or repair memberships:
+Owner/admin membership management is available over the API:
+
+```text
+GET    /inventories/{inventory_slug}/members
+POST   /inventories/{inventory_slug}/members
+PATCH  /inventories/{inventory_slug}/members/{actor_id}
+DELETE /inventories/{inventory_slug}/members/{actor_id}
+```
+
+Grant or update requests use these role values:
+
+```json
+{
+  "actor_id": "alice@example.com",
+  "role": "viewer"
+}
+```
+
+`PATCH` requests send only the replacement role:
+
+```json
+{
+  "role": "editor"
+}
+```
+
+The API preserves at least one `owner` per inventory. To transfer ownership,
+grant another owner first, then demote or remove the old owner. Managed
+membership changes write inventory audit events with actor and request-id
+context.
+
+Use the inventory CLI when you need to seed or repair memberships outside an
+authenticated HTTP session:
 
 ```bash
 mtg-personal-inventory grant-inventory-membership \
@@ -183,8 +217,9 @@ Recommended first-live rollout:
 1. If the system is blank, let first users create inventories through the app
    so custom names are preserved and the creator becomes `owner`. Use
    `POST /me/bootstrap` only when the default `Collection` name is acceptable,
-   or grant `owner` memberships to existing inventories with the CLI.
-2. Grant `viewer` / `editor` memberships for the first cohort.
+   or grant `owner` memberships to existing inventories with the API or CLI.
+2. Grant `viewer` / `editor` memberships for the first cohort through the app,
+   API, or CLI.
 3. Verify visible inventories, allowed writes, and denied writes with at least
    two real user identities before launch.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -180,7 +180,9 @@ below through your proxy or API client.
 
 Check `GET /me/access-summary` first for each user. Then verify
 `GET /inventories`, catalog search availability, inventory reads, and denied
-writes match the table above.
+writes match the table above. Owner/admin membership-management checks can use
+`GET /inventories/{inventory_slug}/members` plus the matching POST/PATCH/DELETE
+member routes.
 
 ## Proxy-Backed Shared-Service Validation
 

--- a/src/mtg_source_stack/api/dependencies.py
+++ b/src/mtg_source_stack/api/dependencies.py
@@ -337,6 +337,27 @@ def require_inventory_share_management_access(
     raise AuthorizationError(f"Owner access to inventory '{inventory_slug}' is required to manage share links.")
 
 
+def require_inventory_membership_management_access(
+    settings: ApiSettings,
+    context: RequestContext,
+    *,
+    inventory_slug: str,
+) -> None:
+    inventory_slug = normalize_inventory_slug(inventory_slug)
+    if settings.runtime_mode != "shared_service":
+        return
+    from ..inventory.service import actor_can_manage_inventory_share
+
+    if actor_can_manage_inventory_share(
+        settings.db_path,
+        inventory_slug=inventory_slug,
+        actor_id=context.actor_id,
+        actor_roles=context.roles,
+    ):
+        return
+    raise AuthorizationError(f"Owner access to inventory '{inventory_slug}' is required to manage memberships.")
+
+
 def get_inventory_write_request_context(
     inventory_slug: str,
     request: "Request",

--- a/src/mtg_source_stack/api/request_models.py
+++ b/src/mtg_source_stack/api/request_models.py
@@ -18,6 +18,7 @@ from ..inventory.normalize import (
 
 
 FinishInput = Literal["normal", "nonfoil", "foil", "etched"]
+InventoryMembershipRoleInput = Literal["viewer", "editor", "owner"]
 
 _CANONICAL_FINISHES_TEXT = ", ".join(CANONICAL_FINISHES)
 _ACCEPTED_FINISH_INPUTS_TEXT = ", ".join(ACCEPTED_FINISH_INPUTS)
@@ -215,6 +216,15 @@ class InventoryCreateRequest(ApiBaseModel):
     notes: str | None = None
     acquisition_price: str | None = None
     acquisition_currency: str | None = None
+
+
+class InventoryMembershipGrantRequest(ApiBaseModel):
+    actor_id: str
+    role: InventoryMembershipRoleInput
+
+
+class InventoryMembershipUpdateRequest(ApiBaseModel):
+    role: InventoryMembershipRoleInput
 
 
 class DecklistImportResolutionRequest(ApiBaseModel):

--- a/src/mtg_source_stack/api/response_models.py
+++ b/src/mtg_source_stack/api/response_models.py
@@ -93,6 +93,20 @@ class InventoryCreateResponse(ApiBaseModel):
     acquisition_currency: str | None
 
 
+class InventoryMembershipResponse(ApiBaseModel):
+    inventory: str
+    actor_id: str
+    role: Literal["viewer", "editor", "owner"]
+    created_at: str
+    updated_at: str
+
+
+class InventoryMembershipRemovalResponse(ApiBaseModel):
+    inventory: str
+    actor_id: str
+    role: Literal["viewer", "editor", "owner"]
+
+
 class DefaultInventoryBootstrapResponse(ApiBaseModel):
     created: bool
     inventory: InventoryCreateResponse

--- a/src/mtg_source_stack/api/routes.py
+++ b/src/mtg_source_stack/api/routes.py
@@ -37,9 +37,11 @@ from ..inventory.service import (
     import_deck_url,
     list_card_printings_for_oracle,
     list_inventory_audit_events,
+    list_inventory_memberships,
     list_visible_inventories,
     list_owned_filtered,
     remove_card,
+    remove_inventory_membership,
     render_inventory_csv_export,
     revoke_inventory_share_link,
     rotate_inventory_share_link,
@@ -48,6 +50,7 @@ from ..inventory.service import (
     set_acquisition,
     set_condition,
     set_finish,
+    set_inventory_membership_role,
     set_location,
     set_notes,
     set_printing,
@@ -56,6 +59,7 @@ from ..inventory.service import (
     summarize_card_printings_for_oracle,
     summarize_actor_access,
     transfer_inventory_items,
+    update_inventory_membership_role,
 )
 from .dependencies import (
     ApiSettings,
@@ -65,6 +69,7 @@ from .dependencies import (
     get_inventory_scoped_read_request_context,
     get_authenticated_request_context,
     get_settings,
+    require_inventory_membership_management_access,
     require_inventory_share_management_access,
     require_inventory_write_access,
 )
@@ -78,6 +83,8 @@ from .request_models import (
     FinishInput,
     InventoryCreateRequest,
     InventoryDuplicateRequest,
+    InventoryMembershipGrantRequest,
+    InventoryMembershipUpdateRequest,
     InventoryTransferRequest,
     LANGUAGE_CODE_DESCRIPTION,
     PatchInventoryItemRequest,
@@ -102,6 +109,8 @@ from .response_models import (
     InventoryAuditEventResponse,
     InventoryCreateResponse,
     InventoryDuplicateResponse,
+    InventoryMembershipRemovalResponse,
+    InventoryMembershipResponse,
     InventoryShareLinkStatusResponse,
     InventoryShareLinkTokenResponse,
     InventoryItemPatchResponse,
@@ -382,6 +391,101 @@ def bootstrap_default_inventory(
             settings.db_path,
             actor_id=context.actor_id,
             actor_roles=context.roles,
+        )
+    )
+
+
+@router.get(
+    "/inventories/{inventory_slug}/members",
+    response_model=list[InventoryMembershipResponse],
+    responses=_error_responses(401, 403, 404, 503, 500),
+)
+def inventory_members_list(
+    inventory_slug: str,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
+) -> Any:
+    require_inventory_membership_management_access(settings, context, inventory_slug=inventory_slug)
+    return _serialize(
+        list_inventory_memberships(
+            settings.db_path,
+            inventory_slug=inventory_slug,
+        )
+    )
+
+
+@router.post(
+    "/inventories/{inventory_slug}/members",
+    status_code=status.HTTP_201_CREATED,
+    response_model=InventoryMembershipResponse,
+    responses=_error_responses(401, 403, 400, 404, 409, 503, 500),
+)
+def inventory_member_grant(
+    inventory_slug: str,
+    payload: InventoryMembershipGrantRequest,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
+) -> Any:
+    require_inventory_membership_management_access(settings, context, inventory_slug=inventory_slug)
+    return _serialize(
+        set_inventory_membership_role(
+            settings.db_path,
+            inventory_slug=inventory_slug,
+            member_actor_id=payload.actor_id,
+            role=payload.role,
+            actor_id=context.actor_id,
+            actor_type=context.actor_type,
+            request_id=context.request_id,
+        )
+    )
+
+
+@router.patch(
+    "/inventories/{inventory_slug}/members/{actor_id}",
+    response_model=InventoryMembershipResponse,
+    responses=_error_responses(401, 403, 400, 404, 409, 503, 500),
+)
+def inventory_member_update(
+    inventory_slug: str,
+    actor_id: str,
+    payload: InventoryMembershipUpdateRequest,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
+) -> Any:
+    require_inventory_membership_management_access(settings, context, inventory_slug=inventory_slug)
+    return _serialize(
+        update_inventory_membership_role(
+            settings.db_path,
+            inventory_slug=inventory_slug,
+            member_actor_id=actor_id,
+            role=payload.role,
+            actor_id=context.actor_id,
+            actor_type=context.actor_type,
+            request_id=context.request_id,
+        )
+    )
+
+
+@router.delete(
+    "/inventories/{inventory_slug}/members/{actor_id}",
+    response_model=InventoryMembershipRemovalResponse,
+    responses=_error_responses(401, 403, 404, 409, 503, 500),
+)
+def inventory_member_revoke(
+    inventory_slug: str,
+    actor_id: str,
+    settings: Annotated[ApiSettings, Depends(get_settings)],
+    context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
+) -> Any:
+    require_inventory_membership_management_access(settings, context, inventory_slug=inventory_slug)
+    return _serialize(
+        remove_inventory_membership(
+            settings.db_path,
+            inventory_slug=inventory_slug,
+            member_actor_id=actor_id,
+            actor_id=context.actor_id,
+            actor_type=context.actor_type,
+            request_id=context.request_id,
         )
     )
 

--- a/src/mtg_source_stack/inventory/access.py
+++ b/src/mtg_source_stack/inventory/access.py
@@ -8,7 +8,8 @@ from typing import Iterable
 
 from ..db.connection import connect
 from ..db.schema import require_current_schema
-from ..errors import NotFoundError, ValidationError
+from ..errors import ConflictError, NotFoundError, ValidationError
+from .audit import write_inventory_audit_event
 from .access_models import InventoryMembershipRemovalResult, InventoryMembershipRow
 from .normalize import normalize_inventory_slug
 
@@ -80,6 +81,48 @@ def _membership_row_from_identity(
     )
 
 
+def _membership_row_from_identity_or_none(
+    connection: sqlite3.Connection,
+    *,
+    inventory_id: int,
+    actor_id: str,
+) -> InventoryMembershipRow | None:
+    try:
+        return _membership_row_from_identity(
+            connection,
+            inventory_id=inventory_id,
+            actor_id=actor_id,
+        )
+    except NotFoundError:
+        return None
+
+
+def _owner_membership_count(connection: sqlite3.Connection, *, inventory_id: int) -> int:
+    row = connection.execute(
+        """
+        SELECT COUNT(*) AS owner_count
+        FROM inventory_memberships
+        WHERE inventory_id = ? AND role = 'owner'
+        """,
+        (inventory_id,),
+    ).fetchone()
+    return int(row["owner_count"])
+
+
+def _ensure_owner_membership_can_change(
+    connection: sqlite3.Connection,
+    *,
+    inventory_id: int,
+    inventory_slug: str,
+    current_role: str,
+    new_role: str | None,
+) -> None:
+    if current_role != "owner" or new_role == "owner":
+        return
+    if _owner_membership_count(connection, inventory_id=inventory_id) <= 1:
+        raise ConflictError(f"Inventory '{inventory_slug}' must retain at least one owner.")
+
+
 def grant_inventory_membership_with_connection(
     connection: sqlite3.Connection,
     *,
@@ -125,6 +168,201 @@ def grant_inventory_membership(
         )
         connection.commit()
         return membership
+
+
+def _write_membership_audit_event(
+    connection: sqlite3.Connection,
+    *,
+    inventory_slug: str,
+    action: str,
+    member_actor_id: str,
+    actor_type: str,
+    actor_id: str | None,
+    request_id: str | None,
+    previous_role: str | None,
+    role: str | None,
+) -> None:
+    metadata = {
+        "member_actor_id": member_actor_id,
+        "previous_role": previous_role,
+        "role": role,
+    }
+    write_inventory_audit_event(
+        connection,
+        inventory_slug=inventory_slug,
+        action=action,
+        metadata=metadata,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        request_id=request_id,
+    )
+
+
+def set_inventory_membership_role(
+    db_path: str | Path,
+    *,
+    inventory_slug: str,
+    member_actor_id: str,
+    role: str,
+    actor_id: str | None,
+    actor_type: str = "cli",
+    request_id: str | None = None,
+) -> InventoryMembershipRow:
+    normalized_actor_id = _normalize_actor_id(member_actor_id)
+    normalized_role = normalize_inventory_membership_role(role)
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        inventory = _inventory_row_from_slug(connection, inventory_slug)
+        inventory_id = int(inventory["id"])
+        existing = _membership_row_from_identity_or_none(
+            connection,
+            inventory_id=inventory_id,
+            actor_id=normalized_actor_id,
+        )
+        if existing is not None and existing.role == normalized_role:
+            return existing
+
+        if existing is not None:
+            _ensure_owner_membership_can_change(
+                connection,
+                inventory_id=inventory_id,
+                inventory_slug=inventory["slug"],
+                current_role=existing.role,
+                new_role=normalized_role,
+            )
+
+        membership = grant_inventory_membership_with_connection(
+            connection,
+            inventory_id=inventory_id,
+            actor_id=normalized_actor_id,
+            role=normalized_role,
+        )
+        _write_membership_audit_event(
+            connection,
+            inventory_slug=inventory["slug"],
+            action="grant_inventory_membership" if existing is None else "update_inventory_membership",
+            member_actor_id=normalized_actor_id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            request_id=request_id,
+            previous_role=existing.role if existing is not None else None,
+            role=membership.role,
+        )
+        connection.commit()
+        return membership
+
+
+def update_inventory_membership_role(
+    db_path: str | Path,
+    *,
+    inventory_slug: str,
+    member_actor_id: str,
+    role: str,
+    actor_id: str | None,
+    actor_type: str = "cli",
+    request_id: str | None = None,
+) -> InventoryMembershipRow:
+    normalized_actor_id = _normalize_actor_id(member_actor_id)
+    normalized_role = normalize_inventory_membership_role(role)
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        inventory = _inventory_row_from_slug(connection, inventory_slug)
+        inventory_id = int(inventory["id"])
+        existing = _membership_row_from_identity_or_none(
+            connection,
+            inventory_id=inventory_id,
+            actor_id=normalized_actor_id,
+        )
+        if existing is None:
+            raise NotFoundError(
+                f"No inventory membership found for actor '{normalized_actor_id}' in inventory '{inventory['slug']}'."
+            )
+        if existing.role == normalized_role:
+            return existing
+
+        _ensure_owner_membership_can_change(
+            connection,
+            inventory_id=inventory_id,
+            inventory_slug=inventory["slug"],
+            current_role=existing.role,
+            new_role=normalized_role,
+        )
+        membership = grant_inventory_membership_with_connection(
+            connection,
+            inventory_id=inventory_id,
+            actor_id=normalized_actor_id,
+            role=normalized_role,
+        )
+        _write_membership_audit_event(
+            connection,
+            inventory_slug=inventory["slug"],
+            action="update_inventory_membership",
+            member_actor_id=normalized_actor_id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            request_id=request_id,
+            previous_role=existing.role,
+            role=membership.role,
+        )
+        connection.commit()
+        return membership
+
+
+def remove_inventory_membership(
+    db_path: str | Path,
+    *,
+    inventory_slug: str,
+    member_actor_id: str,
+    actor_id: str | None,
+    actor_type: str = "cli",
+    request_id: str | None = None,
+) -> InventoryMembershipRemovalResult:
+    normalized_actor_id = _normalize_actor_id(member_actor_id)
+    db_file = require_current_schema(db_path)
+    with connect(db_file) as connection:
+        inventory = _inventory_row_from_slug(connection, inventory_slug)
+        inventory_id = int(inventory["id"])
+        existing = _membership_row_from_identity_or_none(
+            connection,
+            inventory_id=inventory_id,
+            actor_id=normalized_actor_id,
+        )
+        if existing is None:
+            raise NotFoundError(
+                f"No inventory membership found for actor '{normalized_actor_id}' in inventory '{inventory['slug']}'."
+            )
+
+        _ensure_owner_membership_can_change(
+            connection,
+            inventory_id=inventory_id,
+            inventory_slug=inventory["slug"],
+            current_role=existing.role,
+            new_role=None,
+        )
+        connection.execute(
+            """
+            DELETE FROM inventory_memberships
+            WHERE inventory_id = ? AND actor_id = ?
+            """,
+            (inventory_id, normalized_actor_id),
+        )
+        _write_membership_audit_event(
+            connection,
+            inventory_slug=inventory["slug"],
+            action="revoke_inventory_membership",
+            member_actor_id=normalized_actor_id,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            request_id=request_id,
+            previous_role=existing.role,
+            role=None,
+        )
+        connection.commit()
+        return InventoryMembershipRemovalResult(
+            inventory=inventory["slug"],
+            actor_id=normalized_actor_id,
+            role=existing.role,
+        )
 
 
 def list_inventory_memberships(

--- a/src/mtg_source_stack/inventory/service.py
+++ b/src/mtg_source_stack/inventory/service.py
@@ -15,7 +15,10 @@ from .access import (
     is_global_admin,
     list_inventory_memberships,
     normalize_inventory_membership_role,
+    remove_inventory_membership,
     revoke_inventory_membership,
+    set_inventory_membership_role,
+    update_inventory_membership_role,
 )
 from .audit import list_inventory_audit_events
 from .analysis import (

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -29,6 +29,8 @@ from mtg_source_stack.api.request_models import (
     DeckUrlImportRequest,
     InventoryCreateRequest,
     InventoryDuplicateRequest,
+    InventoryMembershipGrantRequest,
+    InventoryMembershipUpdateRequest,
     InventoryTransferRequest,
     PatchInventoryItemRequest,
     SetInventoryItemPrintingRequest,
@@ -49,6 +51,8 @@ from mtg_source_stack.api.response_models import (
     InventoryCreateResponse,
     InventoryDuplicateResponse,
     InventoryListRowResponse,
+    InventoryMembershipRemovalResponse,
+    InventoryMembershipResponse,
     InventoryShareLinkStatusResponse,
     InventoryShareLinkTokenResponse,
     InventoryTransferResponse,
@@ -302,6 +306,18 @@ class ApiContractTest(RepoSmokeTestCase):
                 "total_cards": 45,
             }
         ]
+        membership_payload = {
+            "inventory": "alice-collection",
+            "actor_id": "viewer@example.com",
+            "role": "viewer",
+            "created_at": "2026-04-21 12:00:00",
+            "updated_at": "2026-04-21 12:00:00",
+        }
+        membership_removal_payload = {
+            "inventory": "alice-collection",
+            "actor_id": "viewer@example.com",
+            "role": "viewer",
+        }
         share_link_status_payload = {
             "inventory": "alice-collection",
             "active": False,
@@ -486,6 +502,8 @@ class ApiContractTest(RepoSmokeTestCase):
         )
         inventory_create = InventoryCreateResponse.model_validate(inventory_create_payload)
         inventory_list = [InventoryListRowResponse.model_validate(row) for row in inventory_list_payload]
+        membership = InventoryMembershipResponse.model_validate(membership_payload)
+        membership_removal = InventoryMembershipRemovalResponse.model_validate(membership_removal_payload)
         share_link_status = InventoryShareLinkStatusResponse.model_validate(share_link_status_payload)
         share_link_token = InventoryShareLinkTokenResponse.model_validate(share_link_token_payload)
         public_share = PublicInventoryShareResponse.model_validate(public_share_payload)
@@ -519,6 +537,9 @@ class ApiContractTest(RepoSmokeTestCase):
         self.assertEqual("USD", inventory_create.acquisition_currency)
         self.assertEqual("Main trade stock", inventory_list[0].notes)
         self.assertEqual(45, inventory_list[0].total_cards)
+        self.assertEqual("viewer@example.com", membership.actor_id)
+        self.assertEqual("viewer", membership.role)
+        self.assertEqual("viewer@example.com", membership_removal.actor_id)
         self.assertFalse(share_link_status.active)
         self.assertEqual("/shared/inventories/public-token", share_link_token.public_path)
         self.assertEqual("Collection", public_share.inventory.display_name)
@@ -558,6 +579,10 @@ class ApiContractTest(RepoSmokeTestCase):
         self.assertIn("Canonical condition codes: M, NM, LP, MP, HP, DMG", add_properties["condition_code"]["description"])
         self.assertIsNone(add_properties["language_code"]["default"])
         self.assertIsNone(add_properties["location"]["default"])
+        membership_grant_schema = InventoryMembershipGrantRequest.model_json_schema()
+        membership_update_schema = InventoryMembershipUpdateRequest.model_json_schema()
+        self.assertEqual(["viewer", "editor", "owner"], membership_grant_schema["properties"]["role"]["enum"])
+        self.assertEqual(["viewer", "editor", "owner"], membership_update_schema["properties"]["role"]["enum"])
         self.assertIn("inherits the resolved printing language", add_properties["language_code"]["description"])
         self.assertEqual({"type": "string"}, add_properties["oracle_id"]["anyOf"][0])
         self.assertIn("prefers English mainstream-paper printings", add_properties["oracle_id"]["description"])

--- a/tests/test_inventory_access.py
+++ b/tests/test_inventory_access.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from mtg_source_stack.db.connection import connect
 from mtg_source_stack.db.schema import initialize_database
-from mtg_source_stack.errors import NotFoundError, ValidationError
+from mtg_source_stack.errors import ConflictError, NotFoundError, ValidationError
 from mtg_source_stack.inventory.service import (
     actor_can_manage_inventory_share,
     actor_can_read_any_inventory,
@@ -21,10 +21,14 @@ from mtg_source_stack.inventory.service import (
     create_inventory,
     ensure_default_inventory,
     grant_inventory_membership,
+    list_inventory_audit_events,
     list_inventory_memberships,
     list_visible_inventories,
     normalize_inventory_membership_role,
+    remove_inventory_membership,
     revoke_inventory_membership,
+    set_inventory_membership_role,
+    update_inventory_membership_role,
 )
 
 
@@ -126,6 +130,166 @@ class InventoryAccessTest(unittest.TestCase):
 
             memberships_after = list_inventory_memberships(db_path, inventory_slug="personal")
             self.assertEqual([("bob@example.com", "owner")], [(row.actor_id, row.role) for row in memberships_after])
+
+    def test_managed_membership_changes_are_audited_without_duplicate_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description=None,
+                actor_id="owner@example.com",
+            )
+
+            granted = set_inventory_membership_role(
+                db_path,
+                inventory_slug="personal",
+                member_actor_id="alice@example.com",
+                role="viewer",
+                actor_id="owner@example.com",
+                actor_type="api",
+                request_id="req-grant-member",
+            )
+            self.assertEqual("viewer", granted.role)
+
+            repeated = set_inventory_membership_role(
+                db_path,
+                inventory_slug="personal",
+                member_actor_id="alice@example.com",
+                role="viewer",
+                actor_id="owner@example.com",
+                actor_type="api",
+                request_id="req-noop-member",
+            )
+            self.assertEqual(granted, repeated)
+
+            updated = update_inventory_membership_role(
+                db_path,
+                inventory_slug="personal",
+                member_actor_id="alice@example.com",
+                role="editor",
+                actor_id="owner@example.com",
+                actor_type="api",
+                request_id="req-update-member",
+            )
+            self.assertEqual("editor", updated.role)
+
+            removed = remove_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                member_actor_id="alice@example.com",
+                actor_id="owner@example.com",
+                actor_type="api",
+                request_id="req-remove-member",
+            )
+            self.assertEqual("alice@example.com", removed.actor_id)
+            self.assertEqual("editor", removed.role)
+
+            memberships = list_inventory_memberships(db_path, inventory_slug="personal")
+            self.assertEqual([("owner@example.com", "owner")], [(row.actor_id, row.role) for row in memberships])
+            audit_rows = list_inventory_audit_events(db_path, inventory_slug="personal", limit=10)
+            self.assertEqual(
+                [
+                    "revoke_inventory_membership",
+                    "update_inventory_membership",
+                    "grant_inventory_membership",
+                ],
+                [row.action for row in audit_rows],
+            )
+            self.assertEqual(["req-remove-member", "req-update-member", "req-grant-member"], [row.request_id for row in audit_rows])
+            self.assertTrue(all(row.actor_id == "owner@example.com" for row in audit_rows))
+            self.assertEqual("alice@example.com", audit_rows[0].metadata["member_actor_id"])
+            self.assertEqual("editor", audit_rows[0].metadata["previous_role"])
+            self.assertIsNone(audit_rows[0].metadata["role"])
+            self.assertEqual("viewer", audit_rows[1].metadata["previous_role"])
+            self.assertEqual("editor", audit_rows[1].metadata["role"])
+
+    def test_managed_membership_update_requires_existing_member(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description=None,
+                actor_id="owner@example.com",
+            )
+
+            with self.assertRaisesRegex(NotFoundError, "No inventory membership found for actor 'missing@example.com'"):
+                update_inventory_membership_role(
+                    db_path,
+                    inventory_slug="personal",
+                    member_actor_id="missing@example.com",
+                    role="viewer",
+                    actor_id="owner@example.com",
+                )
+
+    def test_managed_membership_changes_preserve_at_least_one_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description=None,
+                actor_id="owner@example.com",
+            )
+
+            with self.assertRaisesRegex(ConflictError, "must retain at least one owner"):
+                update_inventory_membership_role(
+                    db_path,
+                    inventory_slug="personal",
+                    member_actor_id="owner@example.com",
+                    role="editor",
+                    actor_id="admin@example.com",
+                    actor_type="api",
+                    request_id="req-demote-last-owner",
+                )
+            with self.assertRaisesRegex(ConflictError, "must retain at least one owner"):
+                remove_inventory_membership(
+                    db_path,
+                    inventory_slug="personal",
+                    member_actor_id="owner@example.com",
+                    actor_id="admin@example.com",
+                    actor_type="api",
+                    request_id="req-remove-last-owner",
+                )
+
+            set_inventory_membership_role(
+                db_path,
+                inventory_slug="personal",
+                member_actor_id="second-owner@example.com",
+                role="owner",
+                actor_id="admin@example.com",
+                actor_type="api",
+                request_id="req-add-second-owner",
+            )
+            demoted = update_inventory_membership_role(
+                db_path,
+                inventory_slug="personal",
+                member_actor_id="owner@example.com",
+                role="editor",
+                actor_id="admin@example.com",
+                actor_type="api",
+                request_id="req-demote-owner",
+            )
+            self.assertEqual("editor", demoted.role)
+            removed = remove_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                member_actor_id="owner@example.com",
+                actor_id="admin@example.com",
+                actor_type="api",
+                request_id="req-remove-former-owner",
+            )
+            self.assertEqual("editor", removed.role)
+
+            memberships = list_inventory_memberships(db_path, inventory_slug="personal")
+            self.assertEqual([("second-owner@example.com", "owner")], [(row.actor_id, row.role) for row in memberships])
 
     def test_ensure_default_inventory_creates_owned_collection_once(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -21,6 +21,7 @@ from mtg_source_stack.inventory.service import (
     create_inventory,
     grant_inventory_membership,
     import_deck_url,
+    list_inventory_audit_events,
 )
 from tests.optional_dependencies import (
     WEB_TEST_SKIP_REASON,
@@ -116,6 +117,10 @@ class WebApiSchemaTest(unittest.TestCase):
                 ("/imports/deck-url", "post"),
                 ("/me/access-summary", "get"),
                 ("/me/bootstrap", "post"),
+                ("/inventories/{inventory_slug}/members", "get"),
+                ("/inventories/{inventory_slug}/members", "post"),
+                ("/inventories/{inventory_slug}/members/{actor_id}", "patch"),
+                ("/inventories/{inventory_slug}/members/{actor_id}", "delete"),
                 ("/inventories/{inventory_slug}/share-link", "get"),
                 ("/inventories/{inventory_slug}/share-link", "post"),
                 ("/inventories/{inventory_slug}/share-link/rotate", "post"),
@@ -148,6 +153,10 @@ class WebApiSchemaTest(unittest.TestCase):
                 ("/inventories/{inventory_slug}/export.csv", "get"),
                 ("/me/access-summary", "get"),
                 ("/me/bootstrap", "post"),
+                ("/inventories/{inventory_slug}/members", "get"),
+                ("/inventories/{inventory_slug}/members", "post"),
+                ("/inventories/{inventory_slug}/members/{actor_id}", "patch"),
+                ("/inventories/{inventory_slug}/members/{actor_id}", "delete"),
                 ("/inventories/{inventory_slug}/share-link", "get"),
                 ("/inventories/{inventory_slug}/share-link", "post"),
                 ("/inventories/{inventory_slug}/share-link/rotate", "post"),
@@ -429,6 +438,37 @@ class WebApiSchemaTest(unittest.TestCase):
             self.assertEqual(
                 [{"type": "string"}, {"type": "null"}],
                 access_summary_properties["default_inventory_slug"]["anyOf"],
+            )
+
+            members_schema = spec["paths"]["/inventories/{inventory_slug}/members"]["get"]["responses"]["200"][
+                "content"
+            ]["application/json"]["schema"]
+            self.assertEqual("array", members_schema["type"])
+            member_schema_name = self._schema_name_from_ref(members_schema["items"]["$ref"])
+            self.assertEqual("InventoryMembershipResponse", member_schema_name)
+            member_properties = components[member_schema_name]["properties"]
+            self.assertEqual(["viewer", "editor", "owner"], member_properties["role"]["enum"])
+            self.assertEqual("string", member_properties["actor_id"]["type"])
+            member_grant_request_schema = spec["paths"]["/inventories/{inventory_slug}/members"]["post"][
+                "requestBody"
+            ]["content"]["application/json"]["schema"]
+            self.assertEqual(
+                "InventoryMembershipGrantRequest",
+                self._schema_name_from_ref(member_grant_request_schema["$ref"]),
+            )
+            member_update_request_schema = spec["paths"]["/inventories/{inventory_slug}/members/{actor_id}"][
+                "patch"
+            ]["requestBody"]["content"]["application/json"]["schema"]
+            self.assertEqual(
+                "InventoryMembershipUpdateRequest",
+                self._schema_name_from_ref(member_update_request_schema["$ref"]),
+            )
+            member_remove_schema = spec["paths"]["/inventories/{inventory_slug}/members/{actor_id}"]["delete"][
+                "responses"
+            ]["200"]["content"]["application/json"]["schema"]
+            self.assertEqual(
+                "InventoryMembershipRemovalResponse",
+                self._schema_name_from_ref(member_remove_schema["$ref"]),
             )
             share_link_schema = spec["paths"]["/inventories/{inventory_slug}/share-link"]["post"]["responses"][
                 "201"
@@ -5021,6 +5061,187 @@ class WebApiTest(unittest.TestCase):
                 created = client.post("/inventories/admin-only/share-link", headers=admin_headers)
                 self.assertEqual(201, created.status_code)
                 self.assertEqual("admin-only", created.json()["inventory"])
+
+    def test_inventory_memberships_are_owner_managed_and_audited(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            initialize_database(db_path)
+            owner_headers = {"X-Authenticated-User": "owner-user"}
+            viewer_headers = {"X-Authenticated-User": "viewer-user"}
+            editor_headers = {"X-Authenticated-User": "editor-user"}
+            outsider_headers = {"X-Authenticated-User": "outsider-user"}
+
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description=None,
+                actor_id="owner-user",
+            )
+            grant_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                actor_id="viewer-user",
+                role="viewer",
+            )
+            grant_inventory_membership(
+                db_path,
+                inventory_slug="personal",
+                actor_id="editor-user",
+                role="editor",
+            )
+
+            with self._client(db_path, runtime_mode="shared_service", auto_migrate=False) as client:
+                anonymous_list = client.get("/inventories/personal/members")
+                self.assertEqual(401, anonymous_list.status_code)
+
+                viewer_list = client.get("/inventories/personal/members", headers=viewer_headers)
+                self.assertEqual(403, viewer_list.status_code)
+
+                editor_grant = client.post(
+                    "/inventories/personal/members",
+                    headers=editor_headers,
+                    json={"actor_id": "new-user", "role": "viewer"},
+                )
+                self.assertEqual(403, editor_grant.status_code)
+
+                outsider_list = client.get("/inventories/personal/members", headers=outsider_headers)
+                self.assertEqual(403, outsider_list.status_code)
+
+                listed = client.get("/inventories/personal/members", headers=owner_headers)
+                self.assertEqual(200, listed.status_code)
+                self.assertEqual(
+                    [
+                        ("editor-user", "editor"),
+                        ("owner-user", "owner"),
+                        ("viewer-user", "viewer"),
+                    ],
+                    [(row["actor_id"], row["role"]) for row in listed.json()],
+                )
+
+                invalid_role = client.post(
+                    "/inventories/personal/members",
+                    headers=owner_headers,
+                    json={"actor_id": "bad-user", "role": "manager"},
+                )
+                self.assertEqual(400, invalid_role.status_code)
+                self.assertEqual("validation_error", invalid_role.json()["error"]["code"])
+
+                granted = client.post(
+                    "/inventories/personal/members",
+                    headers={**owner_headers, "X-Request-Id": "req-grant-member"},
+                    json={"actor_id": "new-user", "role": "viewer"},
+                )
+                self.assertEqual(201, granted.status_code)
+                self.assertEqual("personal", granted.json()["inventory"])
+                self.assertEqual("new-user", granted.json()["actor_id"])
+                self.assertEqual("viewer", granted.json()["role"])
+                self.assertTrue(granted.json()["created_at"])
+                self.assertTrue(granted.json()["updated_at"])
+
+                duplicate_grant = client.post(
+                    "/inventories/personal/members",
+                    headers=owner_headers,
+                    json={"actor_id": "new-user", "role": "viewer"},
+                )
+                self.assertEqual(201, duplicate_grant.status_code)
+
+                updated = client.patch(
+                    "/inventories/personal/members/new-user",
+                    headers={**owner_headers, "X-Request-Id": "req-update-member"},
+                    json={"role": "editor"},
+                )
+                self.assertEqual(200, updated.status_code)
+                self.assertEqual("editor", updated.json()["role"])
+
+                missing_update = client.patch(
+                    "/inventories/personal/members/missing-user",
+                    headers=owner_headers,
+                    json={"role": "viewer"},
+                )
+                self.assertEqual(404, missing_update.status_code)
+
+                last_owner_demote = client.patch(
+                    "/inventories/personal/members/owner-user",
+                    headers=owner_headers,
+                    json={"role": "editor"},
+                )
+                self.assertEqual(409, last_owner_demote.status_code)
+                self.assertEqual("conflict", last_owner_demote.json()["error"]["code"])
+
+                last_owner_delete = client.delete(
+                    "/inventories/personal/members/owner-user",
+                    headers=owner_headers,
+                )
+                self.assertEqual(409, last_owner_delete.status_code)
+
+                removed = client.delete(
+                    "/inventories/personal/members/new-user",
+                    headers={**owner_headers, "X-Request-Id": "req-remove-member"},
+                )
+                self.assertEqual(200, removed.status_code)
+                self.assertEqual(
+                    {
+                        "inventory": "personal",
+                        "actor_id": "new-user",
+                        "role": "editor",
+                    },
+                    removed.json(),
+                )
+
+                final_list = client.get("/inventories/personal/members", headers=owner_headers)
+                self.assertEqual(200, final_list.status_code)
+                self.assertEqual(
+                    [
+                        ("editor-user", "editor"),
+                        ("owner-user", "owner"),
+                        ("viewer-user", "viewer"),
+                    ],
+                    [(row["actor_id"], row["role"]) for row in final_list.json()],
+                )
+
+            audit_rows = list_inventory_audit_events(db_path, inventory_slug="personal", limit=10)
+            self.assertEqual(
+                [
+                    "revoke_inventory_membership",
+                    "update_inventory_membership",
+                    "grant_inventory_membership",
+                ],
+                [row.action for row in audit_rows],
+            )
+            self.assertEqual(["req-remove-member", "req-update-member", "req-grant-member"], [row.request_id for row in audit_rows])
+            self.assertTrue(all(row.actor_type == "api" for row in audit_rows))
+            self.assertTrue(all(row.actor_id == "owner-user" for row in audit_rows))
+
+    def test_inventory_memberships_allow_global_admin_management(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            initialize_database(db_path)
+            admin_headers = {
+                "X-Authenticated-User": "admin-user",
+                "X-Authenticated-Roles": "admin",
+            }
+            create_inventory(
+                db_path,
+                slug="admin-only",
+                display_name="Admin Only",
+                description=None,
+            )
+
+            with self._client(db_path, runtime_mode="shared_service", auto_migrate=False) as client:
+                listed = client.get("/inventories/admin-only/members", headers=admin_headers)
+                self.assertEqual(200, listed.status_code)
+                self.assertEqual([], listed.json())
+
+                granted = client.post(
+                    "/inventories/admin-only/members",
+                    headers=admin_headers,
+                    json={"actor_id": "owner-user", "role": "owner"},
+                )
+                self.assertEqual(201, granted.status_code)
+                self.assertEqual("admin-only", granted.json()["inventory"])
+                self.assertEqual("owner-user", granted.json()["actor_id"])
+                self.assertEqual("owner", granted.json()["role"])
 
     def test_shared_service_mutating_requests_require_authenticated_actor_header(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- add owner/admin membership management routes for listing, granting, updating, and revoking inventory members
- add managed service helpers with audit events and last-owner guardrails
- publish typed request/response schemas, refresh OpenAPI, and update shared-service/frontend docs

## Validation
- PYTHONPATH=src .venv/bin/python -m unittest tests.test_api_contract.ApiContractTest.test_openapi_snapshot_matches_live_app -q
- PYTHONPATH=src .venv/bin/python -m unittest -q
- git diff --check

Closes #64