### PR TITLE
Improve check-search-index full-catalog performance

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -339,6 +339,21 @@ PYTHONPATH=src .venv/bin/python -m mtg_source_stack.mvp_importer check-search-in
 PYTHONPATH=src .venv/bin/python -m mtg_source_stack.mvp_importer rebuild-search-index --db var/db/mtg_mvp.db
 ```
 
+`check-search-index` is an exhaustive drift check. It verifies missing FTS
+rows, orphan FTS rows, duplicate FTS rows, and searchable-field mismatches
+between `mtg_cards` and `mtg_cards_fts`. The command materializes an indexed
+temporary FTS snapshot before comparing, prints phase progress before each
+potentially long step, and reports per-phase timings. Exit behavior is
+unchanged: healthy catalogs exit `0`; detected drift exits `1`.
+
+Full-catalog validation snapshot from `2026-04-23`:
+
+- input cache: Scryfall `default_cards`, MTGJSON `AllIdentifiers`, MTGJSON
+  `AllPricesToday`
+- imported rows: `113,726` `mtg_cards`, `113,726` `mtg_cards_fts`, `118,615`
+  `mtgjson_card_links`, `554,798` `price_snapshots`
+- full `check-search-index` result: healthy in `0.507s`
+
 Sync run history:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ mtg-mvp-importer list-sync-runs --db "var/db/mtg_mvp.db"
 mtg-mvp-importer show-sync-run --db "var/db/mtg_mvp.db" --run-id 42
 ```
 
+`check-search-index` is safe to run as a periodic exhaustive validation check.
+It prints phase progress, reports per-phase timings, exits `0` when healthy,
+and exits `1` when drift is detected. On `2026-04-23`, a fresh full-catalog
+validation database built from cached Scryfall `default_cards`, MTGJSON
+`AllIdentifiers`, and MTGJSON `AllPricesToday` contained `113,726` catalog
+rows and completed `check-search-index` healthy in `0.507s`.
+
 Important upgrade note:
 
 - migration `0008` adds the durable catalog-classification fields used by the

--- a/src/mtg_source_stack/cli/importer.py
+++ b/src/mtg_source_stack/cli/importer.py
@@ -351,6 +351,10 @@ def _print_search_index_section(
     print_table(rows, columns)
 
 
+def _print_search_index_progress(_phase: str, label: str) -> None:
+    print(f"check-search-index: {label}", flush=True)
+
+
 def _print_search_index_check_result(result: Any) -> None:
     status = "healthy" if result.is_healthy else "drift_detected"
     print("check-search-index completed")
@@ -362,6 +366,11 @@ def _print_search_index_check_result(result: Any) -> None:
         f"duplicate_rows={result.duplicate_count} "
         f"mismatched_rows={result.mismatch_count}"
     )
