### PR TITLE
Improve leading-name search ranking

### DIFF
--- a/src/mtg_source_stack/inventory/catalog.py
+++ b/src/mtg_source_stack/inventory/catalog.py
@@ -437,7 +437,18 @@ def search_card_names(
         params: list[Any] = []
         if not exact and not include_substring_fallback and fts_query is not None:
             params.append(fts_query)
-        params.extend([trimmed_query, f"{trimmed_query}%"])
+        params.extend(
+            [
+                trimmed_query,
+                f"{trimmed_query}%",
+                trimmed_query,
+                trimmed_query,
+                trimmed_query,
+                trimmed_query,
+                trimmed_query,
+                f"{trimmed_query}%",
+            ]
+        )
         params.extend(match_params)
         params.append(limit)
 
@@ -455,6 +466,17 @@ def search_card_names(
                         WHEN search_match.scryfall_id IS NOT NULL THEN 2
                         ELSE 3
                     END AS match_order,
+                    CASE
+                        WHEN LOWER(mtg_cards.name) = LOWER(?) THEN 0
+                        WHEN LOWER(SUBSTR(mtg_cards.name, 1, LENGTH(?))) = LOWER(?)
+                             AND LENGTH(mtg_cards.name) > LENGTH(?)
+                             AND SUBSTR(mtg_cards.name, LENGTH(?) + 1, 1) IN (
+                                 ',', ':', ';', '!', '?', '.', '-', '/', '(', '['
+                             ) THEN 1
+                        WHEN LOWER(mtg_cards.name) LIKE LOWER(?) THEN 2
+                        WHEN search_match.scryfall_id IS NOT NULL THEN 3
+                        ELSE 4
+                    END AS name_relevance_order,
                     COALESCE(search_match.search_rank, 0) AS search_rank,
                     mtg_cards.edhrec_rank
                 FROM mtg_cards
@@ -465,6 +487,7 @@ def search_card_names(
                 SELECT
                     oracle_id,
                     MIN(match_order) AS match_order,
+                    MIN(name_relevance_order) AS name_relevance_order,
                     MIN(CASE WHEN edhrec_rank IS NULL THEN 1 ELSE 0 END) AS edhrec_rank_missing,
                     MIN(edhrec_rank) AS best_edhrec_rank,
                     MIN(search_rank) AS best_search_rank,
@@ -477,6 +500,7 @@ def search_card_names(
                 SELECT
                     oracle_id,
                     match_order,
+                    name_relevance_order,
                     edhrec_rank_missing,
                     best_edhrec_rank,
                     best_search_rank,
@@ -484,6 +508,7 @@ def search_card_names(
                     ROW_NUMBER() OVER (
                         ORDER BY
                             match_order,
+                            name_relevance_order,
                             edhrec_rank_missing,
                             COALESCE(best_edhrec_rank, 2147483647),
                             best_search_rank,
@@ -495,6 +520,7 @@ def search_card_names(
                     SELECT
                         oracle_id,
                         match_order,
+                        name_relevance_order,
                         edhrec_rank_missing,
                         best_edhrec_rank,
                         best_search_rank,
@@ -508,6 +534,7 @@ def search_card_names(
                 SELECT
                     oracle_id,
                     match_order,
+                    name_relevance_order,
                     edhrec_rank_missing,
                     best_edhrec_rank,
                     best_search_rank,

--- a/tests/test_inventory_service.py
+++ b/tests/test_inventory_service.py
@@ -1654,6 +1654,52 @@ class InventoryServiceTest(RepoSmokeTestCase):
             self.assertEqual(4, result.total_count)
             self.assertFalse(result.has_more)
 
+    def test_search_card_names_prefers_exact_leading_name_boundary_before_popularity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="cloud-key",
+                oracle_id="cloud-key-oracle",
+                name="Cloud Key",
+                collector_number="61",
+                edhrec_rank=657,
+                is_default_add_searchable=1,
+            )
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="cloud-midgar-mercenary",
+                oracle_id="cloud-midgar-mercenary-oracle",
+                name="Cloud, Midgar Mercenary",
+                collector_number="62",
+                edhrec_rank=2010,
+                is_default_add_searchable=1,
+            )
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="cloud-manta",
+                oracle_id="cloud-manta-oracle",
+                name="Cloud Manta",
+                collector_number="63",
+                edhrec_rank=100,
+                is_default_add_searchable=1,
+            )
+
+            result = search_card_names(db_path, query="cloud", exact=False, limit=10)
+
+            self.assertEqual(
+                [
+                    "Cloud, Midgar Mercenary",
+                    "Cloud Manta",
+                    "Cloud Key",
+                ],
+                [row.name for row in result.items],
+            )
+            self.assertEqual(3, result.total_count)
+            self.assertFalse(result.has_more)
+
     def test_search_card_names_scope_all_includes_auxiliary_group_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "collection.db"

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -3296,6 +3296,51 @@ class WebApiTest(unittest.TestCase):
                     [row["name"] for row in response.json()["items"]],
                 )
 
+    def test_demo_api_grouped_name_search_prefers_exact_leading_name_boundary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            with self._client(db_path) as client:
+                self._insert_catalog_card(
+                    db_path,
+                    scryfall_id="api-cloud-key",
+                    oracle_id="api-cloud-key-oracle",
+                    name="Cloud Key",
+                    collector_number="81",
+                    edhrec_rank=657,
+                    is_default_add_searchable=1,
+                )
+                self._insert_catalog_card(
+                    db_path,
+                    scryfall_id="api-cloud-midgar-mercenary",
+                    oracle_id="api-cloud-midgar-mercenary-oracle",
+                    name="Cloud, Midgar Mercenary",
+                    collector_number="82",
+                    edhrec_rank=2010,
+                    is_default_add_searchable=1,
+                )
+                self._insert_catalog_card(
+                    db_path,
+                    scryfall_id="api-cloud-manta",
+                    oracle_id="api-cloud-manta-oracle",
+                    name="Cloud Manta",
+                    collector_number="83",
+                    edhrec_rank=100,
+                    is_default_add_searchable=1,
+                )
+
+                response = client.get("/cards/search/names", params={"query": "cloud"})
+                self.assertEqual(200, response.status_code)
+                self.assertEqual(3, response.json()["total_count"])
+                self.assertFalse(response.json()["has_more"])
+                self.assertEqual(
+                    [
+                        "Cloud, Midgar Mercenary",
+                        "Cloud Manta",
+                        "Cloud Key",
+                    ],
+                    [row["name"] for row in response.json()["items"]],
+                )
+
     def test_demo_api_bulk_tag_mutation_updates_multiple_rows_and_writes_grouped_audit(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "api.db"


### PR DESCRIPTION
Closes #65.\n\nSummary:\n- Add a grouped-name relevance tier before EDHREC popularity.\n- Keep exact full-name matches first.\n- Rank leading punctuation-boundary matches, such as query=cloud matching Cloud, Midgar Mercenary, ahead of ordinary leading-prefix matches like Cloud Key.\n- Preserve EDHREC as the tie-breaker within the same textual relevance bucket.\n\nCoverage:\n- Add service regression for cloud ordering despite Cloud Key having a better EDHREC rank.\n- Add API-level grouped-name regression for the same behavior.\n- Existing popularity-within-prefix-bucket tests continue to pass.\n\nVerification:\n- git diff --check\n- PYTHONPATH=src .venv/bin/python -m unittest -q\n- Full suite passed: 437 tests, 91 skipped.