### PR TITLE
[codex] Aggregate public share rows and merge demo-prep

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,56 +10,75 @@ status and ownership.
 
 ## Current Checkpoint
 
-Last refreshed: `2026-04-22`
+Last refreshed: `2026-04-23`
 
-Current review branch:
+Current local branch:
 
-- `frontend-refinement`
+- `local_install_prep`
 
 Current reviewed base:
 
-- `31095e4` / `origin/master`
+- `1d35591` / `origin/master`
+
+Most recent merge:
+
+- PR `#74` / `frontend-refinement`
 
 Open review PR:
 
 - none currently
 
+Open GitHub issues:
+
+- `#72` Aggregate public inventory share rows by visible identity
+- `#70` Allow viewer copy-out and export for readable inventories
+- `#57` Future work: production reverse-proxy path for shared-service rollout
+- `#52` Frontend: complete owner-managed read-only inventory sharing links
+- `#47` Break up oversized backend modules before more feature work lands
+- `#41` Support bulk inventory mutations across all filtered rows
+
 Readiness summary:
 
-- demo readiness: controlled-demo ready for the core happy path
+- demo readiness: controlled-demo ready for the core happy path after the
+  frontend-refinement merge
 - small rollout readiness: conditionally ready for a trusted 10-15 person pilot
   only after the real proxy, backup/restore, membership, and browser-session
   checks below are rehearsed on the target host
 - not ready for broader shared use, direct API exposure, separate-origin CORS,
   or an unmanaged "open it and see what happens" rollout
+- share-link UI/public-page, browser export, duplicate UI, transfer dry-run,
+  and ambiguous import resolution should be framed as incomplete or API-only
+  unless they are explicitly added to the demo story
 
 ## Current Validation Snapshot
 
-Last known green checks from the readiness review:
+Last known green checks from the post-merge readiness review:
 
-- `PATH=.venv/bin:$PATH ./scripts/test_backend.sh`
-  - `427` passed, `0` skipped when optional web dependencies are installed and
-    localhost socket binding is allowed
-- `PATH=.venv/bin:$PATH ./scripts/test_backend_web.sh`
-  - `108` passed, `84` skipped in the normal wrapper because the live socket
-    tests are covered by the full elevated backend run above
+- `PATH=.venv/bin:$PATH ./scripts/test_backend.sh` with localhost socket
+  binding allowed
+  - `440` tests ran, `OK`, `0` skipped
+- `PATH=.venv/bin:$PATH ./scripts/test_backend_web.sh` with localhost socket
+  binding allowed
+  - `113` tests ran, `OK`, `0` skipped
 - `cd frontend && npm test`
-  - `71` passed
+  - `75` passed
 - `cd frontend && npm run build`
   - production build passed
 - `cd frontend && npm run demo:bootstrap -- --force --shared-service-fixtures`
   - shared-service fixture DB bootstrap passed
-- `cd frontend && npm run smoke:shared-service-proxy -- --start-backend`
+- `cd frontend && npm run smoke:shared-service-proxy -- --start-backend` with
+  localhost socket binding allowed
   - passed when localhost socket binding was allowed
   - verified `/api` prefix stripping, static frontend serving, spoofed auth
     header stripping, fixture identity injection, expected visible inventories,
     readable-user search, and no-access search denial
 - `cd frontend && npm run demo:bootstrap -- --force --shared-service-fixtures --full-catalog ...`
-  - full-catalog shared-service demo DB bootstrapped at
+  - historical full-catalog shared-service demo DB bootstrapped at
     `var/db/frontend_demo_full.db`
   - imported `113776` Scryfall cards, `113774` MTGJSON identifier links, and
     `558116` MTGJSON price snapshots
-- shared-service full-catalog demo served through the local proxy harness
+- historical shared-service full-catalog demo served through the local proxy
+  harness
   - backend: `http://127.0.0.1:8000`
   - browser URL: `http://127.0.0.1:5174`
   - fixture identity: `writer@example.com`
@@ -82,7 +101,40 @@ Important validation caveat:
 
 ## Highest Priority Follow-Ups
 
-### 1. Production Reverse Proxy Runbook
+### 1. Demo Scope Closure And Issue Cleanup
+
+The core happy-path demo is ready. The biggest near-term planning task is to
+decide whether the next demo stays on that core path or expands into features
+that are currently incomplete in the browser.
+
+Needed:
+
+- keep the first demo focused on:
+  - inventory selection
+  - card search and autocomplete
+  - quick add
+  - compact browse and table views
+  - quick edits
+  - selected-row bulk edits
+  - selected-row copy/move as a writable user
+  - audit drawer
+- if viewer copy/export is part of the story, finish or re-scope `#70`:
+  - copy source eligibility should follow readable source access
+  - move source eligibility should require writable source access
+  - destination choices should use `can_transfer_to`
+  - browser CSV export still needs a UI affordance if it is demo-visible
+- if public share links are part of the story, finish `#72` and `#52` first
+- leave ambiguous import resolution, duplicate inventory UI, and transfer
+  dry-run preview out of the first demo unless explicitly framed as API-only
+
+Why:
+
+- the merged frontend can support a strong controlled demo, but the open issue
+  tracker still contains product surfaces that should not be implied as done
+- the roadmap previously listed closed issue dependencies as blockers; GitHub is
+  now the source of truth for live issue state
+
+### 2. Production Reverse Proxy Runbook (`#57`)
 
 This is the biggest blocker for even a small real rollout.
 
@@ -107,7 +159,7 @@ Why:
   proxy
 - exposing `mtg-web-api` directly would let clients spoof trusted headers
 
-### 2. First-Live Backup And Restore Rehearsal
+### 3. First-Live Backup And Restore Rehearsal
 
 Needed:
 
@@ -125,7 +177,7 @@ Why:
 - bulk imports, bad membership grants, or mistaken write actions need a clear
   recovery path
 
-### 3. Real User Permission Rehearsal
+### 4. Real User Permission Rehearsal
 
 Needed:
 
@@ -143,7 +195,47 @@ Why:
   launch-critical integration
 - membership management is currently CLI-first, so operator mistakes are likely
 
-### 4. Frontend Import Resolution UX
+### 5. Public Share-Link Completion (`#52`, `#72`)
+
+Needed:
+
+- aggregate public share rows by the fields visible in the public response:
+  `scryfall_id`, `condition_code`, `finish`, and `language_code`
+- keep public payloads free of private fields such as item IDs, location, tags,
+  notes, acquisition fields, and pricing
+- add owner/admin sharing controls in the inventory UI:
+  status, create, copy active link, rotate, and revoke
+- add the anonymous public inventory page at
+  `/shared/inventories/{share_token}`
+- have the public page fetch JSON through
+  `/api/shared/inventories/{share_token}` in shared-service deployments
+- handle loading, empty, revoked/not-found, and permission-denied states
+
+Why:
+
+- backend share-link routes exist, but the browser experience is not complete
+- `#72` is a backend projection issue that can make public rows look duplicated
+  because the fields that distinguish private rows are intentionally hidden
+
+### 6. Viewer Copy-Out And Browser Export Completion (`#70`)
+
+Needed:
+
+- verify the frontend treats `can_transfer_to` as a destination capability, not
+  as a source-copy requirement
+- allow copy controls when the source inventory is readable and the target is
+  writable/transferable
+- keep move controls gated on writable source plus writable/transferable target
+- add a CSV export UI if readable-inventory export should be demo-visible
+- close or update `#70` once the remaining frontend scope is confirmed
+
+Why:
+
+- the backend authorization and API tests are in place after PR `#73`
+- the remaining issue comment calls out browser-side capability behavior and
+  export visibility
+
+### 7. Frontend Import Resolution UX
 
 Needed:
 
