### PR TITLE
Allow viewer copy-out and export access

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -58,6 +58,7 @@ Current authz model:
 - `GET /inventories/{inventory_slug}/items/page` is the server-side paginated
   inventory-table read contract; the older `/items` array route remains for
   compatibility
+- CSV export requires read access to the source inventory
 - inventory writes require inventory `editor` / `owner` membership or global
   `admin`
 - inventory membership management requires inventory `owner` membership or
@@ -78,7 +79,9 @@ Current authz model:
   - `set_condition`
 - `POST /inventories/{source_inventory_slug}/transfer` now supports atomic
   selected-row and whole-inventory `copy` / `move` operations, `dry_run`
-  previews, `on_conflict=fail|merge`, and `keep_acquisition`
+  previews, `on_conflict=fail|merge`, and `keep_acquisition`; in
+  `shared_service`, `copy` requires source read plus target write, while
+  `move` requires source write plus target write
 - `POST /inventories/{source_inventory_slug}/duplicate` creates a new inventory
   atomically, copies all source rows into it, requires write access to the
   source inventory, and grants the caller `owner`

--- a/README.md
+++ b/README.md
@@ -139,7 +139,11 @@ The current shared-service behavior is:
 - inventory item/audit reads require membership on that inventory; use
   `GET /inventories/{inventory_slug}/items/page` for server-side table
   pagination and sorting
+- CSV export requires read access to the source inventory
 - inventory writes require `editor` or `owner` membership on that inventory
+- inventory transfer `copy` requires read access to the source inventory and
+  write access to the target inventory; transfer `move` requires write access
+  to both inventories
 - inventory membership management requires `owner` membership on that
   inventory or global `admin`
 - `POST /inventories` lets any authenticated user create an owned inventory

--- a/docs/api_v1_contract.md
+++ b/docs/api_v1_contract.md
@@ -74,7 +74,8 @@ preserve for the first API-backed version of the project.
   `rows_written`, `ready_to_commit`, `source_snapshot_token`, `summary`,
   `resolution_issues`, `dry_run`, and `imported_rows`.
 - `GET /inventories/{inventory_slug}/export.csv` returns `text/csv` rather
-  than JSON and uses `Content-Disposition` for download semantics.
+  than JSON, uses `Content-Disposition` for download semantics, and requires
+  read access to the inventory in `shared_service`.
 - `POST /inventories/{source_inventory_slug}/transfer` returns a stable
   transfer envelope with source/target inventory slugs, summary counts,
   selection metadata, and ordered per-item results.
@@ -308,6 +309,10 @@ preserve for the first API-backed version of the project.
   - transfers selected source inventory rows, or the entire source inventory,
     into `target_inventory_slug`
   - `mode` accepts `copy` or `move`
+  - in `shared_service`, `copy` requires read access to the source inventory
+    and write access to the target inventory
+  - in `shared_service`, `move` requires write access to both the source and
+    target inventories
   - use exactly one of:
     - `item_ids`, which must be non-empty and unique
     - `all_items=true`, which selects every row in the source inventory
@@ -659,8 +664,9 @@ before the generic 500 envelope is returned.
   `POST /imports/csv`, `POST /imports/decklist`, and
   `POST /imports/deck-url` require inventory write access.
 - `POST /inventories/{source_inventory_slug}/transfer` requires write access to
-  both the source inventory in the path and the target inventory in the
-  request body; global `admin` bypasses both checks.
+  the target inventory in the request body. `copy` requires read access to the
+  source inventory in the path, while `move` requires write access to that
+  source inventory; global `admin` bypasses these inventory membership checks.
 - `POST /inventories/{source_inventory_slug}/duplicate` requires write access
   to the source inventory; global `admin` bypasses the inventory membership
   check. The caller becomes `owner` of the duplicated inventory.

--- a/docs/frontend_backend_requests/inventory_transfer_api.md
+++ b/docs/frontend_backend_requests/inventory_transfer_api.md
@@ -35,7 +35,13 @@ Current behavior:
 - transfer audit rows are grouped under one request correlation id
 - duplication now builds on the same transfer engine to create a new inventory
   atomically and copy all source rows into it