+    if result.phase_timings:
+        print("timings:")
+        for phase_timing in result.phase_timings:
+            print(f"  {phase_timing.label}: {phase_timing.elapsed_seconds:.3f}s")
+        print(f"  total: {result.total_elapsed_seconds:.3f}s")
     _print_search_index_section(
         "missing rows preview",
         result.missing_rows,
@@ -790,7 +799,11 @@ def main() -> None:
 
         if args.command == "check-search-index":
             require_current_schema(args.db)
-            result = check_card_search_index(args.db, limit=args.limit)
+            result = check_card_search_index(
+                args.db,
+                limit=args.limit,
+                progress_callback=_print_search_index_progress,
+            )
             _print_search_index_check_result(result)
             if not result.is_healthy:
                 raise SystemExit(1)
@@ -806,7 +819,11 @@ def main() -> None:
             snapshot = ensure_snapshot()
             print(f"snapshot: {snapshot['snapshot_path']}")
             rebuild_result = rebuild_card_search_index(args.db)
-            check_result = check_card_search_index(args.db, limit=args.limit)
+            check_result = check_card_search_index(
+                args.db,
+                limit=args.limit,
+                progress_callback=_print_search_index_progress,
+            )
             print("rebuild-search-index completed")
             print(f"previous_rows: {rebuild_result.previous_row_count}")
             print(f"source_rows: {rebuild_result.source_row_count}")

--- a/src/mtg_source_stack/db/search_index.py
+++ b/src/mtg_source_stack/db/search_index.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, TypeVar
 
 from .connection import connect
+
+T = TypeVar("T")
 
 
 SEARCH_INDEX_COLUMNS: tuple[str, ...] = (
@@ -15,6 +18,21 @@ SEARCH_INDEX_COLUMNS: tuple[str, ...] = (
     "collector_number",
     "lang",
 )
+SEARCH_INDEX_CHECK_PHASE_LABELS: dict[str, str] = {
+    "prepare_indexed_snapshot": "preparing indexed FTS snapshot",
+    "missing_rows": "checking missing rows",
+    "orphan_rows": "checking orphan rows",
+    "duplicate_rows": "checking duplicate rows",
+    "mismatched_rows": "checking field mismatches",
+}
+SearchIndexProgressCallback = Callable[[str, str], None]
+
+
+@dataclass(frozen=True, slots=True)
+class SearchIndexPhaseTiming:
+    phase: str
+    label: str
+    elapsed_seconds: float
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,6 +45,8 @@ class SearchIndexCheckResult:
     orphan_rows: list[dict[str, Any]]
     duplicate_rows: list[dict[str, Any]]
     mismatch_rows: list[dict[str, Any]]
+    phase_timings: tuple[SearchIndexPhaseTiming, ...] = ()
+    total_elapsed_seconds: float = 0.0
 
     @property
     def is_healthy(self) -> bool:
@@ -73,163 +93,237 @@ def _rows_to_dicts(rows: list[Any]) -> list[dict[str, Any]]:
     return [dict(row) for row in rows]
 
 
-def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIndexCheckResult:
+def _run_check_phase(
+    phase: str,
+    *,
+    phase_timings: list[SearchIndexPhaseTiming],
+    progress_callback: SearchIndexProgressCallback | None,
+    action: Callable[[], T],
+) -> T:
+    label = SEARCH_INDEX_CHECK_PHASE_LABELS[phase]
+    if progress_callback is not None:
+        progress_callback(phase, label)
+    started = time.perf_counter()
+    try:
+        return action()
+    finally:
+        phase_timings.append(
+            SearchIndexPhaseTiming(
+                phase=phase,
+                label=label,
+                elapsed_seconds=time.perf_counter() - started,
+            )
+        )
+
+
+def check_card_search_index(
+    db_path: str | Path,
+    *,
+    limit: int = 10,
+    progress_callback: SearchIndexProgressCallback | None = None,
+) -> SearchIndexCheckResult:
     _validate_limit(limit)
 
+    overall_started = time.perf_counter()
+    phase_timings: list[SearchIndexPhaseTiming] = []
     with connect(db_path) as connection:
-        connection.execute("DROP TABLE IF EXISTS temp.search_index_check_fts")
-        connection.execute(
-            """
-            CREATE TEMP TABLE search_index_check_fts AS
-            SELECT
-                rowid AS fts_rowid,
-                scryfall_id,
-                name,
-                set_code,
-                set_name,
-                collector_number,
-                lang
-            FROM mtg_cards_fts
-            """
-        )
-        connection.execute(
-            """
-            CREATE INDEX temp.search_index_check_fts_scryfall_id_idx
-            ON search_index_check_fts (scryfall_id)
-            """
-        )
-
-        missing_count = int(
+        def _prepare_indexed_snapshot() -> None:
+            connection.execute("DROP TABLE IF EXISTS temp.search_index_check_fts")
             connection.execute(
                 """
-                SELECT COUNT(*)
-                FROM mtg_cards AS cards
-                LEFT JOIN search_index_check_fts AS fts
-                    ON fts.scryfall_id = cards.scryfall_id
-                WHERE fts.scryfall_id IS NULL
-                """
-            ).fetchone()[0]
-        )
-        missing_rows = _rows_to_dicts(
-            connection.execute(
-                """
+                CREATE TEMP TABLE search_index_check_fts AS
                 SELECT
-                    cards.scryfall_id,
-                    cards.name,
-                    cards.set_code,
-                    cards.collector_number,
-                    cards.lang
-                FROM mtg_cards AS cards
-                LEFT JOIN search_index_check_fts AS fts
-                    ON fts.scryfall_id = cards.scryfall_id
-                WHERE fts.scryfall_id IS NULL
-                ORDER BY cards.scryfall_id
-                LIMIT ?
-                """,
-                (limit,),
-            ).fetchall()
+                    rowid AS fts_rowid,
+                    scryfall_id,
+                    name,
+                    set_code,
+                    set_name,
+                    collector_number,
+                    lang
+                FROM mtg_cards_fts
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX temp.search_index_check_fts_scryfall_id_idx
+                ON search_index_check_fts (scryfall_id)
+                """
+            )
+
+        _run_check_phase(
+            "prepare_indexed_snapshot",
+            phase_timings=phase_timings,
+            progress_callback=progress_callback,
+            action=_prepare_indexed_snapshot,
         )
 
-        orphan_count = int(
-            connection.execute(
-                """
-                SELECT COUNT(*)
-                FROM search_index_check_fts AS fts
-                LEFT JOIN mtg_cards AS cards
-                    ON cards.scryfall_id = fts.scryfall_id
-                WHERE cards.scryfall_id IS NULL
-                """
-            ).fetchone()[0]
-        )
-        orphan_rows = _rows_to_dicts(
-            connection.execute(
-                """
-                SELECT
-                    fts.scryfall_id,
-                    fts.name,
-                    fts.set_code,
-                    fts.collector_number,
-                    fts.lang
-                FROM search_index_check_fts AS fts
-                LEFT JOIN mtg_cards AS cards
-                    ON cards.scryfall_id = fts.scryfall_id
-                WHERE cards.scryfall_id IS NULL
-                ORDER BY fts.scryfall_id
-                LIMIT ?
-                """,
-                (limit,),
-            ).fetchall()
+        def _check_missing_rows() -> tuple[int, list[dict[str, Any]]]:
+            missing_count = int(
+                connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM mtg_cards AS cards
+                    LEFT JOIN search_index_check_fts AS fts
+                        ON fts.scryfall_id = cards.scryfall_id
+                    WHERE fts.scryfall_id IS NULL
+                    """
+                ).fetchone()[0]
+            )
+            missing_rows = _rows_to_dicts(
+                connection.execute(
+                    """
+                    SELECT
+                        cards.scryfall_id,
+                        cards.name,
+                        cards.set_code,
+                        cards.collector_number,
+                        cards.lang
+                    FROM mtg_cards AS cards
+                    LEFT JOIN search_index_check_fts AS fts
+                        ON fts.scryfall_id = cards.scryfall_id
+                    WHERE fts.scryfall_id IS NULL
+                    ORDER BY cards.scryfall_id
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+            )
+            return missing_count, missing_rows
+
+        missing_count, missing_rows = _run_check_phase(
+            "missing_rows",
+            phase_timings=phase_timings,
+            progress_callback=progress_callback,
+            action=_check_missing_rows,
         )
 
-        duplicate_count = int(
-            connection.execute(
-                """
-                SELECT COUNT(*)
-                FROM (
-                    SELECT fts.scryfall_id
+        def _check_orphan_rows() -> tuple[int, list[dict[str, Any]]]:
+            orphan_count = int(
+                connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM search_index_check_fts AS fts
+                    LEFT JOIN mtg_cards AS cards
+                        ON cards.scryfall_id = fts.scryfall_id
+                    WHERE cards.scryfall_id IS NULL
+                    """
+                ).fetchone()[0]
+            )
+            orphan_rows = _rows_to_dicts(
+                connection.execute(
+                    """
+                    SELECT
+                        fts.scryfall_id,
+                        fts.name,
+                        fts.set_code,
+                        fts.collector_number,
+                        fts.lang
+                    FROM search_index_check_fts AS fts
+                    LEFT JOIN mtg_cards AS cards
+                        ON cards.scryfall_id = fts.scryfall_id
+                    WHERE cards.scryfall_id IS NULL
+                    ORDER BY fts.scryfall_id
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+            )
+            return orphan_count, orphan_rows
+
+        orphan_count, orphan_rows = _run_check_phase(
+            "orphan_rows",
+            phase_timings=phase_timings,
+            progress_callback=progress_callback,
+            action=_check_orphan_rows,
+        )
+
+        def _check_duplicate_rows() -> tuple[int, list[dict[str, Any]]]:
+            duplicate_count = int(
+                connection.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM (
+                        SELECT fts.scryfall_id
+                        FROM search_index_check_fts AS fts
+                        GROUP BY fts.scryfall_id
+                        HAVING COUNT(*) > 1
+                    )
+                    """
+                ).fetchone()[0]
+            )
+            duplicate_rows = _rows_to_dicts(
+                connection.execute(
+                    """
+                    SELECT
+                        fts.scryfall_id,
+                        COUNT(*) AS row_count
                     FROM search_index_check_fts AS fts
                     GROUP BY fts.scryfall_id
                     HAVING COUNT(*) > 1
-                )
-                """
-            ).fetchone()[0]
-        )
-        duplicate_rows = _rows_to_dicts(
-            connection.execute(
-                """
-                SELECT
-                    fts.scryfall_id,
-                    COUNT(*) AS row_count
-                FROM search_index_check_fts AS fts
-                GROUP BY fts.scryfall_id
-                HAVING COUNT(*) > 1
-                ORDER BY row_count DESC, fts.scryfall_id
-                LIMIT ?
-                """,
-                (limit,),
-            ).fetchall()
+                    ORDER BY row_count DESC, fts.scryfall_id
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+            )
+            return duplicate_count, duplicate_rows
+
+        duplicate_count, duplicate_rows = _run_check_phase(
+            "duplicate_rows",
+            phase_timings=phase_timings,
+            progress_callback=progress_callback,
+            action=_check_duplicate_rows,
         )
 
-        mismatch_query = """
-            SELECT
-                cards.scryfall_id,
-                cards.name AS card_name,
-                cards.set_code AS card_set_code,
-                cards.set_name AS card_set_name,
-                cards.collector_number AS card_collector_number,
-                cards.lang AS card_lang,
-                fts.name AS fts_name,
-                fts.set_code AS fts_set_code,
-                fts.set_name AS fts_set_name,
-                fts.collector_number AS fts_collector_number,
-                fts.lang AS fts_lang
-            FROM mtg_cards AS cards
-            JOIN search_index_check_fts AS fts
-                ON fts.scryfall_id = cards.scryfall_id
-            WHERE
-                cards.name IS NOT fts.name
-                OR cards.set_code IS NOT fts.set_code
-                OR cards.set_name IS NOT fts.set_name
-                OR cards.collector_number IS NOT fts.collector_number
-                OR cards.lang IS NOT fts.lang
-            ORDER BY cards.scryfall_id, fts.fts_rowid
-        """
-        mismatch_count = int(
-            connection.execute(
-                f"""
-                SELECT COUNT(*)
-                FROM ({mismatch_query})
-                """
-            ).fetchone()[0]
-        )
-        raw_mismatch_rows = _rows_to_dicts(
-            connection.execute(
-                f"""
-                {mismatch_query}
-                LIMIT ?
-                """,
-                (limit,),
-            ).fetchall()
+        def _check_mismatched_rows() -> tuple[int, list[dict[str, Any]]]:
+            mismatch_query = """
+                SELECT
+                    cards.scryfall_id,
+                    cards.name AS card_name,
+                    cards.set_code AS card_set_code,
+                    cards.set_name AS card_set_name,
+                    cards.collector_number AS card_collector_number,
+                    cards.lang AS card_lang,
+                    fts.name AS fts_name,
+                    fts.set_code AS fts_set_code,
+                    fts.set_name AS fts_set_name,
+                    fts.collector_number AS fts_collector_number,
+                    fts.lang AS fts_lang
+                FROM mtg_cards AS cards
+                JOIN search_index_check_fts AS fts
+                    ON fts.scryfall_id = cards.scryfall_id
+                WHERE
+                    cards.name IS NOT fts.name
+                    OR cards.set_code IS NOT fts.set_code
+                    OR cards.set_name IS NOT fts.set_name
+                    OR cards.collector_number IS NOT fts.collector_number
+                    OR cards.lang IS NOT fts.lang
+                ORDER BY cards.scryfall_id, fts.fts_rowid
+            """
+            mismatch_count = int(
+                connection.execute(
+                    f"""
+                    SELECT COUNT(*)
+                    FROM ({mismatch_query})
+                    """
+                ).fetchone()[0]
+            )
+            raw_mismatch_rows = _rows_to_dicts(
+                connection.execute(
+                    f"""
+                    {mismatch_query}
+                    LIMIT ?
+                    """,
+                    (limit,),
+                ).fetchall()
+            )
+            return mismatch_count, raw_mismatch_rows
+
+        mismatch_count, raw_mismatch_rows = _run_check_phase(
+            "mismatched_rows",
+            phase_timings=phase_timings,
+            progress_callback=progress_callback,
+            action=_check_mismatched_rows,
         )
 
     mismatch_rows: list[dict[str, Any]] = []
@@ -267,6 +361,8 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
         orphan_rows=orphan_rows,
         duplicate_rows=duplicate_rows,
         mismatch_rows=mismatch_rows,
+        phase_timings=tuple(phase_timings),
+        total_elapsed_seconds=time.perf_counter() - overall_started,
     )
 
 

--- a/src/mtg_source_stack/db/search_index.py
+++ b/src/mtg_source_stack/db/search_index.py
@@ -77,12 +77,34 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
     _validate_limit(limit)
 
     with connect(db_path) as connection:
+        connection.execute("DROP TABLE IF EXISTS temp.search_index_check_fts")
+        connection.execute(
+            """
+            CREATE TEMP TABLE search_index_check_fts AS
+            SELECT
+                rowid AS fts_rowid,
+                scryfall_id,
+                name,
+                set_code,
+                set_name,
+                collector_number,
+                lang
+            FROM mtg_cards_fts
+            """
+        )
+        connection.execute(
+            """
+            CREATE INDEX temp.search_index_check_fts_scryfall_id_idx
+            ON search_index_check_fts (scryfall_id)
+            """
+        )
+
         missing_count = int(
             connection.execute(
                 """
                 SELECT COUNT(*)
                 FROM mtg_cards AS cards
-                LEFT JOIN mtg_cards_fts AS fts
+                LEFT JOIN search_index_check_fts AS fts
                     ON fts.scryfall_id = cards.scryfall_id
                 WHERE fts.scryfall_id IS NULL
                 """
@@ -98,7 +120,7 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
                     cards.collector_number,
                     cards.lang
                 FROM mtg_cards AS cards
-                LEFT JOIN mtg_cards_fts AS fts
+                LEFT JOIN search_index_check_fts AS fts
                     ON fts.scryfall_id = cards.scryfall_id
                 WHERE fts.scryfall_id IS NULL
                 ORDER BY cards.scryfall_id
@@ -112,7 +134,7 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
             connection.execute(
                 """
                 SELECT COUNT(*)
-                FROM mtg_cards_fts AS fts
+                FROM search_index_check_fts AS fts
                 LEFT JOIN mtg_cards AS cards
                     ON cards.scryfall_id = fts.scryfall_id
                 WHERE cards.scryfall_id IS NULL
@@ -128,7 +150,7 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
                     fts.set_code,
                     fts.collector_number,
                     fts.lang
-                FROM mtg_cards_fts AS fts
+                FROM search_index_check_fts AS fts
                 LEFT JOIN mtg_cards AS cards
                     ON cards.scryfall_id = fts.scryfall_id
                 WHERE cards.scryfall_id IS NULL
@@ -145,7 +167,7 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
                 SELECT COUNT(*)
                 FROM (
                     SELECT fts.scryfall_id
-                    FROM mtg_cards_fts AS fts
+                    FROM search_index_check_fts AS fts
                     GROUP BY fts.scryfall_id
                     HAVING COUNT(*) > 1
                 )
@@ -158,7 +180,7 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
                 SELECT
                     fts.scryfall_id,
                     COUNT(*) AS row_count
-                FROM mtg_cards_fts AS fts
+                FROM search_index_check_fts AS fts
                 GROUP BY fts.scryfall_id
                 HAVING COUNT(*) > 1
                 ORDER BY row_count DESC, fts.scryfall_id
@@ -182,7 +204,7 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
                 fts.collector_number AS fts_collector_number,
                 fts.lang AS fts_lang
             FROM mtg_cards AS cards
-            JOIN mtg_cards_fts AS fts
+            JOIN search_index_check_fts AS fts
                 ON fts.scryfall_id = cards.scryfall_id
             WHERE
                 cards.name IS NOT fts.name
@@ -190,7 +212,7 @@ def check_card_search_index(db_path: str | Path, *, limit: int = 10) -> SearchIn
                 OR cards.set_name IS NOT fts.set_name
                 OR cards.collector_number IS NOT fts.collector_number
                 OR cards.lang IS NOT fts.lang
-            ORDER BY cards.scryfall_id, fts.rowid
+            ORDER BY cards.scryfall_id, fts.fts_rowid
         """
         mismatch_count = int(
             connection.execute(

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -2741,9 +2741,20 @@ class ImporterTest(RepoSmokeTestCase):
                 str(db_path),
             )
 
+            self.assertIn("check-search-index: preparing indexed FTS snapshot", output)
+            self.assertIn("check-search-index: checking missing rows", output)
+            self.assertIn("check-search-index: checking orphan rows", output)
+            self.assertIn("check-search-index: checking duplicate rows", output)
+            self.assertIn("check-search-index: checking field mismatches", output)
+            self.assertLess(
+                output.index("check-search-index: preparing indexed FTS snapshot"),
+                output.index("check-search-index completed"),
+            )
             self.assertIn("check-search-index completed", output)
             self.assertIn("status: healthy", output)
             self.assertIn("missing_rows=0 orphan_rows=0 duplicate_rows=0 mismatched_rows=0", output)
+            self.assertIn("timings:", output)
+            self.assertIn("  total:", output)
 
     def test_check_search_index_detects_missing_orphan_duplicate_and_mismatched_rows(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2871,6 +2882,19 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertEqual("search-service-duplicate-1", result.duplicate_rows[0]["scryfall_id"])
             self.assertEqual("search-service-mismatch-1", result.mismatch_rows[0]["scryfall_id"])
             self.assertIn("collector_number", result.mismatch_rows[0]["differences"])
+            self.assertEqual(
+                [
+                    "prepare_indexed_snapshot",
+                    "missing_rows",
+                    "orphan_rows",
+                    "duplicate_rows",
+                    "mismatched_rows",
+                ],
+                [phase_timing.phase for phase_timing in result.phase_timings],
+            )
+            self.assertGreaterEqual(result.total_elapsed_seconds, 0.0)
+            for phase_timing in result.phase_timings:
+                self.assertGreaterEqual(phase_timing.elapsed_seconds, 0.0)
 
     def test_rebuild_search_index_repairs_detected_drift(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from mtg_source_stack.db.connection import SQLITE_BUSY_TIMEOUT_MS, connect
+from mtg_source_stack.db.search_index import check_card_search_index
 from tests.common import RepoSmokeTestCase
 from mtg_source_stack.mvp_importer import import_scryfall_cards, initialize_database
 
@@ -2807,6 +2808,69 @@ class ImporterTest(RepoSmokeTestCase):
             self.assertIn("orphan rows preview:", result.stdout)
             self.assertIn("duplicate rows preview:", result.stdout)
             self.assertIn("mismatched rows preview:", result.stdout)
+
+    def test_check_search_index_service_detects_drift_via_indexed_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+
+            initialize_database(db_path)
+            with connect(db_path) as connection:
+                connection.executemany(
+                    """
+                    INSERT INTO mtg_cards (
+                        scryfall_id,
+                        oracle_id,
+                        name,
+                        set_code,
+                        set_name,
+                        collector_number
+                    )
+                    VALUES (?, ?, ?, 'svc', 'Service Drift Set', ?)
+                    """,
+                    [
+                        ("search-service-missing-1", "oracle-search-service-missing-1", "Missing Service Card", "1"),
+                        ("search-service-mismatch-1", "oracle-search-service-mismatch-1", "Mismatch Service Card", "2"),
+                        ("search-service-duplicate-1", "oracle-search-service-duplicate-1", "Duplicate Service Card", "3"),
+                    ],
+                )
+                connection.execute(
+                    "DELETE FROM mtg_cards_fts WHERE scryfall_id = 'search-service-missing-1'"
+                )
+                connection.execute(
+                    """
+                    UPDATE mtg_cards_fts
+                    SET collector_number = '999'
+                    WHERE scryfall_id = 'search-service-mismatch-1'
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards_fts (scryfall_id, name, set_code, set_name, collector_number, lang)
+                    SELECT scryfall_id, name, set_code, set_name, collector_number, lang
+                    FROM mtg_cards_fts
+                    WHERE scryfall_id = 'search-service-duplicate-1'
+                    """
+                )
+                connection.execute(
+                    """
+                    INSERT INTO mtg_cards_fts (scryfall_id, name, set_code, set_name, collector_number, lang)
+                    VALUES ('search-service-orphan-1', 'Orphan Service Card', 'svc', 'Service Drift Set', '9', 'en')
+                    """
+                )
+                connection.commit()
+
+            result = check_card_search_index(db_path, limit=1)
+
+            self.assertFalse(result.is_healthy)
+            self.assertEqual(1, result.missing_count)
+            self.assertEqual(1, result.orphan_count)
+            self.assertEqual(1, result.duplicate_count)
+            self.assertEqual(1, result.mismatch_count)
+            self.assertEqual("search-service-missing-1", result.missing_rows[0]["scryfall_id"])
+            self.assertEqual("search-service-orphan-1", result.orphan_rows[0]["scryfall_id"])
+            self.assertEqual("search-service-duplicate-1", result.duplicate_rows[0]["scryfall_id"])
+            self.assertEqual("search-service-mismatch-1", result.mismatch_rows[0]["scryfall_id"])
+            self.assertIn("collector_number", result.mismatch_rows[0]["differences"])
 
     def test_rebuild_search_index_repairs_detected_drift(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Closes #61.\n\nSummary:\n- Materialize mtg_cards_fts into an indexed temp snapshot before exhaustive drift comparisons.\n- Preserve missing/orphan/duplicate/mismatch coverage and existing healthy/drift exit behavior.\n- Add phase progress output and per-phase timings to check-search-index and post-rebuild verification.\n- Document full-catalog validation expectations and measured runtime.\n\nFull-catalog validation:\n- Built fresh /tmp/mtg_issue61_full_catalog.db from cached Scryfall default_cards, MTGJSON AllIdentifiers, and MTGJSON AllPricesToday.\n- Imported rows: 113,726 mtg_cards, 113,726 mtg_cards_fts, 118,615 mtgjson_card_links, 554,798 price_snapshots.\n- check-search-index completed healthy in 0.507s.\n\nVerification:\n- PYTHONPATH=src .venv/bin/python -m unittest -q\n- Full suite passed: 438 tests, 91 skipped.\n- git diff --check