@@ -167,35 +259,7 @@ Blocked / needs backend confirmation:
   building the full resolver UI
 - deck URL resolution must preserve and resubmit `source_snapshot_token`
 
-### 5. Permission-Aware Frontend Controls
-
-Needed:
-
-- update frontend inventory types after `#62` lands
-- use per-inventory capabilities to gate:
-  - add card
-  - import
-  - inline edits and remove row
-  - bulk edit
-  - copy/move source and destination eligibility
-  - duplicate inventory
-  - CSV export if export is not meant to be read-only
-  - public share-link management
-- make read-only viewer mode feel intentional rather than letting users discover
-  permissions by receiving `403` errors
-
-Blocked by:
-
-- `#62` Expose per-inventory capabilities for permission-aware frontend
-
-Why:
-
-- the frontend can currently list visible inventories, but it cannot tell which
-  ones are writable or manageable
-- this is the highest-value frontend/backend contract gap for a clean
-  shared-service pilot
-
-### 6. Surface Or Explicitly De-Scope Backend-Only API Features
+### 8. Surface Or Explicitly De-Scope Backend-Only API Features
 
 Needed:
 
@@ -213,18 +277,21 @@ Why:
   app
 - demo expectations should match what the browser can actually do
 
-### 7. Frontend Work That Can Proceed Now
+### 9. Frontend Work That Can Proceed Now
 
-These workstreams are not blocked by `#62`, `#63`, or `#64`.
+These workstreams are no longer blocked by the previously tracked capability,
+pagination, and membership API slices, but some are still product-scope
+decisions for the next demo.
 
 Recommended order:
 
 1. full-catalog browser polish
-2. CSV export UI
-3. duplicate inventory UI
-4. transfer dry-run preview
-5. Playwright smoke coverage
-6. public share-link UI, if it belongs in the demo narrative
+2. Playwright smoke coverage for the shared-service fixture modes
+3. viewer copy/export polish if `#70` remains in demo scope
+4. public share-link UI and public page if `#52` is in demo scope
+5. CSV export UI
+6. duplicate inventory UI
+7. transfer dry-run preview
 
 Details:
 
@@ -254,21 +321,25 @@ Details:
   - cover writer, viewer, no-access, and admin fixture modes
   - cover add/edit/remove, table selection, bulk actions, copy/move, mobile
     layout, full-catalog search, and image behavior
+- viewer copy/export polish
+  - align source and destination gating with `can_read`, `can_write`, and
+    `can_transfer_to`
+  - expose CSV export only if it belongs in the browser demo
 - public share-link UI
   - backend routes already exist for status/create/rotate/revoke and public
     JSON reads
-  - can start with graceful `403` handling until `#62` capability gating lands
+  - also needs the public page and `#72` row aggregation before being presented
+    as a complete public-sharing story
   - should be skipped if share links are not part of the near-term demo story
 
 Do not start yet:
 
-- broad permission-aware hiding/disabling across the app, blocked by `#62`
-- server-backed table pagination, blocked by `#63`
-- membership management UI, blocked by `#64`
 - full import resolution UI until the ambiguous preview/commit behavior is
   verified against realistic examples
+- broad organization/team administration UI until there is a deliberate product
+  story for it
 
-### 8. Full-Catalog Browser UX Pass
+### 10. Full-Catalog Browser UX Pass
 
 Done:
 
@@ -297,7 +368,7 @@ Why:
 - API timings are now reassuring, but browser rendering, remote card images,
   and dense-table behavior still need human-facing review
 
-### 9. Minimal Pilot Ops Checklist
+### 11. Minimal Pilot Ops Checklist
 
 Needed:
 
@@ -320,7 +391,7 @@ Why:
 - the repo has enough pieces for a small pilot, but the operational sequence is
   still spread across docs and scripts
 
-### 10. Dependency And Packaging Tightening
+### 12. Dependency And Packaging Tightening
 
 Needed:
 
@@ -336,6 +407,22 @@ Why:
 - production dependency audit is clean, but the Python web dependency versions
   are currently range-based
 - dev-only audit findings should not be allowed to become background noise
+
+### 13. General Backlog (`#41`, `#47`)
+
+Needed:
+
+- add first-class filtered-row bulk mutation support instead of relying only on
+  selected explicit item IDs (`#41`)
+- break up at least one oversized backend module along a clean boundary before
+  piling on another large feature wave (`#47`)
+
+Why:
+
+- `#41` is the product-grade answer for applying edits to the current filtered
+  result set
+- `#47` is not demo-critical, but it lowers the cost and risk of the next
+  backend changes
 
 ## Demo Guidance
 

--- a/contracts/openapi.json
+++ b/contracts/openapi.json
@@ -1537,6 +1537,17 @@
             "title": "Quantity",
             "type": "integer"
           },