-- `shared_service` validates write access to both source and target inventories
+- in `shared_service`, `copy` validates read access to the source inventory and
+  write access to the target inventory
+- in `shared_service`, `move` validates write access to both source and target
+  inventories
+- `can_transfer_to` is a destination capability; a viewer may copy out of a
+  readable source into a writable target even when the source row has
+  `can_transfer_to=false`
 
 Compatibility note:
 

--- a/docs/frontend_handoff.md
+++ b/docs/frontend_handoff.md
@@ -145,6 +145,10 @@ Use this as the first-pass UI-to-endpoint map:
   Request body is JSON.
   - supports selected `item_ids` or `all_items=true`
   - use `mode=copy|move`
+  - for shared-service permission UX, allow `copy` when the source has
+    `can_read=true` and the chosen target has `can_transfer_to=true`
+  - allow `move` only when the source has `can_write=true` and the chosen
+    target has `can_transfer_to=true`
   - use `dry_run=true` to preview `copy`, `move`, `merge`, or `fail` outcomes
   - whole-inventory previews can truncate the returned per-row `results`, so
     use the summary counts as the authoritative top-level signal
@@ -154,7 +158,8 @@ Use this as the first-pass UI-to-endpoint map:
   - the response includes both the created inventory and the stable transfer
     summary payload
 - CSV export download -> `GET /inventories/{inventory_slug}/export.csv`
-  Uses `profile=default` today and returns `text/csv`.
+  Uses `profile=default` today, returns `text/csv`, and requires source
+  inventory read access in shared-service mode.
 - Owned rows table -> `GET /inventories/{inventory_slug}/items`
   This existing route returns a plain array and remains supported for local
   demo compatibility. Returned rows include `oracle_id`, `allowed_finishes`,
@@ -364,6 +369,9 @@ export default {
   - each inventory list row includes `role`, `can_read`, `can_write`,
     `can_manage_share`, and `can_transfer_to` so write/share/transfer controls
     can be hidden or disabled before a `403`
+  - `can_transfer_to` describes whether that inventory can be used as a
+    transfer destination; source-side copy affordances should use `can_read`,
+    while source-side move affordances should use `can_write`
   - some inventory reads may return `403`
   - paginated inventory table reads use the same read-access rules as the
     legacy owned-items array endpoint

--- a/docs/shared_service_deploy.md
+++ b/docs/shared_service_deploy.md
@@ -73,13 +73,16 @@ Effective behavior:
 - `GET /inventories` returns only the inventories visible to the caller
 - each `GET /inventories` row includes permission-aware frontend hints:
   `role`, `can_read`, `can_write`, `can_manage_share`, and `can_transfer_to`
-  using the same policy as the read, write, share-link, and transfer routes
+  using the same policy as the corresponding read, write, share-link, and
+  transfer-target checks
 - inventory card search routes require a caller who can read at least one
   inventory, or a global `admin`
 - inventory reads require `viewer`, `editor`, or `owner` membership on that
   inventory, or a global `admin`
 - inventory writes require `editor` or `owner` membership on that inventory,
   or a global `admin`
+- inventory transfer `copy` requires source read access and target write
+  access; inventory transfer `move` requires write access on both inventories
 - inventory membership management requires `owner` membership on that
   inventory, or a global `admin`
 - inventory share-link management requires `owner` membership on that

--- a/src/mtg_source_stack/api/dependencies.py
+++ b/src/mtg_source_stack/api/dependencies.py
@@ -295,6 +295,27 @@ def get_inventory_read_request_context(
     raise AuthorizationError(f"Read access to inventory '{inventory_slug}' is required for this shared_service request.")
 
 
+def require_inventory_read_access(
+    settings: ApiSettings,
+    context: RequestContext,
+    *,
+    inventory_slug: str,
+) -> None:
+    inventory_slug = normalize_inventory_slug(inventory_slug)
+    if settings.runtime_mode != "shared_service":
+        return
+    from ..inventory.service import actor_can_read_inventory
+
+    if actor_can_read_inventory(
+        settings.db_path,
+        inventory_slug=inventory_slug,
+        actor_id=context.actor_id,
+        actor_roles=context.roles,
+    ):
+        return
+    raise AuthorizationError(f"Read access to inventory '{inventory_slug}' is required for this shared_service request.")
+
+
 def require_inventory_write_access(
     settings: ApiSettings,
     context: RequestContext,

--- a/src/mtg_source_stack/api/routes.py
+++ b/src/mtg_source_stack/api/routes.py
@@ -74,6 +74,7 @@ from .dependencies import (
     get_authenticated_request_context,
     get_settings,
     require_inventory_membership_management_access,
+    require_inventory_read_access,
     require_inventory_share_management_access,
     require_inventory_write_access,
 )
@@ -1111,7 +1112,10 @@ def inventory_items_transfer(
     settings: Annotated[ApiSettings, Depends(get_settings)],
     context: Annotated[RequestContext, Depends(get_authenticated_request_context)],
 ) -> Any:
-    require_inventory_write_access(settings, context, inventory_slug=source_inventory_slug)
+    if payload.mode == "copy":
+        require_inventory_read_access(settings, context, inventory_slug=source_inventory_slug)
+    else:
+        require_inventory_write_access(settings, context, inventory_slug=source_inventory_slug)
     require_inventory_write_access(settings, context, inventory_slug=payload.target_inventory_slug)
     return _serialize(
         transfer_inventory_items(

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -6027,6 +6027,187 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual("moved", allowed.json()["results"][0]["status"])
                 self.assertEqual("target", allowed.json()["target_inventory"])
 
+    def test_shared_service_transfer_allows_viewer_copy_out_to_writable_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            initialize_database(db_path)
+            viewer_headers = {"X-Authenticated-User": "viewer-user"}
+
+            create_inventory(
+                db_path,
+                slug="source",
+                display_name="Source Collection",
+                description=None,
+                actor_id="owner-user",
+            )
+            create_inventory(
+                db_path,
+                slug="target-selected",
+                display_name="Selected Copy Target",
+                description=None,
+                actor_id="viewer-user",
+            )
+            create_inventory(
+                db_path,
+                slug="target-all",
+                display_name="All Rows Copy Target",
+                description=None,
+                actor_id="viewer-user",
+            )
+            create_inventory(
+                db_path,
+                slug="target-move",
+                display_name="Move Target",
+                description=None,
+                actor_id="viewer-user",
+            )
+            grant_inventory_membership(
+                db_path,
+                inventory_slug="source",
+                actor_id="viewer-user",
+                role="viewer",
+            )
+
+            with self._client(db_path, runtime_mode="shared_service", auto_migrate=False) as client:
+                self._seed_card(db_path)
+                self._insert_catalog_card(
+                    db_path,
+                    scryfall_id="api-card-2",
+                    oracle_id="api-oracle-2",
+                    name="API Test Card Two",
+                    collector_number="11",
+                )
+                self._insert_inventory_item(
+                    db_path,
+                    inventory_slug="source",
+                    scryfall_id="api-card-1",
+                    quantity=2,
+                    tags_json='["copy"]',
+                )
+                self._insert_inventory_item(
+                    db_path,
+                    inventory_slug="source",
+                    scryfall_id="api-card-2",
+                    quantity=1,
+                )
+                with connect(db_path) as connection:
+                    source_item_ids = [
+                        int(row["id"])
+                        for row in connection.execute(
+                            """
+                            SELECT ii.id
+                            FROM inventory_items ii
+                            JOIN inventories i ON i.id = ii.inventory_id
+                            WHERE i.slug = 'source'
+                            ORDER BY ii.id
+                            """
+                        ).fetchall()
+                    ]
+
+                selected_copy = client.post(
+                    "/inventories/source/transfer",
+                    headers=viewer_headers,
+                    json={
+                        "target_inventory_slug": "target-selected",
+                        "mode": "copy",
+                        "item_ids": [source_item_ids[0]],
+                        "on_conflict": "fail",
+                    },
+                )
+                self.assertEqual(200, selected_copy.status_code)
+                self.assertEqual("copied", selected_copy.json()["results"][0]["status"])
+                self.assertFalse(selected_copy.json()["results"][0]["source_removed"])
+
+                all_copy = client.post(
+                    "/inventories/source/transfer",
+                    headers=viewer_headers,
+                    json={
+                        "target_inventory_slug": "target-all",
+                        "mode": "copy",
+                        "all_items": True,
+                        "on_conflict": "fail",
+                    },
+                )
+                self.assertEqual(200, all_copy.status_code)
+                self.assertEqual("all_items", all_copy.json()["selection_kind"])
+                self.assertEqual(2, all_copy.json()["copied_count"])
+
+                denied_move = client.post(
+                    "/inventories/source/transfer",
+                    headers=viewer_headers,
+                    json={
+                        "target_inventory_slug": "target-move",
+                        "mode": "move",
+                        "item_ids": [source_item_ids[0]],
+                        "on_conflict": "fail",
+                    },
+                )
+                self.assertEqual(403, denied_move.status_code)
+                self.assertEqual("forbidden", denied_move.json()["error"]["code"])
+
+                source_rows = client.get("/inventories/source/items", headers=viewer_headers)
+                selected_target_rows = client.get("/inventories/target-selected/items", headers=viewer_headers)
+                all_target_rows = client.get("/inventories/target-all/items", headers=viewer_headers)
+                self.assertEqual(200, source_rows.status_code)
+                self.assertEqual(200, selected_target_rows.status_code)
+                self.assertEqual(200, all_target_rows.status_code)
+                self.assertEqual(2, len(source_rows.json()))
+                self.assertEqual(1, len(selected_target_rows.json()))
+                self.assertEqual(2, len(all_target_rows.json()))
+
+    def test_shared_service_transfer_rejects_no_access_copy_from_source(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            initialize_database(db_path)
+            outsider_headers = {"X-Authenticated-User": "outsider-user"}
+
+            create_inventory(
+                db_path,
+                slug="source",
+                display_name="Source Collection",
+                description=None,
+                actor_id="owner-user",
+            )
+            create_inventory(
+                db_path,
+                slug="target",
+                display_name="Outsider Target",
+                description=None,
+                actor_id="outsider-user",
+            )
+
+            with self._client(db_path, runtime_mode="shared_service", auto_migrate=False) as client:
+                self._seed_card(db_path)
+                self._insert_inventory_item(
+                    db_path,
+                    inventory_slug="source",
+                    scryfall_id="api-card-1",
+                )
+                with connect(db_path) as connection:
+                    source_item_id = int(
+                        connection.execute(
+                            """
+                            SELECT ii.id
+                            FROM inventory_items ii
+                            JOIN inventories i ON i.id = ii.inventory_id
+                            WHERE i.slug = 'source'
+                            """
+                        ).fetchone()["id"]
+                    )
+
+                denied = client.post(
+                    "/inventories/source/transfer",
+                    headers=outsider_headers,
+                    json={
+                        "target_inventory_slug": "target",
+                        "mode": "copy",
+                        "item_ids": [source_item_id],
+                        "on_conflict": "fail",
+                    },
+                )
+                self.assertEqual(403, denied.status_code)
+                self.assertEqual("forbidden", denied.json()["error"]["code"])
+
     def test_shared_service_duplicate_requires_source_write_access_and_grants_owner(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "api.db"


### PR DESCRIPTION
## Summary

- Adds shared-service API coverage for viewer copy-out transfers and no-access denial.
- Changes transfer authorization so `copy` requires source read access plus target write access.
- Keeps `move` restricted to source write access plus target write access.
- Updates backend/frontend docs so export, copy, move, and `can_transfer_to` semantics are explicit.

Refs #70.

## Validation

- `PYTHONPATH=src .venv/bin/python -m unittest tests.test_web_api.WebApiTest.test_shared_service_transfer_allows_viewer_copy_out_to_writable_target tests.test_web_api.WebApiTest.test_shared_service_transfer_rejects_no_access_copy_from_source tests.test_web_api.WebApiTest.test_shared_service_inventory_read_routes_allow_viewers_and_reject_non_members tests.test_web_api.WebApiTest.test_shared_service_transfer_requires_write_access_to_both_source_and_target -q`
  - Local result: 4 tests skipped because the optional web stack is unavailable.
- `PYTHONPATH=src .venv/bin/python -m unittest -q`
  - Local result: 440 tests, 93 skipped.
- `git diff --check`

## Frontend Follow-Up

- Wire copy controls so readable source inventories can copy to targets where `can_transfer_to=true`.
- Keep move controls gated on source `can_write=true` and target `can_transfer_to=true`.
- Keep CSV export controls available for readable inventories.