+          "scryfall_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scryfall Id"
+          },
           "set_code": {
             "anyOf": [
               {
@@ -1550,6 +1561,7 @@
           }
         },
         "required": [
+          "scryfall_id",
           "name",
           "quantity",
           "set_code",
@@ -1565,6 +1577,7 @@
             "enum": [
               "ambiguous_card_name",
               "ambiguous_printing",
+              "unknown_card",
               "finish_required"
             ],
             "title": "Kind",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -500,6 +500,66 @@ describe("App", () => {
     expect(await screen.findByText("Current collection: Trade Binder")).toBeInTheDocument();
   });
 
+  it("shows the unresolved card name after a partial URL import and closes the dialog", async () => {
+    const user = userEvent.setup();
+
+    mockBaseSearchApp();
+    vi.mocked(importDeckUrl).mockResolvedValue(
+      buildDeckUrlImportResponse({
+        rows_seen: 2,
+        rows_written: 1,
+        ready_to_commit: true,
+        summary: {
+          total_card_quantity: 3,
+          distinct_card_names: 1,
+          distinct_printings: 1,
+          section_card_quantities: { mainboard: 3 },
+          requested_card_quantity: 4,
+          unresolved_card_quantity: 1,
+        },
+        resolution_issues: [
+          {
+            kind: "unknown_card",
+            source_position: 227,
+            section: "mainboard",
+            requested: {
+              scryfall_id: "stale-wildgrowth-id",
+              name: "Wildgrowth Archaic",
+              quantity: 1,
+              set_code: "TST",
+              collector_number: "168",
+              finish: "normal",
+            },
+            options: [],
+          },
+        ],
+      }),
+    );
+
+    render(<App />);
+
+    await user.click(await screen.findByRole("button", { name: "Import Cards" }));
+    await user.click(screen.getByRole("menuitem", { name: /Import from URL/i }));
+
+    const dialog = await screen.findByRole("dialog", { name: "Import From URL" });
+    await user.type(
+      within(dialog).getByRole("textbox", { name: "Deck URL" }),
+      "https://archidekt.com/decks/15761099/counters_and_counters",
+    );
+    await user.click(within(dialog).getByRole("button", { name: "Import cards" }));
+
+    await waitFor(() => {
+      expect(importDeckUrl).toHaveBeenCalledWith({
+        source_url: "https://archidekt.com/decks/15761099/counters_and_counters",
+        default_inventory: "personal",
+      });
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Imported 3 cards into Personal Collection. Could not import Wildgrowth Archaic.",
+    );
+    expect(screen.queryByRole("dialog", { name: "Import From URL" })).not.toBeInTheDocument();
+  });
+
   it("creates a new collection from the import dialog and imports into it", async () => {
     const user = userEvent.setup();
     const personal = buildInventorySummary();

--- a/frontend/src/hooks/useInventoryMutations.ts
+++ b/frontend/src/hooks/useInventoryMutations.ts
@@ -176,6 +176,54 @@ export function useInventoryMutations(options: UseInventoryMutationsOptions) {
     } into ${destinationLabel}.`;
   }
 
+  function getImportIssueLabel(issue: InventoryImportResponse["resolution_issues"][number]) {
+    const requested = issue.requested as Record<string, unknown>;
+    const requestedName =
+      typeof requested.name === "string" && requested.name.trim()
+        ? requested.name.trim()
+        : null;
+    if (requestedName) {
+      return requestedName;
+    }
+
+    const requestedScryfallId =
+      typeof requested.scryfall_id === "string" && requested.scryfall_id.trim()
+        ? requested.scryfall_id.trim()
+        : null;
+    if (requestedScryfallId) {
+      return requestedScryfallId;
+    }
+
+    if ("source_position" in issue) {
+      return `card at deck position ${issue.source_position}`;
+    }
+    if ("decklist_line" in issue) {
+      return `card on decklist line ${issue.decklist_line}`;
+    }
+    return `card on CSV row ${issue.csv_row}`;
+  }
+
+  function getImportIssueMessage(response: InventoryImportResponse) {
+    const labels = Array.from(
+      new Set(
+        response.resolution_issues
+          .map(getImportIssueLabel)
+          .filter((label) => Boolean(label)),
+      ),
+    );
+
+    if (labels.length === 0) {
+      return "Some cards could not be imported.";
+    }
+    if (labels.length === 1) {
+      return `Could not import ${labels[0]}.`;
+    }
+    if (labels.length === 2) {
+      return `Could not import ${labels[0]} and ${labels[1]}.`;
+    }
+    return `Could not import ${labels[0]}, ${labels[1]}, and ${labels.length - 2} other cards.`;
+  }
+
   async function handleImportResponse(
     inventorySlug: string,
     inventoryLabel: string | null | undefined,
@@ -186,7 +234,38 @@ export function useInventoryMutations(options: UseInventoryMutationsOptions) {
 
     try {
       const response = await loadResponse();
-      if (!response.ready_to_commit || response.resolution_issues.length > 0) {
+      if (response.resolution_issues.length > 0) {
+        const issueMessage = getImportIssueMessage(response);
+
+        if (response.rows_written <= 0) {
+          showNotice(issueMessage, "error");
+          return false;
+        }
+
+        const importingIntoDifferentCollection = inventorySlug !== options.selectedInventory;
+        try {
+          if (importingIntoDifferentCollection) {
+            await options.reloadInventorySummaries(inventorySlug);
+          }
+
+          await options.loadInventoryOverview(inventorySlug, {
+            reloadInventories: !importingIntoDifferentCollection,
+          });
+          showNotice(
+            `${getImportSuccessMessage(response, inventorySlug, inventoryLabel)} ${issueMessage}`,
+            "error",
+          );
+        } catch {
+          showNotice(
+            `${getImportSuccessMessage(response, inventorySlug, inventoryLabel)} ${issueMessage} The latest view could not refresh automatically.`,
+            "error",
+          );
+        }
+        options.resetSearchWorkspace();
+        return true;
+      }
+
+      if (!response.ready_to_commit) {
         showNotice(
           "This import still needs manual resolution. The preview flow is not wired into the frontend yet.",
           "error",

--- a/frontend/src/hooks/useInventoryMutations.ts
+++ b/frontend/src/hooks/useInventoryMutations.ts
@@ -177,18 +177,19 @@ export function useInventoryMutations(options: UseInventoryMutationsOptions) {
   }
 
   function getImportIssueLabel(issue: InventoryImportResponse["resolution_issues"][number]) {
-    const requested = issue.requested as Record<string, unknown>;
     const requestedName =
-      typeof requested.name === "string" && requested.name.trim()
-        ? requested.name.trim()
+      typeof issue.requested.name === "string" && issue.requested.name.trim()
+        ? issue.requested.name.trim()
         : null;
     if (requestedName) {
       return requestedName;
     }
 
     const requestedScryfallId =
-      typeof requested.scryfall_id === "string" && requested.scryfall_id.trim()
-        ? requested.scryfall_id.trim()
+      "scryfall_id" in issue.requested &&
+      typeof issue.requested.scryfall_id === "string" &&
+      issue.requested.scryfall_id.trim()
+        ? issue.requested.scryfall_id.trim()
         : null;
     if (requestedScryfallId) {
       return requestedScryfallId;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -48,6 +48,7 @@ export type InventoryTransferItemStatus =
 export type ImportResolutionIssueKind =
   | "ambiguous_card_name"
   | "ambiguous_printing"
+  | "unknown_card"
   | "finish_required";
 export type CsvImportDetectedFormat =
   | "deckbox_collection_csv"
@@ -595,6 +596,7 @@ export interface DeckUrlImportResolutionRequest {
 }
 
 export interface DeckUrlImportRequestedCardResponse {
+  scryfall_id: string | null;
   name: string | null;
   quantity: number;
   set_code: string | null;

--- a/src/mtg_source_stack/api/response_models.py
+++ b/src/mtg_source_stack/api/response_models.py
@@ -472,6 +472,7 @@ class DeckUrlImportRowResponse(InventoryItemMutationBaseResponse):
 
 
 class DeckUrlImportRequestedCardResponse(ApiBaseModel):
+    scryfall_id: str | None
     name: str | None
     quantity: int
     set_code: str | None
@@ -480,7 +481,7 @@ class DeckUrlImportRequestedCardResponse(ApiBaseModel):
 
 
 class DeckUrlImportResolutionIssueResponse(ApiBaseModel):
-    kind: Literal["ambiguous_card_name", "ambiguous_printing", "finish_required"]
+    kind: Literal["ambiguous_card_name", "ambiguous_printing", "unknown_card", "finish_required"]
     source_position: int
     section: str
     requested: DeckUrlImportRequestedCardResponse

--- a/src/mtg_source_stack/inventory/deck_url_import.py
+++ b/src/mtg_source_stack/inventory/deck_url_import.py
@@ -617,6 +617,36 @@ def _normalize_remote_finish(value: str | None) -> str:
     return normalize_finish(normalized.replace(" ", ""))
 
 
+def _archidekt_remote_card_name(card: Mapping[str, Any]) -> str | None:
+    oracle_card = card.get("oracleCard")
+    if isinstance(oracle_card, dict):
+        name = text_or_none(oracle_card.get("name"))
+        if name is not None:
+            return name
+    return text_or_none(card.get("displayName")) or text_or_none(card.get("name"))
+
+
+def _archidekt_remote_set_code(card: Mapping[str, Any]) -> str | None:
+    edition = card.get("edition")
+    if isinstance(edition, dict):
+        edition_code = text_or_none(edition.get("editioncode"))
+        if edition_code is not None:
+            return edition_code.upper()
+    return None
+
+
+def _moxfield_remote_card_name(card: Mapping[str, Any]) -> str | None:
+    return text_or_none(card.get("name"))
+
+
+def _moxfield_remote_set_code(card: Mapping[str, Any]) -> str | None:
+    return text_or_none(card.get("set")) or text_or_none(card.get("setCode"))
+
+
+def _moxfield_remote_collector_number(card: Mapping[str, Any]) -> str | None:
+    return text_or_none(card.get("number")) or text_or_none(card.get("collectorNumber"))
+
+
 def _archidekt_deck_id_from_url(source_url: str) -> str:
     parsed = _parse_remote_deck_url(source_url)
     if (parsed.hostname or "").lower() not in _ARCHIDEKT_HOSTS:
@@ -773,6 +803,9 @@ def _archidekt_card_to_remote_card(
         section=section,
         scryfall_id=scryfall_id,
         finish=finish,
+        name=_archidekt_remote_card_name(card),
+        set_code=_archidekt_remote_set_code(card),
+        collector_number=text_or_none(card.get("collectorNumber")),
     )
 
 
@@ -846,6 +879,9 @@ def _moxfield_entry_to_remote_card(
         section=section,
         scryfall_id=scryfall_id,
         finish=_normalize_remote_finish(raw_finish),
+        name=_moxfield_remote_card_name(card),
+        set_code=_moxfield_remote_set_code(card),
+        collector_number=_moxfield_remote_collector_number(card),
     )
 
 
@@ -1545,11 +1581,15 @@ def _remote_card_with_resolved_printing(
         section=card.section,
         scryfall_id=scryfall_id,
         finish=finish or card.finish,
+        name=card.name,
+        set_code=card.set_code,
+        collector_number=card.collector_number,
     )
 
 
 def _build_remote_requested_card(card: RemoteDeckCard) -> RemoteDeckRequestedCard:
     return RemoteDeckRequestedCard(
+        scryfall_id=card.scryfall_id,
         name=card.name,
         quantity=card.quantity,
         set_code=card.set_code,
@@ -1600,24 +1640,53 @@ def _build_remote_resolution_issue(
     )
 
 
+def _build_unknown_remote_card_issue(card: RemoteDeckCard) -> RemoteDeckResolutionIssue:
+    return _build_remote_resolution_issue("unknown_card", card, options=[])
+
+
+def _remote_card_without_exact_printing(card: RemoteDeckCard) -> RemoteDeckCard:
+    return RemoteDeckCard(
+        source_position=card.source_position,
+        quantity=card.quantity,
+        section=card.section,
+        scryfall_id=None,
+        finish=card.finish,
+        name=card.name,
+        set_code=card.set_code,
+        collector_number=card.collector_number,
+    )
+
+
 def _probe_remote_card_resolution(
     connection: sqlite3.Connection,
     *,
     card: RemoteDeckCard,
     default_inventory: str | None,
+    requested_card: RemoteDeckCard | None = None,
 ) -> tuple[PendingImportRow | None, RemoteDeckResolutionIssue | None]:
+    issue_card = requested_card or card
     if card.scryfall_id is not None:
-        resolve_card_row(
-            connection,
-            scryfall_id=card.scryfall_id,
-            oracle_id=None,
-            tcgplayer_product_id=None,
-            name=None,
-            set_code=None,
-            collector_number=None,
-            lang=None,
-            finish=card.finish,
-        )
+        try:
+            resolve_card_row(
+                connection,
+                scryfall_id=card.scryfall_id,
+                oracle_id=None,
+                tcgplayer_product_id=None,
+                name=None,
+                set_code=None,
+                collector_number=None,
+                lang=None,
+                finish=card.finish,
+            )
+        except NotFoundError:
+            if text_or_none(card.name) is None:
+                return None, _build_unknown_remote_card_issue(issue_card)
+            return _probe_remote_card_resolution(
+                connection,
+                card=_remote_card_without_exact_printing(card),
+                default_inventory=default_inventory,
+                requested_card=issue_card,
+            )
         return _build_pending_remote_row(
             card,
             default_inventory=default_inventory,
@@ -1628,12 +1697,15 @@ def _probe_remote_card_resolution(
         raise ValidationError("Remote deck import requires either a printing id or a card name.")
 
     if text_or_none(card.set_code) is None and text_or_none(card.collector_number) is None:
-        candidate_rows = list_default_card_name_candidate_rows(
-            connection,
-            name=card.name or "",
-            lang=None,
-            finish=card.finish,
-        )
+        try:
+            candidate_rows = list_default_card_name_candidate_rows(
+                connection,
+                name=card.name or "",
+                lang=None,
+                finish=card.finish,
+            )
+        except NotFoundError:
+            return None, _build_unknown_remote_card_issue(issue_card)
         oracle_ids = sorted({str(row["oracle_id"]) for row in candidate_rows})
         if len(oracle_ids) > 1:
             options: list[Any] = []
@@ -1654,7 +1726,7 @@ def _probe_remote_card_resolution(
                     requested_finish=card.finish,
                 )
                 options.extend(row_options)
-            return None, _build_remote_resolution_issue("ambiguous_card_name", card, options=options)
+            return None, _build_remote_resolution_issue("ambiguous_card_name", issue_card, options=options)
 
         resolved_card = resolve_default_card_row_for_name(
             connection,
@@ -1682,15 +1754,18 @@ def _probe_remote_card_resolution(
             ),
         ), None
 
-    candidate_rows = list_printing_candidate_rows(
-        connection,
-        name=card.name or "",
-        set_code=card.set_code,
-        set_name=None,
-        collector_number=card.collector_number,
-        lang=None,
-        finish=card.finish,
-    )
+    try:
+        candidate_rows = list_printing_candidate_rows(
+            connection,
+            name=card.name or "",
+            set_code=card.set_code,
+            set_name=None,
+            collector_number=card.collector_number,
+            lang=None,
+            finish=card.finish,
+        )
+    except NotFoundError:
+        return None, _build_unknown_remote_card_issue(issue_card)
     if len(candidate_rows) > 1:
         options: list[Any] = []
         for row in candidate_rows:
@@ -1699,7 +1774,7 @@ def _probe_remote_card_resolution(
                 requested_finish=card.finish,
             )
             options.extend(row_options)
-        return None, _build_remote_resolution_issue("ambiguous_printing", card, options=options)
+        return None, _build_remote_resolution_issue("ambiguous_printing", issue_card, options=options)
 
     return _build_pending_remote_row(
         _remote_card_with_resolved_printing(
@@ -1861,7 +1936,8 @@ def import_deck_url(
         inventory_validator=inventory_validator,
         default_inventory=inventory_slug,
     )
-    if plan.resolution_issues and not dry_run:
+    blocking_resolution_issues = [issue for issue in plan.resolution_issues if issue.options]
+    if blocking_resolution_issues and not dry_run:
         raise ValidationError(
             "Unresolved remote deck import ambiguities remain.",
             details={
@@ -1896,7 +1972,7 @@ def import_deck_url(
         "default_inventory": default_inventory,
         "rows_seen": plan.rows_seen,
         "rows_written": len(imported_rows),
-        "ready_to_commit": not plan.resolution_issues,
+        "ready_to_commit": not blocking_resolution_issues,
         "source_snapshot_token": plan.source_snapshot_token,
         "summary": build_resolvable_deck_import_summary(
             imported_rows,

--- a/src/mtg_source_stack/inventory/import_resolution.py
+++ b/src/mtg_source_stack/inventory/import_resolution.py
@@ -77,6 +77,7 @@ class DecklistResolutionSelection:
 
 @dataclass(frozen=True, slots=True)
 class RemoteDeckRequestedCard:
+    scryfall_id: str | None
     name: str | None
     quantity: int
     set_code: str | None = None

--- a/src/mtg_source_stack/inventory/sharing.py
+++ b/src/mtg_source_stack/inventory/sharing.py
@@ -31,6 +31,25 @@ SHARE_TOKEN_VERSION = "v1"
 # that page fetches JSON through the proxied API route
 # `/api/shared/inventories/{share_token}`.
 PUBLIC_SHARE_PAGE_PATH_PREFIX = "/shared/inventories"
+_GROUPED_PUBLIC_ITEMS_CTE = """
+WITH grouped_public_items AS (
+    SELECT
+        ii.inventory_id,
+        ii.scryfall_id,
+        ii.condition_code,
+        ii.finish,
+        ii.language_code,
+        SUM(ii.quantity) AS quantity
+    FROM inventory_items ii
+    WHERE ii.inventory_id = ?
+    GROUP BY
+        ii.inventory_id,
+        ii.scryfall_id,
+        ii.condition_code,
+        ii.finish,
+        ii.language_code
+)
+"""
 
 
 def _normalize_actor_id(actor_id: str | None) -> str:
@@ -456,6 +475,50 @@ def _public_summary_from_row(row: sqlite3.Row) -> PublicInventorySummary:
     )
 
 
+def _public_summary_row(connection: sqlite3.Connection, inventory_id: int) -> sqlite3.Row | None:
+    return connection.execute(
+        _GROUPED_PUBLIC_ITEMS_CTE
+        + """
+        SELECT
+            i.display_name,
+            COALESCE(i.description, '') AS description,
+            COUNT(gpi.scryfall_id) AS item_rows,
+            COALESCE(SUM(gpi.quantity), 0) AS total_cards
+        FROM inventories i
+        LEFT JOIN grouped_public_items gpi ON gpi.inventory_id = i.id
+        WHERE i.id = ?
+        GROUP BY i.id, i.display_name, i.description
+        """,
+        (inventory_id, inventory_id),
+    ).fetchone()
+
+
+def _public_item_rows(connection: sqlite3.Connection, inventory_id: int) -> list[sqlite3.Row]:
+    return connection.execute(
+        _GROUPED_PUBLIC_ITEMS_CTE
+        + """
+        SELECT
+            gpi.scryfall_id,
+            c.oracle_id,
+            c.name,
+            c.set_code,
+            c.set_name,
+            c.rarity,
+            c.collector_number,
+            c.image_uris_json,
+            c.finishes_json,
+            gpi.quantity,
+            gpi.condition_code,
+            gpi.finish,
+            gpi.language_code
+        FROM grouped_public_items gpi
+        JOIN mtg_cards c ON c.scryfall_id = gpi.scryfall_id
+        ORDER BY c.name, c.set_code, c.collector_number, gpi.condition_code, gpi.finish, gpi.language_code
+        """,
+        (inventory_id,),
+    ).fetchall()
+
+
 def get_public_inventory_share(
     db_path: str | Path,
     *,
@@ -483,46 +546,11 @@ def get_public_inventory_share(
             raise NotFoundError("Shared inventory link was not found.")
 
         inventory_id = int(share["inventory_id"])
-        summary_row = connection.execute(
-            """
-            SELECT
-                i.display_name,
-                COALESCE(i.description, '') AS description,
-                COUNT(ii.id) AS item_rows,
-                COALESCE(SUM(ii.quantity), 0) AS total_cards
-            FROM inventories i
-            LEFT JOIN inventory_items ii ON ii.inventory_id = i.id
-            WHERE i.id = ?
-            GROUP BY i.id, i.display_name, i.description
-            """,
-            (inventory_id,),
-        ).fetchone()
+        summary_row = _public_summary_row(connection, inventory_id)
         if summary_row is None:
             raise NotFoundError("Shared inventory link was not found.")
 
-        item_rows = connection.execute(
-            """
-            SELECT
-                ii.scryfall_id,
-                c.oracle_id,
-                c.name,
-                c.set_code,
-                c.set_name,
-                c.rarity,
-                c.collector_number,
-                c.image_uris_json,
-                c.finishes_json,
-                ii.quantity,
-                ii.condition_code,
-                ii.finish,
-                ii.language_code
-            FROM inventory_items ii
-            JOIN mtg_cards c ON c.scryfall_id = ii.scryfall_id
-            WHERE ii.inventory_id = ?
-            ORDER BY c.name, c.set_code, c.collector_number, ii.condition_code, ii.finish
-            """,
-            (inventory_id,),
-        ).fetchall()
+        item_rows = _public_item_rows(connection, inventory_id)
 
     return PublicInventoryShareResult(
         inventory=_public_summary_from_row(summary_row),

--- a/tests/test_deck_url_import.py
+++ b/tests/test_deck_url_import.py
@@ -348,28 +348,48 @@ class DeckUrlImportTest(unittest.TestCase):
                         "companion": False,
                         "modifier": "Normal",
                         "quantity": 1,
-                        "card": {"uid": "cmd-card"},
+                        "card": {
+                            "uid": "cmd-card",
+                            "oracleCard": {"name": "Commander Card"},
+                            "edition": {"editioncode": "cmm"},
+                            "collectorNumber": "10",
+                        },
                     },
                     {
                         "categories": ["Ramp"],
                         "companion": False,
                         "modifier": "Foil",
                         "quantity": 4,
-                        "card": {"uid": "main-card"},
+                        "card": {
+                            "uid": "main-card",
+                            "oracleCard": {"name": "Main Card"},
+                            "edition": {"editioncode": "mh3"},
+                            "collectorNumber": "150",
+                        },
                     },
                     {
                         "categories": ["Maybeboard"],
                         "companion": False,
                         "modifier": "Normal",
                         "quantity": 2,
-                        "card": {"uid": "maybe-card"},
+                        "card": {
+                            "uid": "maybe-card",
+                            "oracleCard": {"name": "Maybe Card"},
+                            "edition": {"editioncode": "lea"},
+                            "collectorNumber": "42",
+                        },
                     },
                     {
                         "categories": ["Sideboard"],
                         "companion": False,
                         "modifier": "Etched",
                         "quantity": 1,
-                        "card": {"uid": "side-card"},
+                        "card": {
+                            "uid": "side-card",
+                            "oracleCard": {"name": "Side Card"},
+                            "edition": {"editioncode": "2xm"},
+                            "collectorNumber": "33",
+                        },
                     },
                 ],
             },
@@ -379,9 +399,9 @@ class DeckUrlImportTest(unittest.TestCase):
         self.assertEqual("Remote Deck", source.deck_name)
         self.assertEqual(
             [
-                (1, "commander", 1, "cmd-card", "normal"),
-                (2, "mainboard", 4, "main-card", "foil"),
-                (4, "sideboard", 1, "side-card", "etched"),
+                (1, "commander", 1, "cmd-card", "Commander Card", "CMM", "10", "normal"),
+                (2, "mainboard", 4, "main-card", "Main Card", "MH3", "150", "foil"),
+                (4, "sideboard", 1, "side-card", "Side Card", "2XM", "33", "etched"),
             ],
             [
                 (
@@ -389,6 +409,9 @@ class DeckUrlImportTest(unittest.TestCase):
                     card.section,
                     card.quantity,
                     card.scryfall_id,
+                    card.name,
+                    card.set_code,
+                    card.collector_number,
                     card.finish,
                 )
                 for card in source.cards
@@ -404,21 +427,36 @@ class DeckUrlImportTest(unittest.TestCase):
                     "cmd-key": {
                         "quantity": 1,
                         "finish": "nonfoil",
-                        "card": {"scryfall_id": "cmd-card"},
+                        "card": {
+                            "scryfall_id": "cmd-card",
+                            "name": "Commander Card",
+                            "set": "CMM",
+                            "number": "10",
+                        },
                     }
                 },
                 "companions": {
                     "comp-key": {
                         "quantity": 1,
                         "finish": "foil",
-                        "card": {"scryfall_id": "comp-card"},
+                        "card": {
+                            "scryfall_id": "comp-card",
+                            "name": "Companion Card",
+                            "setCode": "IKO",
+                            "collectorNumber": "222",
+                        },
                     }
                 },
                 "mainboard": {
                     "main-key": {
                         "quantity": 4,
                         "finish": "etched foil",
-                        "card": {"scryfall_id": "main-card"},
+                        "card": {
+                            "scryfall_id": "main-card",
+                            "name": "Main Card",
+                            "set": "MH3",
+                            "number": "150",
+                        },
                     }
                 },
                 "sideboard": {
@@ -427,6 +465,9 @@ class DeckUrlImportTest(unittest.TestCase):
                         "isFoil": True,
                         "card": {
                             "scryfall_id": "side-card",
+                            "name": "Side Card",
+                            "setCode": "2XM",
+                            "collectorNumber": "33",
                             "defaultFinish": "nonfoil",
                         },
                     }
@@ -435,7 +476,12 @@ class DeckUrlImportTest(unittest.TestCase):
                     "sig-key": {
                         "quantity": 1,
                         "finish": "normal",
-                        "card": {"scryfall_id": "sig-card"},
+                        "card": {
+                            "scryfall_id": "sig-card",
+                            "name": "Signature Spell",
+                            "set": "STA",
+                            "number": "7",
+                        },
                     }
                 },
                 "maybeboard": {
@@ -455,11 +501,11 @@ class DeckUrlImportTest(unittest.TestCase):
         self.assertEqual("Moxfield Deck", source.deck_name)
         self.assertEqual(
             [
-                (1, "commander", 1, "cmd-card", "normal"),
-                (2, "companion", 1, "comp-card", "foil"),
-                (3, "signature-spell", 1, "sig-card", "normal"),
-                (4, "mainboard", 4, "main-card", "etched"),
-                (5, "sideboard", 2, "side-card", "foil"),
+                (1, "commander", 1, "cmd-card", "Commander Card", "CMM", "10", "normal"),
+                (2, "companion", 1, "comp-card", "Companion Card", "IKO", "222", "foil"),
+                (3, "signature-spell", 1, "sig-card", "Signature Spell", "STA", "7", "normal"),
+                (4, "mainboard", 4, "main-card", "Main Card", "MH3", "150", "etched"),
+                (5, "sideboard", 2, "side-card", "Side Card", "2XM", "33", "foil"),
             ],
             [
                 (
@@ -467,6 +513,9 @@ class DeckUrlImportTest(unittest.TestCase):
                     card.section,
                     card.quantity,
                     card.scryfall_id,
+                    card.name,
+                    card.set_code,
+                    card.collector_number,
                     card.finish,
                 )
                 for card in source.cards
@@ -1259,6 +1308,142 @@ class DeckUrlImportTest(unittest.TestCase):
                 [("cmd-card", 1), ("main-card", 2)],
                 [(row["scryfall_id"], row["quantity"]) for row in rows],
             )
+
+    def test_import_deck_url_falls_back_from_missing_scryfall_id_to_name_based_exact_printing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+            self._insert_card(
+                db_path,
+                scryfall_id="refreshed-card",
+                oracle_id="remote-oracle-1",
+                name="Wildgrowth Archaic",
+                collector_number="168",
+                finishes_json='["normal"]',
+            )
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description=None,
+            )
+
+            remote_source = RemoteDeckSource(
+                provider="archidekt",
+                source_url="https://archidekt.com/decks/15761099/counters_and_counters",
+                deck_name="Counters and Counters",
+                cards=[
+                    RemoteDeckCard(
+                        14,
+                        1,
+                        "mainboard",
+                        "stale-card-id",
+                        "normal",
+                        name="Wildgrowth Archaic",
+                        set_code="TST",
+                        collector_number="168",
+                    )
+                ],
+            )
+
+            with patch(
+                "mtg_source_stack.inventory.deck_url_import.fetch_remote_deck_source",
+                return_value=remote_source,
+            ):
+                preview = import_deck_url(
+                    db_path,
+                    source_url="https://archidekt.com/decks/15761099/counters_and_counters",
+                    default_inventory="personal",
+                    dry_run=True,
+                )
+                committed = import_deck_url(
+                    db_path,
+                    source_url="https://archidekt.com/decks/15761099/counters_and_counters",
+                    default_inventory="personal",
+                    dry_run=False,
+                    source_snapshot_token=preview["source_snapshot_token"],
+                )
+
+            self.assertTrue(preview["ready_to_commit"])
+            self.assertEqual([], preview["resolution_issues"])
+            self.assertEqual("refreshed-card", preview["imported_rows"][0]["scryfall_id"])
+            self.assertEqual("explicit", preview["imported_rows"][0]["printing_selection_mode"])
+            self.assertEqual(1, committed["rows_written"])
+
+            with connect(db_path) as connection:
+                row = connection.execute(
+                    "SELECT scryfall_id, quantity, printing_selection_mode FROM inventory_items"
+                ).fetchone()
+
+            self.assertEqual(("refreshed-card", 1, "explicit"), tuple(row))
+
+    def test_import_deck_url_keeps_known_rows_and_reports_unknown_cards_by_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+            self._insert_card(
+                db_path,
+                scryfall_id="known-card",
+                oracle_id="remote-oracle-1",
+                name="Known Card",
+                collector_number="10",
+                finishes_json='["normal"]',
+            )
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description=None,
+            )
+
+            remote_source = RemoteDeckSource(
+                provider="archidekt",
+                source_url="https://archidekt.com/decks/15761099/counters_and_counters",
+                deck_name="Counters and Counters",
+                cards=[
+                    RemoteDeckCard(1, 2, "mainboard", "known-card", "normal"),
+                    RemoteDeckCard(
+                        227,
+                        1,
+                        "mainboard",
+                        "stale-wildgrowth-id",
+                        "normal",
+                        name="Wildgrowth Archaic",
+                        set_code="TST",
+                        collector_number="168",
+                    ),
+                ],
+            )
+
+            with patch(
+                "mtg_source_stack.inventory.deck_url_import.fetch_remote_deck_source",
+                return_value=remote_source,
+            ):
+                committed = import_deck_url(
+                    db_path,
+                    source_url="https://archidekt.com/decks/15761099/counters_and_counters",
+                    default_inventory="personal",
+                    dry_run=False,
+                )
+
+            self.assertTrue(committed["ready_to_commit"])
+            self.assertEqual(2, committed["summary"]["total_card_quantity"])
+            self.assertEqual(3, committed["summary"]["requested_card_quantity"])
+            self.assertEqual(1, committed["summary"]["unresolved_card_quantity"])
+            self.assertEqual(1, committed["rows_written"])
+            self.assertEqual(1, len(committed["resolution_issues"]))
+            issue = committed["resolution_issues"][0]
+            self.assertEqual("unknown_card", issue["kind"])
+            self.assertEqual("Wildgrowth Archaic", issue["requested"]["name"])
+            self.assertEqual("stale-wildgrowth-id", issue["requested"]["scryfall_id"])
+            self.assertEqual([], issue["options"])
+
+            with connect(db_path) as connection:
+                rows = connection.execute(
+                    "SELECT scryfall_id, quantity FROM inventory_items ORDER BY scryfall_id"
+                ).fetchall()
+
+            self.assertEqual([("known-card", 2)], [(row["scryfall_id"], row["quantity"]) for row in rows])
 
     def test_import_deck_url_supports_default_name_resolution_for_name_only_provider_rows(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_inventory_service.py
+++ b/tests/test_inventory_service.py
@@ -2464,6 +2464,99 @@ class InventoryServiceTest(RepoSmokeTestCase):
             self.assertEqual("req-create-share", audit_rows[2].request_id)
             self.assertTrue(all("token" not in row.metadata for row in audit_rows[:3]))
 
+    def test_inventory_share_links_group_public_rows_by_visible_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "collection.db"
+            initialize_database(db_path)
+            self._insert_catalog_card(
+                db_path,
+                scryfall_id="share-card-1",
+                oracle_id="share-oracle-1",
+                name="Shared Test Card",
+                finishes_json='["normal","foil"]',
+            )
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description="Public description",
+                actor_id="owner-user",
+            )
+            self._insert_inventory_item(
+                db_path,
+                inventory_slug="personal",
+                scryfall_id="share-card-1",
+                quantity=2,
+                finish="normal",
+                location="Private Binder A",
+                acquisition_price="1.25",
+                acquisition_currency="USD",
+                notes="private note a",
+                tags_json='["private-a"]',
+            )
+            self._insert_inventory_item(
+                db_path,
+                inventory_slug="personal",
+                scryfall_id="share-card-1",
+                quantity=3,
+                finish="normal",
+                location="Private Binder B",
+                acquisition_price="2.50",
+                acquisition_currency="USD",
+                notes="private note b",
+                tags_json='["private-b"]',
+            )
+            self._insert_inventory_item(
+                db_path,
+                inventory_slug="personal",
+                scryfall_id="share-card-1",
+                quantity=1,
+                finish="foil",
+                location="Private Binder C",
+                acquisition_price="4.00",
+                acquisition_currency="USD",
+                notes="private foil note",
+                tags_json='["private-c"]',
+            )
+
+            created = create_inventory_share_link(
+                db_path,
+                inventory_slug="personal",
+                actor_id="owner-user",
+                token_secret=TEST_SHARE_TOKEN_SECRET,
+                actor_type="api",
+                request_id="req-create-share",
+            )
+
+            public_share = get_public_inventory_share(
+                db_path,
+                token=created.token,
+                token_secret=TEST_SHARE_TOKEN_SECRET,
+            )
+
+            self.assertEqual("Personal Collection", public_share.inventory.display_name)
+            self.assertEqual("Public description", public_share.inventory.description)
+            self.assertEqual(2, public_share.inventory.item_rows)
+            self.assertEqual(6, public_share.inventory.total_cards)
+            self.assertEqual(2, len(public_share.items))
+
+            items_by_finish = {item.finish: serialize_response(item) for item in public_share.items}
+            self.assertEqual({"normal", "foil"}, set(items_by_finish))
+            self.assertEqual(5, items_by_finish["normal"]["quantity"])
+            self.assertEqual(1, items_by_finish["foil"]["quantity"])
+            for public_item in items_by_finish.values():
+                for private_key in (
+                    "item_id",
+                    "location",
+                    "tags",
+                    "acquisition_price",
+                    "acquisition_currency",
+                    "unit_price",
+                    "est_value",
+                    "notes",
+                ):
+                    self.assertNotIn(private_key, public_item)
+
     def test_add_card_uses_inventory_default_location_and_tags_when_omitted(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "collection.db"

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -683,6 +683,14 @@ class WebApiSchemaTest(unittest.TestCase):
                     components[deck_url_response_schema_name]["properties"]["resolution_issues"]["items"]["$ref"]
                 ),
             )
+            self.assertIn(
+                "unknown_card",
+                components["DeckUrlImportResolutionIssueResponse"]["properties"]["kind"]["enum"],
+            )
+            self.assertIn(
+                "scryfall_id",
+                components["DeckUrlImportRequestedCardResponse"]["properties"],
+            )
             export_csv_response = spec["paths"]["/inventories/{inventory_slug}/export.csv"]["get"]["responses"]["200"]
             self.assertIn("text/csv", export_csv_response["content"])
             self.assertEqual(
@@ -2408,6 +2416,82 @@ class WebApiTest(unittest.TestCase):
 
                 self.assertEqual(4, item_row["quantity"])
                 self.assertEqual(("api", "local-demo", "req-deck-url-commit"), tuple(audit_row))
+
+    def test_demo_api_deck_url_import_reports_unknown_cards_without_blocking_known_rows(self) -> None:
+        from mtg_source_stack.inventory.deck_url_import import RemoteDeckCard, RemoteDeckSource
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            with self._client(db_path) as client:
+                self._insert_catalog_card(
+                    db_path,
+                    scryfall_id="api-known-card",
+                    oracle_id="api-known-oracle",
+                    name="Known Card",
+                    set_code="tst",
+                    set_name="Test Set",
+                    collector_number="10",
+                    finishes_json='["normal"]',
+                )
+
+                created_inventory = client.post(
+                    "/inventories",
+                    json={"slug": "personal", "display_name": "Personal Collection"},
+                )
+                self.assertEqual(201, created_inventory.status_code)
+
+                remote_source = RemoteDeckSource(
+                    provider="archidekt",
+                    source_url="https://archidekt.com/decks/15761099/counters_and_counters",
+                    deck_name="Counters and Counters",
+                    cards=[
+                        RemoteDeckCard(1, 2, "mainboard", "api-known-card", "normal"),
+                        RemoteDeckCard(
+                            227,
+                            1,
+                            "mainboard",
+                            "stale-wildgrowth-id",
+                            "normal",
+                            name="Wildgrowth Archaic",
+                            set_code="TST",
+                            collector_number="168",
+                        ),
+                    ],
+                )
+
+                with patch(
+                    "mtg_source_stack.inventory.deck_url_import.fetch_remote_deck_source",
+                    return_value=remote_source,
+                ):
+                    committed = client.post(
+                        "/imports/deck-url",
+                        json={
+                            "source_url": "https://archidekt.com/decks/15761099/counters_and_counters",
+                            "default_inventory": "personal",
+                        },
+                    )
+
+                self.assertEqual(200, committed.status_code)
+                committed_payload = committed.json()
+                self.assertTrue(committed_payload["ready_to_commit"])
+                self.assertEqual(1, committed_payload["rows_written"])
+                self.assertEqual(1, len(committed_payload["resolution_issues"]))
+                self.assertEqual("unknown_card", committed_payload["resolution_issues"][0]["kind"])
+                self.assertEqual(
+                    "Wildgrowth Archaic",
+                    committed_payload["resolution_issues"][0]["requested"]["name"],
+                )
+                self.assertEqual(
+                    "stale-wildgrowth-id",
+                    committed_payload["resolution_issues"][0]["requested"]["scryfall_id"],
+                )
+
+                with connect(db_path) as connection:
+                    rows = connection.execute(
+                        "SELECT scryfall_id, quantity FROM inventory_items ORDER BY scryfall_id"
+                    ).fetchall()
+
+                self.assertEqual([("api-known-card", 2)], [(row["scryfall_id"], row["quantity"]) for row in rows])
 
     def test_demo_api_deck_url_import_uses_strict_schema_policy(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -5165,6 +5165,94 @@ class WebApiTest(unittest.TestCase):
                 self.assertEqual(200, revoked_again.status_code)
                 self.assertFalse(revoked_again.json()["active"])
 
+    def test_inventory_share_links_public_route_groups_rows_by_visible_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "api.db"
+            initialize_database(db_path)
+            owner_headers = {"X-Authenticated-User": "owner-user"}
+
+            create_inventory(
+                db_path,
+                slug="personal",
+                display_name="Personal Collection",
+                description="Cards I want to share",
+                actor_id="owner-user",
+            )
+
+            with self._client(db_path, runtime_mode="shared_service", auto_migrate=False) as client:
+                self._seed_card(db_path)
+                self._insert_inventory_item(
+                    db_path,
+                    inventory_slug="personal",
+                    scryfall_id="api-card-1",
+                    quantity=2,
+                    finish="normal",
+                    location="Private Binder A",
+                    acquisition_price="1.25",
+                    acquisition_currency="USD",
+                    notes="private owner note a",
+                    tags_json='["trade-a"]',
+                )
+                self._insert_inventory_item(
+                    db_path,
+                    inventory_slug="personal",
+                    scryfall_id="api-card-1",
+                    quantity=3,
+                    finish="normal",
+                    location="Private Binder B",
+                    acquisition_price="2.50",
+                    acquisition_currency="USD",
+                    notes="private owner note b",
+                    tags_json='["trade-b"]',
+                )
+                self._insert_inventory_item(
+                    db_path,
+                    inventory_slug="personal",
+                    scryfall_id="api-card-1",
+                    quantity=1,
+                    finish="foil",
+                    location="Private Binder C",
+                    acquisition_price="4.00",
+                    acquisition_currency="USD",
+                    notes="private foil note",
+                    tags_json='["trade-c"]',
+                )
+
+                created = client.post("/inventories/personal/share-link", headers=owner_headers)
+                self.assertEqual(201, created.status_code)
+
+                public_view = client.get(f"/shared/inventories/{created.json()['token']}")
+                self.assertEqual(200, public_view.status_code)
+                public_payload = public_view.json()
+
+                self.assertEqual(
+                    {
+                        "display_name": "Personal Collection",
+                        "description": "Cards I want to share",
+                        "item_rows": 2,
+                        "total_cards": 6,
+                    },
+                    public_payload["inventory"],
+                )
+                self.assertEqual(2, len(public_payload["items"]))
+
+                items_by_finish = {
+                    item["finish"]: item for item in public_payload["items"]
+                }
+                self.assertEqual({"normal", "foil"}, set(items_by_finish))
+                self.assertEqual(5, items_by_finish["normal"]["quantity"])
+                self.assertEqual(1, items_by_finish["foil"]["quantity"])
+                for public_item in items_by_finish.values():
+                    self.assertNotIn("notes", public_item)
+                    self.assertNotIn("acquisition_price", public_item)
+                    self.assertNotIn("acquisition_currency", public_item)
+                    self.assertNotIn("location", public_item)
+                    self.assertNotIn("tags", public_item)
+                    self.assertNotIn("item_id", public_item)
+                    self.assertNotIn("currency", public_item)
+                    self.assertNotIn("unit_price", public_item)
+                    self.assertNotIn("est_value", public_item)
+
     def test_inventory_share_links_allow_global_admin_management(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "api.db"


### PR DESCRIPTION
## Summary
- aggregate public share rows by visible identity so hidden private fields do not create duplicate-looking public rows
- refresh roadmap context after the frontend-refinement merge
- merge the demo-prep deck URL partial-import work into this branch
- fix the merged frontend import-issue label typing so the frontend build stays green

## Validation
- PATH=.venv/bin:/home/boydm9/.local/bin:/home/boydm9/.codex/tmp/arg0/codex-arg00wkaHc:/home/boydm9/.vscode-server/bin/cfbea10c5ffb233ea9177d34726e6056e89913dc/bin/remote-cli:/home/boydm9/.local/bin:/home/boydm9/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/Users/boydm/AppData/Local/Programs/Microsoft VS Code:/mnt/c/Windows/system32:/mnt/c/Windows:/mnt/c/Windows/System32/Wbem:/mnt/c/Windows/System32/WindowsPowerShell/v1.0/:/mnt/c/Windows/System32/OpenSSH/:/mnt/c/Program Files/Microsoft VS Code/bin:/mnt/c/Program Files/Git/cmd:/mnt/c/Users/boydm/.local/bin:/mnt/c/Users/boydm/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/boydm/AppData/Local/Programs/Microsoft VS Code/bin:/snap/bin:/home/boydm9/.vscode-server/extensions/openai.chatgpt-26.415.20818-linux-arm64/bin/linux-aarch64 ./scripts/test_backend.sh
- PATH=.venv/bin:/home/boydm9/.local/bin:/home/boydm9/.codex/tmp/arg0/codex-arg00wkaHc:/home/boydm9/.vscode-server/bin/cfbea10c5ffb233ea9177d34726e6056e89913dc/bin/remote-cli:/home/boydm9/.local/bin:/home/boydm9/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/Users/boydm/AppData/Local/Programs/Microsoft VS Code:/mnt/c/Windows/system32:/mnt/c/Windows:/mnt/c/Windows/System32/Wbem:/mnt/c/Windows/System32/WindowsPowerShell/v1.0/:/mnt/c/Windows/System32/OpenSSH/:/mnt/c/Program Files/Microsoft VS Code/bin:/mnt/c/Program Files/Git/cmd:/mnt/c/Users/boydm/.local/bin:/mnt/c/Users/boydm/AppData/Local/Microsoft/WindowsApps:/mnt/c/Users/boydm/AppData/Local/Programs/Microsoft VS Code/bin:/snap/bin:/home/boydm9/.vscode-server/extensions/openai.chatgpt-26.415.20818-linux-arm64/bin/linux-aarch64 ./scripts/test_backend_web.sh
- cd frontend && npm test
- cd frontend && npm run build